### PR TITLE
Improve the sheet motion while opening/closing the keyboard

### DIFF
--- a/package/analysis_options.yaml
+++ b/package/analysis_options.yaml
@@ -9,3 +9,4 @@ linter:
     require_trailing_commas: false
     prefer_int_literals: false
     flutter_style_todos: false
+    cascade_invocations: false

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -91,10 +91,9 @@ class _IdleDraggableSheetActivity extends IdleSheetActivity {
 
   @override
   void didChangeContentDimensions(Size? oldDimensions) {
+    super.didChangeContentDimensions(oldDimensions);
     if (pixels == null) {
       setPixels(initialExtent.resolve(delegate.contentDimensions!));
-    } else {
-      super.didChangeContentDimensions(oldDimensions);
     }
   }
 }

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -67,7 +67,8 @@ class _SheetDraggableState extends State<SheetDraggable> {
   }
 }
 
-class UserDragSheetActivity extends SheetActivity {
+class UserDragSheetActivity extends SheetActivity
+    with UserControlledSheetActivityMixin {
   void onDragUpdate(DragUpdateDetails details) {
     if (!mounted) return;
     final delta = -1 * details.primaryDelta!;

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -89,9 +89,4 @@ class UserDragSheetActivity extends SheetActivity {
     if (!mounted) return;
     delegate.goBallistic(0);
   }
-
-  @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    // This body is intentionally left blank to disable the default behavior.
-  }
 }

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -67,6 +67,8 @@ class _SheetDraggableState extends State<SheetDraggable> {
   }
 }
 
