### PR TITLE
Use `release/*` for the branch name pattern that trigger dry_publish workflow

### DIFF
--- a/.github/workflows/dry_publish.yaml
+++ b/.github/workflows/dry_publish.yaml
@@ -1,7 +1,7 @@
 name: Dry Publish
 on:
   push:
-    branches: [main, "v*.*.*"]
+    branches: [main, "release/*"]
 
 env:
   package_dir: ./package


### PR DESCRIPTION
This PR fixes #12.