+// TODO: Move this class to sheet_activity.dart
+// TODO: Add constructor with `DragGestureRecognizer` parameter
 class UserDragSheetActivity extends SheetActivity
     with UserControlledSheetActivityMixin {
   void onDragUpdate(DragUpdateDetails details) {

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -94,17 +94,4 @@ class UserDragSheetActivity extends SheetActivity {
   void didChangeContentDimensions(Size? oldDimensions) {
     // This body is intentionally left blank to disable the default behavior.
   }
-
-  @override
-  void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {
-    final oldInsets = oldDimensions?.insets;
-    final insets = delegate.metrics.viewportDimensions.insets;
-    if (pixels != null &&
-        oldInsets != null &&
-        insets.bottom != oldInsets.bottom) {
-      // Append a delta of the bottom inset (typically the keyboard height)
-      // to keep the visual position of the sheet unchanged.
-      correctPixels(pixels! + (oldInsets.bottom - insets.bottom));
-    }
-  }
 }

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -104,6 +104,7 @@ class _RenderSheetViewport extends RenderTransform {
   void performLayout() {
     // We can assume that the viewport will always be as big as possible.
     _lastMeasuredSize = constraints.biggest;
+    _extent.markAsDimensionsWillChange();
     // Notify the SheetExtent about the viewport size changes
     // before performing the layout so that the descendant widgets
     // can use the viewport size during the layout phase.
@@ -121,11 +122,12 @@ class _RenderSheetViewport extends RenderTransform {
     );
 
     assert(
-      _extent.contentDimensions != null && _extent.pixels != null,
-      'The sheet extent and its content dimensions '
+      _extent.hasPixels,
+      'The sheet extent and the dimensions values '
       'must be finalized during the layout phase.',
     );
 
+    _extent.markAsDimensionsChanged();
     _invalidateTranslationValue();
   }
 
@@ -283,9 +285,11 @@ class _RenderSheetContentLayoutObserver extends RenderPositionedBox {
 
   @override
   void performLayout() {
+    _extent?.markAsDimensionsWillChange();
     super.performLayout();
     if (child != null && _isPrimary()) {
       _extent?.applyNewContentDimensions(child!.size);
     }
+    _extent?.markAsDimensionsChanged();
   }
 }

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -201,7 +201,6 @@ class BallisticSheetActivity extends SheetActivity
   }
 }
 
-
 class IdleSheetActivity extends SheetActivity {}
 
 mixin DrivenSheetActivityMixin on SheetActivity {

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -121,6 +121,8 @@ abstract class SheetActivity extends ChangeNotifier {
       correctPixels(pixels! + (oldInsets.bottom - insets.bottom));
     }
   }
+
+  void didFinalizeDimensions() {}
 }
 
 class DrivenSheetActivity extends SheetActivity {
@@ -173,7 +175,7 @@ class DrivenSheetActivity extends SheetActivity {
     _animation.dispose();
     super.dispose();
   }
-  
+
   @override
   void didChangeContentDimensions(Size? oldDimensions) {
     if (delegate.hasPixels) {

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
+import 'dart:math';
 
-import 'package:flutter/animation.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/src/foundation/notification.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
 
 abstract class SheetActivity extends ChangeNotifier {
   bool _mounted = false;
@@ -102,30 +103,64 @@ abstract class SheetActivity extends ChangeNotifier {
     if (other.pixels != null) {
       correctPixels(other.pixels!);
     }
+    _oldContentDimensions = other._oldContentDimensions;
+    _oldViewportDimensions = other._oldViewportDimensions;
   }
 
+  Size? _oldContentDimensions;
+  ViewportDimensions? _oldViewportDimensions;
+
+  @mustCallSuper
   void didChangeContentDimensions(Size? oldDimensions) {
-    if (delegate.hasPixels) {
-      delegate.goBallistic(0);
-    }
+    _oldContentDimensions = oldDimensions;
   }
 
+  @mustCallSuper
   void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {
-    final oldInsets = oldDimensions?.insets;
-    final insets = delegate.metrics.viewportDimensions.insets;
-    if (pixels != null &&
-        oldInsets != null &&
-        insets.bottom != oldInsets.bottom) {
-      // Append a delta of the bottom inset (typically the keyboard height)
-      // to keep the visual position of the sheet unchanged.
-      correctPixels(pixels! + (oldInsets.bottom - insets.bottom));
-    }
+    _oldViewportDimensions = oldDimensions;
   }
 
-  void didFinalizeDimensions() {}
+  void didFinalizeDimensions() {
+    assert(pixels != null);
+    assert(delegate.hasPixels);
+
+    final oldPixels = pixels!;
+    final metrics = delegate.metrics;
+    final newInsets = metrics.viewportDimensions.insets;
+    final oldInsets = _oldViewportDimensions?.insets ?? newInsets;
+    final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
+
+    switch (deltaInsetBottom) {
+      case > 0:
+        // Prevents the sheet from being pushed off the screen by the keyboard.
+        final correction = min(0.0, metrics.maxViewPixels - metrics.viewPixels);
+        setPixels(oldPixels + correction);
+
+      case < 0:
+        // Appends the delta of the bottom inset (typically the keyboard height)
+        // to keep the visual sheet position unchanged.
+        setPixels(
+          min(oldPixels - deltaInsetBottom, delegate.metrics.maxPixels),
+        );
+    }
+
+    if (metrics.contentDimensions != _oldContentDimensions ||
+        metrics.viewportDimensions != _oldViewportDimensions) {
+      // delegate.goBallistic(0.0);
+
+      final parentPhysics = delegate.physics.parent;
+      final detent = (parentPhysics! as SnappingSheetPhysics)
+          .snappingBehavior
+          .findSnapPixels(0, delegate.metrics);
+      if (detent != null) {
+        delegate.animateTo(Extent.pixels(detent),
+            duration: const Duration(milliseconds: 200), curve: Curves.linear);
+      }
+    }
+  }
 }
 
-class DrivenSheetActivity extends SheetActivity {
+class DrivenSheetActivity extends SheetActivity with DrivenSheetActivityMixin {
   DrivenSheetActivity({
     required this.from,
     required this.to,
@@ -138,93 +173,84 @@ class DrivenSheetActivity extends SheetActivity {
   final Duration duration;
   final Curve curve;
 
-  late final AnimationController _animation;
-
-  final _completer = Completer<void>();
-
-  Future<void> get done => _completer.future;
-
   @override
-  void initWith(SheetExtent delegate) {
-    super.initWith(delegate);
-    _animation = AnimationController.unbounded(
-      value: from,
-      vsync: delegate.context.vsync,
-    )
-      ..addListener(onAnimationTick)
-      ..animateTo(to, duration: duration, curve: curve)
-          // Won't trigger if we dispose 'animation' first.
-          .whenComplete(onAnimationEnd);
-  }
-
-  @protected
-  void onAnimationTick() {
-    final oldPixels = pixels;
-    setPixels(_animation.value);
-    if (pixels != oldPixels) {
-      dispatchUpdateNotification();
-    }
-  }
-
-  @protected
-  void onAnimationEnd() => delegate.goBallistic(0);
-
-  @override
-  void dispose() {
-    _completer.complete();
-    _animation.dispose();
-    super.dispose();
+  AnimationController createAnimationController() {
+    return AnimationController.unbounded(
+        value: from, vsync: delegate.context.vsync);
   }
 
   @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    if (delegate.hasPixels) {
-      delegate.goBallistic(_animation.velocity);
-    }
+  TickerFuture startAnimation() {
+    return controller.animateTo(to, duration: duration, curve: curve);
+  }
+
+  @override
+  void onAnimationEnd() {
+    delegate.goBallistic(0);
   }
 }
 
-class BallisticSheetActivity extends SheetActivity {
+class BallisticSheetActivity extends SheetActivity
+    with DrivenSheetActivityMixin {
   BallisticSheetActivity({
     required this.simulation,
   });
 
   final Simulation simulation;
+
+  @override
+  AnimationController createAnimationController() {
+    return AnimationController.unbounded(vsync: delegate.context.vsync);
+  }
+
+  @override
+  TickerFuture startAnimation() {
+    return controller.animateWith(simulation);
+  }
+
+  @override
+  void onAnimationEnd() {
+    delegate.goIdle();
+  }
+}
+
+class IdleSheetActivity extends SheetActivity {}
+
+mixin DrivenSheetActivityMixin on SheetActivity {
   late final AnimationController controller;
+  late double _lastAnimatedValue;
+
+  final _completer = Completer<void>();
+  Future<void> get done => _completer.future;
+
+  AnimationController createAnimationController();
+  TickerFuture startAnimation();
+  void onAnimationEnd() {}
 
   @override
   void initWith(SheetExtent delegate) {
     super.initWith(delegate);
-
-    controller = AnimationController.unbounded(vsync: delegate.context.vsync)
-      ..addListener(onTick)
-      ..animateWith(simulation).whenComplete(onEnd);
+    controller = createAnimationController()..addListener(onAnimationTick);
+    // Won't trigger if we dispose 'animation' first.
+    startAnimation().whenComplete(onAnimationEnd);
+    _lastAnimatedValue = controller.value;
   }
 
-  void onTick() {
-    final oldPixels = pixels;
-    setPixels(controller.value);
-    if (pixels != oldPixels) {
-      dispatchUpdateNotification();
+  void onAnimationTick() {
+    if (mounted) {
+      final oldPixels = pixels;
+      setPixels(pixels! + controller.value - _lastAnimatedValue);
+      if (pixels != oldPixels) {
+        dispatchUpdateNotification();
+      }
+      _lastAnimatedValue = controller.value;
     }
-  }
-
-  void onEnd() {
-    delegate.goIdle();
   }
 
   @override
   void dispose() {
     controller.dispose();
+    _completer.complete();
     super.dispose();
   }
-
-  @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    if (delegate.hasPixels) {
-      delegate.goBallistic(controller.velocity);
-    }
-  }
 }
-
-class IdleSheetActivity extends SheetActivity {}

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -243,42 +243,6 @@ mixin DrivenSheetActivityMixin on SheetActivity {
     _completer.complete();
     super.dispose();
   }
-
-  @override
-  void didFinalizeDimensions(
-    Size? oldContentDimensions,
-    ViewportDimensions? oldViewportDimensions,
-  ) {
-    assert(pixels != null);
-    assert(delegate.hasPixels);
-
-    if (oldContentDimensions == null && oldViewportDimensions == null) {
-      // The sheet was laid out, but not changed in size.
-      return;
-    }
-
-    final oldPixels = pixels!;
-    final metrics = delegate.metrics;
-    final newInsets = metrics.viewportDimensions.insets;
-    final oldInsets = oldViewportDimensions?.insets ?? newInsets;
-    final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
-
-    switch (deltaInsetBottom) {
-      case > 0:
-        // Prevents the sheet from being pushed off the screen by the keyboard.
-        final correction = min(0.0, metrics.maxViewPixels - metrics.viewPixels);
-        setPixels(oldPixels + correction);
-
-      case < 0:
-        // Appends the delta of the bottom inset (typically the keyboard height)
-        // to keep the visual sheet position unchanged.
-        setPixels(
-          min(oldPixels - deltaInsetBottom, delegate.metrics.maxPixels),
-        );
-    }
-
-    delegate.settle();
-  }
 }
 
 mixin UserControlledSheetActivityMixin on SheetActivity {

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -160,8 +160,9 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 }
 
-class DrivenSheetActivity extends SheetActivity with DrivenSheetActivityMixin {
-  DrivenSheetActivity({
+class AnimatedSheetActivity extends SheetActivity
+    with DrivenSheetActivityMixin {
+  AnimatedSheetActivity({
     required this.from,
     required this.to,
     required this.duration,

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -232,7 +232,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
     if (pixels == destination) {
       return Future.value();
     } else {
-      final activity = DrivenSheetActivity(
+      final activity = AnimatedSheetActivity(
         from: pixels!,
         to: destination,
         duration: duration,

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -57,7 +57,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
     required this.minExtent,
     required this.maxExtent,
   }) {
-    _metrics = _SheetMetricsBox(this);
+    _metrics = _SheetMetricsRef(this);
     beginActivity(IdleSheetActivity());
   }
 
@@ -72,7 +72,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
   Size? _contentDimensions;
   ViewportDimensions? _viewportDimensions;
 
-  late final _SheetMetricsBox _metrics;
+  late final _SheetMetricsRef _metrics;
   SheetMetrics get metrics => _metrics;
 
   SheetMetricsSnapshot get snapshot {
@@ -347,8 +347,8 @@ class SheetMetricsSnapshot with MaybeSheetMetrics, SheetMetrics {
       ).toString();
 }
 
-class _SheetMetricsBox with MaybeSheetMetrics, SheetMetrics {
-  _SheetMetricsBox(this._source);
+class _SheetMetricsRef with MaybeSheetMetrics, SheetMetrics {
+  _SheetMetricsRef(this._source);
 
   final MaybeSheetMetrics _source;
 

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -286,6 +286,18 @@ mixin MaybeSheetMetrics {
         _ => null,
       };
 
+  double? get minViewPixels => switch ((minPixels, viewportDimensions)) {
+        (final minPixels?, final viewport?) =>
+          minPixels + viewport.insets.bottom,
+        _ => null,
+      };
+
+  double? get maxViewPixels => switch ((maxPixels, viewportDimensions)) {
+        (final maxPixels?, final viewport?) =>
+          maxPixels + viewport.insets.bottom,
+        _ => null,
+      };
+
   bool get hasPixels =>
       pixels != null &&
       minPixels != null &&
@@ -297,9 +309,11 @@ mixin MaybeSheetMetrics {
   String toString() => (
         hasPixels: hasPixels,
         pixels: pixels,
-        viewPixels: viewPixels,
         minPixels: minPixels,
         maxPixels: maxPixels,
+        viewPixels: viewPixels,
+        minViewPixels: minViewPixels,
+        maxViewPixels: maxViewPixels,
         contentDimensions: contentDimensions,
         viewportDimensions: viewportDimensions,
       ).toString();
@@ -323,6 +337,12 @@ mixin SheetMetrics on MaybeSheetMetrics {
 
   @override
   double get viewPixels => super.viewPixels!;
+
+  @override
+  double get minViewPixels => super.minViewPixels!;
+
+  @override
+  double get maxViewPixels => super.maxViewPixels!;
 }
 
 class SheetMetricsSnapshot with MaybeSheetMetrics, SheetMetrics {

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -5,6 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
 
+// logical pixels per second
+const _defaultSettlingSpeed = 1000.0;
+
 abstract class SheetPhysics {
   const SheetPhysics({
     this.parent,
@@ -50,12 +53,32 @@ abstract class SheetPhysics {
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {
     if (parent != null) {
       return parent!.createBallisticSimulation(velocity, metrics);
-    } else if (metrics.pixels < metrics.minPixels) {
+    } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
       return ScrollSpringSimulation(
           spring, metrics.pixels, metrics.minPixels, velocity);
-    } else if (metrics.pixels > metrics.maxPixels) {
+    } else if (metrics.pixels.isGreaterThan(metrics.maxPixels)) {
       return ScrollSpringSimulation(
           spring, metrics.pixels, metrics.maxPixels, velocity);
+    } else {
+      return null;
+    }
+  }
+
+  Simulation? createSettlingSimulation(SheetMetrics metrics) {
+    if (parent != null) {
+      return parent!.createSettlingSimulation(metrics);
+    } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
+      return UniformLinearSimulation(
+        position: metrics.pixels,
+        detent: metrics.minPixels,
+        speed: _defaultSettlingSpeed,
+      );
+    } else if (metrics.pixels.isGreaterThan(metrics.maxPixels)) {
+      return UniformLinearSimulation(
+        position: metrics.pixels,
+        detent: metrics.minPixels,
+        speed: _defaultSettlingSpeed,
+      );
     } else {
       return null;
     }
@@ -78,6 +101,40 @@ abstract class SheetPhysics {
 
   @override
   int get hashCode => Object.hash(runtimeType, parent);
+}
+
+class UniformLinearSimulation extends Simulation {
+  UniformLinearSimulation({
+    required this.position,
+    required this.detent,
+    required double speed,
+  }) : assert(speed > 0) {
+    velocity = (detent - position).sign * speed;
+    duration = (detent - position) / velocity;
+  }
+
+  final double position;
+  final double detent;
+  late final double velocity;
+  late final double duration;
+
+  @override
+  double dx(double time) {
+    return velocity;
+  }
+
+  @override
+  double x(double time) {
+    return switch (time < duration) {
+      true => position + velocity * time,
+      false => detent,
+    };
+  }
+
+  @override
+  bool isDone(double time) {
+    return x(time).isApprox(detent);
+  }
 }
 
 typedef SnapPixelsProvider = double? Function(
@@ -180,13 +237,25 @@ class SnappingSheetPhysics extends SheetPhysics {
   @override
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {
     final snapPixels = snappingBehavior.findSnapPixels(velocity, metrics);
-    final currentPixels = metrics.pixels;
-
-    if (snapPixels != null && !currentPixels.isApprox(snapPixels)) {
+    if (snapPixels != null && !metrics.pixels.isApprox(snapPixels)) {
       return ScrollSpringSimulation(
-          spring, currentPixels, snapPixels, velocity);
+          spring, metrics.pixels, snapPixels, velocity);
     } else {
       return super.createBallisticSimulation(velocity, metrics);
+    }
+  }
+
+  @override
+  Simulation? createSettlingSimulation(SheetMetrics metrics) {
+    final snapPixels = snappingBehavior.findSnapPixels(0, metrics);
+    if (snapPixels != null && !metrics.pixels.isApprox(snapPixels)) {
+      return UniformLinearSimulation(
+        position: metrics.pixels,
+        detent: snapPixels,
+        speed: _defaultSettlingSpeed,
+      );
+    } else {
+      return super.createSettlingSimulation(metrics);
     }
   }
 

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -18,17 +18,6 @@ abstract class SheetPhysics {
     return _spring ?? const ScrollPhysics().spring;
   }
 
-  double adjustPixelsForNewBoundaryConditions(
-    double pixels,
-    SheetMetrics metrics,
-  ) {
-    if (parent != null) {
-      return parent!.adjustPixelsForNewBoundaryConditions(pixels, metrics);
-    }
-
-    return pixels.clamp(metrics.minPixels, metrics.maxPixels);
-  }
-
   double computeOverflow(double offset, SheetMetrics metrics) {
     if (parent != null) {
       return parent!.computeOverflow(offset, metrics);

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -301,6 +301,8 @@ class _ProxySheetActivity extends SheetActivity {
   }
 
   @override
-  void didChangeContentDimensions(Size? oldDimensions) =>
+  void didChangeContentDimensions(Size? oldDimensions) {
+      super.didChangeContentDimensions(oldDimensions);
       _syncPixelsImplicitly();
+  }
 }

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -302,7 +302,7 @@ class _ProxySheetActivity extends SheetActivity {
 
   @override
   void didChangeContentDimensions(Size? oldDimensions) {
-      super.didChangeContentDimensions(oldDimensions);
-      _syncPixelsImplicitly();
+    super.didChangeContentDimensions(oldDimensions);
+    _syncPixelsImplicitly();
   }
 }

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -238,10 +238,9 @@ class _ContentIdleScrollDrivenSheetActivity
 
   @override
   void didChangeContentDimensions(Size? oldDimensions) {
+    super.didChangeContentDimensions(oldDimensions);
     if (pixels == null) {
       setPixels(initialExtent.resolve(delegate.contentDimensions!));
-    } else {
-      super.didChangeContentDimensions(oldDimensions);
     }
   }
 
@@ -277,11 +276,6 @@ class _ContentUserScrollDrivenSheetActivity
     if (mounted) {
       delegate.goBallistic(0);
     }
-  }
-
-  @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    // This body is intentionally left blank to disable the default behavior.
   }
 }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -59,7 +59,8 @@ class ScrollableSheetExtent extends SingleChildSheetExtent {
 
   @override
   void goIdle() => beginActivity(
-      _ContentIdleScrollDrivenSheetActivity(initialExtent: initialExtent));
+        _ContentIdleScrollDrivenSheetActivity(initialExtent: initialExtent),
+      );
 
   @override
   void goBallistic(double velocity) {

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -283,19 +283,6 @@ class _ContentUserScrollDrivenSheetActivity
   void didChangeContentDimensions(Size? oldDimensions) {
     // This body is intentionally left blank to disable the default behavior.
   }
-
-  @override
-  void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {
-    final oldInsets = oldDimensions?.insets;
-    final insets = delegate.metrics.viewportDimensions.insets;
-    if (pixels != null &&
-        oldInsets != null &&
-        insets.bottom != oldInsets.bottom) {
-      // Append a delta of the bottom inset (typically the keyboard height)
-      // to keep the visual position of the sheet unchanged.
-      correctPixels(pixels! + (oldInsets.bottom - insets.bottom));
-    }
-  }
 }
 
 class _ContentBallisticScrollDrivenSheetActivity

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -252,7 +252,8 @@ class _ContentIdleScrollDrivenSheetActivity
 }
 
 class _ContentUserScrollDrivenSheetActivity
-    extends _ContentScrollDrivenSheetActivity {
+    extends _ContentScrollDrivenSheetActivity
+    with UserControlledSheetActivityMixin {
   @override
   DelegationResult<void> applyUserScrollOffset(
     double delta,
@@ -300,7 +301,7 @@ class _ContentBallisticScrollDrivenSheetActivity
     }
 
     if (delegate.physics.shouldGoBallistic(velocity, delegate.metrics)) {
-      position.goBallistic(velocity);
+      delegate.goBallistic(velocity);
     }
 
     return DelegationResult.handled(overscroll);
@@ -333,17 +334,6 @@ class _DragInterruptibleBallisticSheetActivity extends BallisticSheetActivity
   void onDragStart(DragStartDetails details) {
     _cancelSimulation();
     delegate.beginActivity(_ContentUserScrollDrivenSheetActivity());
-  }
-
-  @override
-  DelegationResult<ScrollActivity> goBallisticScroll(
-    double velocity,
-    bool shouldIgnorePointer,
-    SheetContentScrollPosition position,
-  ) {
-    _cancelSimulation();
-    delegate.goIdle();
-    return const DelegationResult.notHandled();
   }
 }
 


### PR DESCRIPTION
Fixes #22. Unfortunately, there are still some problems related to the keyboard (e.g. #14) that will be taken care of in a future PR.

Summary:

- Added `SheetExtent.settle`, which causes the sheet to settle into a stationary position similar to the `goBallistic(0.0)`, but with a constant (non zero) and relatively high velocity.
- Added `SheetActivity.didFinalizeDimensions`, which is called once in a frame after all measurement processes for both the content and the viewport size have been completed.