### PR TITLE
Physics improvements

### DIFF
--- a/cookbook/ios/Runner.xcodeproj/project.pbxproj
+++ b/cookbook/ios/Runner.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/cookbook/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/cookbook/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/cookbook/lib/showcase/ai_playlist_generator.dart
+++ b/cookbook/lib/showcase/ai_playlist_generator.dart
@@ -107,14 +107,7 @@ final _confirmRoute = GoRoute(
       initialExtent: Extent.proportional(0.7),
       minExtent: Extent.proportional(0.7),
       physics: StretchingSheetPhysics(
-        parent: SnappingSheetPhysics(
-          snappingBehavior: SnapToNearest(
-            snapTo: [
-              Extent.proportional(0.7),
-              Extent.proportional(1),
-            ],
-          ),
-        ),
+        parent: SnappingSheetPhysics(),
       ),
       child: _ConfirmPage(),
     );

--- a/cookbook/lib/showcase/airbnb_mobile_app.dart
+++ b/cookbook/lib/showcase/airbnb_mobile_app.dart
@@ -170,10 +170,6 @@ class _ContentSheet extends StatelessWidget {
                 minSheetExtent,
                 const Extent.proportional(1),
               ],
-              // The greater 'maxFlingVelocityToSnap' is, the more likely
-              // the sheet will snap to the nearest stop position while scrolling.
-              // Try to increase/decrease this value to see the difference.
-              maxFlingVelocityToSnap: 4000,
             ),
           ),
         );

--- a/cookbook/lib/showcase/safari/menu.dart
+++ b/cookbook/lib/showcase/safari/menu.dart
@@ -24,11 +24,7 @@ class MenuSheet extends StatelessWidget {
       initialExtent: halfWayExtent,
       minExtent: halfWayExtent,
       physics: const StretchingSheetPhysics(
-        parent: SnappingSheetPhysics(
-          snappingBehavior: SnapToNearest(
-            snapTo: [halfWayExtent, Extent.proportional(1)],
-          ),
-        ),
+        parent: SnappingSheetPhysics(),
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(16),

--- a/cookbook/lib/tutorial/cupertino_modal_sheet.dart
+++ b/cookbook/lib/tutorial/cupertino_modal_sheet.dart
@@ -68,14 +68,7 @@ class _HalfScreenSheet extends StatelessWidget {
       initialExtent: Extent.proportional(0.5),
       minExtent: Extent.proportional(0.5),
       physics: StretchingSheetPhysics(
-        parent: SnappingSheetPhysics(
-          snappingBehavior: SnapToNearest(
-            snapTo: [
-              Extent.proportional(0.5),
-              Extent.proportional(1),
-            ],
-          ),
-        ),
+        parent: SnappingSheetPhysics(),
       ),
       child: _SheetContent(),
     );

--- a/cookbook/lib/tutorial/scrollable_sheet.dart
+++ b/cookbook/lib/tutorial/scrollable_sheet.dart
@@ -45,6 +45,20 @@ class _MySheet extends StatelessWidget {
     // Just wrap the content in a ScrollableSheet!
     final sheet = ScrollableSheet(
       child: buildSheetBackground(context, content),
+      // Optional: Comment out the following lines to add multiple stop positions.
+      //
+      // minExtent: const Extent.proportional(0.2),
+      // physics: StretchingSheetPhysics(
+      //   parent: SnappingSheetPhysics(
+      //     snappingBehavior: SnapToNearest(
+      //       snapTo: [
+      //         const Extent.proportional(0.2),
+      //         const Extent.proportional(0.5),
+      //         const Extent.proportional(1),
+      //       ],
+      //     ),
+      //   ),
+      // ),
     );
 
     return SafeArea(bottom: false, child: sheet);

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -43,13 +43,13 @@ class _ExampleSheet extends StatelessWidget {
       bottomBar: buildBottomBar(),
     );
 
-    const physics = StretchingSheetPhysics(
+    final physics = StretchingSheetPhysics(
       parent: SnappingSheetPhysics(
         snappingBehavior: SnapToNearest(
           snapTo: [
-            Extent.proportional(0.2),
-            Extent.proportional(0.5),
-            Extent.proportional(1),
+            const Extent.proportional(0.2),
+            const Extent.proportional(0.5),
+            const Extent.proportional(1),
           ],
         ),
       ),

--- a/cookbook/lib/tutorial/sheet_controller.dart
+++ b/cookbook/lib/tutorial/sheet_controller.dart
@@ -90,14 +90,7 @@ class _ExampleSheet extends StatelessWidget {
       controller: controller,
       minExtent: const Extent.proportional(0.5),
       physics: const StretchingSheetPhysics(
-        parent: SnappingSheetPhysics(
-          snappingBehavior: SnapToNearest(
-            snapTo: [
-              Extent.proportional(0.5),
-              Extent.proportional(1),
-            ],
-          ),
-        ),
+        parent: SnappingSheetPhysics(),
       ),
       child: Card(
         margin: EdgeInsets.zero,

--- a/cookbook/lib/tutorial/sheet_draggable.dart
+++ b/cookbook/lib/tutorial/sheet_draggable.dart
@@ -67,14 +67,7 @@ class _ExampleSheet extends StatelessWidget {
 
     const minExtent = Extent.proportional(0.5);
     const physics = StretchingSheetPhysics(
-      parent: SnappingSheetPhysics(
-        snappingBehavior: SnapToNearest(
-          snapTo: [
-            minExtent,
-            Extent.proportional(1),
-          ],
-        ),
-      ),
+      parent: SnappingSheetPhysics(),
     );
 
     return SafeArea(

--- a/cookbook/lib/tutorial/sheet_physics.dart
+++ b/cookbook/lib/tutorial/sheet_physics.dart
@@ -87,13 +87,16 @@ class _MySheet extends StatelessWidget {
     // - the extent at which ony (_halfwayFraction * 100)% of the content is visible, or
     // - the extent at which the entire content is visible.
     // Note that the "extent" is the visible height of the sheet.
-    const snappingPhysics = SnappingSheetPhysics(
+    final snappingPhysics = SnappingSheetPhysics(
       snappingBehavior: SnapToNearest(
         snapTo: [
-          Extent.proportional(_halfwayFraction),
-          Extent.proportional(1),
+          const Extent.proportional(_halfwayFraction),
+          const Extent.proportional(1),
         ],
       ),
+      // Tips: The above configuration can be replaced with a 'SnapToNearestEdge',
+      // which will snap to either the 'minExtent' or 'maxExtent' of the sheet:
+      // snappingBehavior: const SnapToNearestEdge(),
     );
 
     return switch (kind) {
@@ -101,9 +104,9 @@ class _MySheet extends StatelessWidget {
       _PhysicsKind.stretching => const StretchingSheetPhysics(),
       _PhysicsKind.clampingSnapping =>
         // Use 'parent' to combine multiple physics behaviors.
-        const ClampingSheetPhysics(parent: snappingPhysics),
+        ClampingSheetPhysics(parent: snappingPhysics),
       _PhysicsKind.stretchingSnapping =>
-        const StretchingSheetPhysics(parent: snappingPhysics),
+        StretchingSheetPhysics(parent: snappingPhysics),
     };
   }
 

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -84,8 +84,7 @@ class UserDragSheetActivity extends SheetActivity
 
   void onDragEnd(DragEndDetails details) {
     if (!mounted) return;
-    // TODO: Support fling gestures
-    delegate.goBallistic(0);
+    delegate.goBallistic(-1 * details.velocity.pixelsPerSecond.dy);
   }
 
   void onDragCancel() {

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -197,7 +197,7 @@ class BallisticSheetActivity extends SheetActivity
 
   @override
   void onAnimationEnd() {
-    delegate.settle();
+    delegate.goBallistic(0);
   }
 }
 

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -218,10 +218,15 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
     assert(hasPixels);
     final simulation = physics.createBallisticSimulation(velocity, metrics);
     if (simulation != null) {
-      beginActivity(BallisticSheetActivity(simulation: simulation));
+      goBallisticWith(simulation);
     } else {
       goIdle();
     }
+  }
+
+  void goBallisticWith(Simulation simulation) {
+    assert(hasPixels);
+    beginActivity(BallisticSheetActivity(simulation: simulation));
   }
 
   void settle() {
@@ -229,7 +234,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
     final simulation = physics.createSettlingSimulation(metrics);
     if (simulation != null) {
       // TODO: Begin a SettlingSheetActivity
-      beginActivity(BallisticSheetActivity(simulation: simulation));
+      goBallisticWith(simulation);
     } else {
       goIdle();
     }

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -409,6 +409,22 @@ class SheetMetricsSnapshot with MaybeSheetMetrics, SheetMetrics {
   @override
   bool get hasPixels => true;
 
+  SheetMetricsSnapshot copyWith({
+    double? pixels,
+    double? minPixels,
+    double? maxPixels,
+    Size? contentDimensions,
+    ViewportDimensions? viewportDimensions,
+  }) {
+    return SheetMetricsSnapshot(
+      pixels: pixels ?? this.pixels,
+      minPixels: minPixels ?? this.minPixels,
+      maxPixels: maxPixels ?? this.maxPixels,
+      contentDimensions: contentDimensions ?? this.contentDimensions,
+      viewportDimensions: viewportDimensions ?? this.viewportDimensions,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
+import 'package:smooth_sheets/src/internal/double_utils.dart';
 
 /// Visible area of the sheet.
 abstract interface class Extent {
@@ -227,6 +228,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
     assert(hasPixels);
     final simulation = physics.createSettlingSimulation(metrics);
     if (simulation != null) {
+      // TODO: Begin a SettlingSheetActivity
       beginActivity(BallisticSheetActivity(simulation: simulation));
     } else {
       goIdle();
@@ -324,6 +326,11 @@ mixin MaybeSheetMetrics {
       maxPixels != null &&
       contentDimensions != null &&
       viewportDimensions != null;
+
+  bool get isPixelsInBounds =>
+      hasPixels && pixels!.isInBounds(minPixels!, maxPixels!);
+
+  bool get isPixelsOutOfBounds => !isPixelsInBounds;
 
   @override
   String toString() => (

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -148,7 +148,7 @@ typedef SnapPixelsProvider = double? Function(
 );
 
 abstract interface class SnappingSheetBehavior {
-  double? findSnapPixels(double scrollVelocity, SheetMetrics metrics);
+  double? findSnapPixels(double velocity, SheetMetrics metrics);
 }
 
 /// A [SnappingSheetBehavior] that snaps to either [SheetExtent.minPixels]
@@ -177,10 +177,10 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
   final double minFlingGestureSpeed;
 
   @override
-  double? findSnapPixels(double scrollVelocity, SheetMetrics metrics) {
-    if (scrollVelocity.abs() < minFlingGestureSpeed) {
+  double? findSnapPixels(double velocity, SheetMetrics metrics) {
+    if (velocity.abs() < minFlingGestureSpeed) {
       return metrics.pixels.nearest(metrics.minPixels, metrics.maxPixels);
-    } else if (scrollVelocity < 0) {
+    } else if (velocity < 0) {
       return metrics.minPixels;
     } else {
       return metrics.maxPixels;

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -152,8 +152,8 @@ abstract interface class SnappingSheetBehavior {
 }
 
 /// A [SnappingSheetBehavior] that snaps to either [SheetExtent.minPixels]
-/// or [SheetExtent.maxPixels] based on the current position and the gesture
-/// velocity.
+/// or [SheetExtent.maxPixels] based on the current sheet position and
+/// the gesture velocity.
 ///
 /// If the absolute value of the gesture velocity is less than
 /// [minFlingGestureSpeed], the sheet will snap to the nearest of

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -186,6 +186,19 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
       return metrics.maxPixels;
     }
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SnapToNearestEdge &&
+          runtimeType == other.runtimeType &&
+          minFlingGestureSpeed == other.minFlingGestureSpeed);
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        minFlingGestureSpeed,
+      );
 }
 
 class SnapToNearest implements SnappingSheetBehavior {

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -23,8 +23,8 @@ abstract class SheetPhysics {
   }
 
   double computeOverflow(double offset, SheetMetrics metrics) {
-    if (parent != null) {
-      return parent!.computeOverflow(offset, metrics);
+    if (parent case final parent?) {
+      return parent.computeOverflow(offset, metrics);
     }
 
     final newPixels = metrics.pixels + offset;
@@ -38,8 +38,8 @@ abstract class SheetPhysics {
   }
 
   double applyPhysicsToOffset(double offset, SheetMetrics metrics) {
-    if (parent != null) {
-      return parent!.applyPhysicsToOffset(offset, metrics);
+    if (parent case final parent?) {
+      return parent.applyPhysicsToOffset(offset, metrics);
     } else if (offset > 0 && metrics.pixels < metrics.maxPixels) {
       // Prevent the pixels from going beyond the maximum value.
       return min(metrics.maxPixels, metrics.pixels + offset) - metrics.pixels;
@@ -52,8 +52,8 @@ abstract class SheetPhysics {
   }
 
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {
-    if (parent != null) {
-      return parent!.createBallisticSimulation(velocity, metrics);
+    if (parent case final parent?) {
+      return parent.createBallisticSimulation(velocity, metrics);
     } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
       // The simulation velocity is intentionally set to 0
       // as flinging an over-dragged/under-dragged sheet
@@ -69,8 +69,8 @@ abstract class SheetPhysics {
   }
 
   Simulation? createSettlingSimulation(SheetMetrics metrics) {
-    if (parent != null) {
-      return parent!.createSettlingSimulation(metrics);
+    if (parent case final parent?) {
+      return parent.createSettlingSimulation(metrics);
     } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
       return UniformLinearSimulation(
         position: metrics.pixels,

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -89,11 +89,10 @@ abstract class SheetPhysics {
   }
 
   bool shouldGoBallistic(double velocity, SheetMetrics metrics) {
-    if (parent != null) {
-      return parent!.shouldGoBallistic(velocity, metrics);
-    }
-
-    return metrics.pixels.isOutOfRange(metrics.minPixels, metrics.maxPixels);
+    return switch (parent) {
+      null => metrics.pixels.isOutOfRange(metrics.minPixels, metrics.maxPixels),
+      final parent => parent.shouldGoBallistic(velocity, metrics),
+    };
   }
 
   @override

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -207,6 +207,7 @@ class SnapToNearestEdge with _SnapToNearestMixin {
 
   @override
   (double, double) _findSnapRangeContains(SheetMetrics metrics) {
+    assert(metrics.pixels.isInRange(metrics.minPixels, metrics.maxPixels));
     return (metrics.minPixels, metrics.maxPixels);
   }
 
@@ -250,6 +251,13 @@ class SnapToNearest with _SnapToNearestMixin {
           .map((e) => e.resolve(metrics.contentDimensions))
           .toList(growable: false)
         ..sort();
+
+      assert(
+        _snapTo.first.isGreaterThanOrApprox(metrics.minPixels) &&
+            _snapTo.last.isLessThanOrApprox(metrics.maxPixels),
+        'The snap positions must be within the range of '
+        "'SheetExtent.minPixels' and 'SheetExtent.maxPixels'.",
+      );
     }
   }
 

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -1,16 +1,13 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
 
 // logical pixels per second
 const _defaultSettlingSpeed = 1000.0;
-
-/// The default lowest speed (in logical pixels per second)
-/// at which a gesture is considered to be a fling.
-const _defaultMinFlingGestureSpeed = 500.0;
 
 abstract class SheetPhysics {
   const SheetPhysics({
@@ -168,9 +165,12 @@ abstract interface class SnappingSheetBehavior {
 class SnapToNearestEdge implements SnappingSheetBehavior {
   /// Creates a [SnappingSheetBehavior] that snaps to either
   /// [SheetExtent.minPixels] or [SheetExtent.maxPixels].
+  ///
+  /// The [minFlingGestureSpeed] defaults to [kMinFlingVelocity],
+  /// and must be non-negative.
   const SnapToNearestEdge({
-    this.minFlingGestureSpeed = _defaultMinFlingGestureSpeed,
-  }): assert(minFlingGestureSpeed >= 0);
+    this.minFlingGestureSpeed = kMinFlingVelocity,
+  }) : assert(minFlingGestureSpeed >= 0);
 
   /// The lowest speed (in logical pixels per second)
   /// at which a gesture is considered to be a fling.
@@ -204,7 +204,7 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
 class SnapToNearest implements SnappingSheetBehavior {
   SnapToNearest({
     required this.snapTo,
-    this.minFlingGestureSpeed = _defaultMinFlingGestureSpeed,
+    this.minFlingGestureSpeed = kMinFlingVelocity,
   })  : assert(snapTo.isNotEmpty),
         assert(minFlingGestureSpeed >= 0);
 
@@ -252,7 +252,7 @@ class SnapToNearest implements SnappingSheetBehavior {
       return snapTo.first;
     } else if (metrics.pixels.isGreaterThan(snapTo.last)) {
       return snapTo.last;
-  }
+    }
 
     var nearestSmaller = snapTo[0];
     var nearestGreater = snapTo[1];

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -80,7 +80,6 @@ abstract class SheetPhysics {
     }
     final settleTo =
         metrics.pixels.nearest(metrics.minPixels, metrics.maxPixels);
-    
 
     return _InterpolationSimulation(
       start: metrics.pixels,

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -95,14 +95,6 @@ abstract class SheetPhysics {
     );
   }
 
-  bool shouldGoBallistic(double velocity, SheetMetrics metrics) {
-    return switch (parent) {
-      null =>
-        metrics.pixels.isOutOfBounds(metrics.minPixels, metrics.maxPixels),
-      final parent => parent.shouldGoBallistic(velocity, metrics),
-    };
-  }
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -305,18 +297,6 @@ class SnappingSheetPhysics extends SheetPhysics {
   });
 
   final SnappingSheetBehavior snappingBehavior;
-
-  @override
-  bool shouldGoBallistic(double velocity, SheetMetrics metrics) {
-    final snapPixels = snappingBehavior.findSnapPixels(velocity, metrics);
-    final currentPixels = metrics.pixels;
-
-    if (snapPixels != null && !currentPixels.isApprox(snapPixels)) {
-      return true;
-    } else {
-      return super.shouldGoBallistic(velocity, metrics);
-    }
-  }
 
   @override
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -141,12 +141,6 @@ class UniformLinearSimulation extends Simulation {
   }
 }
 
-typedef SnapPixelsProvider = double? Function(
-  Iterable<Extent> snapTo,
-  double velocity,
-  SheetMetrics metrics,
-);
-
 abstract interface class SnappingSheetBehavior {
   double? findSnapPixels(double velocity, SheetMetrics metrics);
 }

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -56,10 +56,10 @@ abstract class SheetPhysics {
       return parent!.createBallisticSimulation(velocity, metrics);
     } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
       return ScrollSpringSimulation(
-          spring, metrics.pixels, metrics.minPixels, velocity);
+          spring, metrics.pixels, metrics.minPixels, 0);
     } else if (metrics.pixels.isGreaterThan(metrics.maxPixels)) {
       return ScrollSpringSimulation(
-          spring, metrics.pixels, metrics.maxPixels, velocity);
+          spring, metrics.pixels, metrics.maxPixels, 0);
     } else {
       return null;
     }
@@ -178,7 +178,9 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
 
   @override
   double? findSnapPixels(double velocity, SheetMetrics metrics) {
-    if (velocity.abs() < minFlingSpeed) {
+    if (metrics.pixels.isOutOfRange(metrics.minPixels, metrics.maxPixels)) {
+      return null;
+    } else if (velocity.abs() < minFlingSpeed) {
       return metrics.pixels.nearest(metrics.minPixels, metrics.maxPixels);
     } else if (velocity < 0) {
       return metrics.minPixels;
@@ -274,9 +276,11 @@ class SnapToNearest implements SnappingSheetBehavior {
     }
   }
 
-  bool _shouldSnap(double scrollVelocity, SheetMetrics metrics) {
-    // TODO: Implement this.
-    return true;
+  bool _shouldSnap(double velocity, SheetMetrics metrics) {
+    return metrics.pixels.isInRange(
+      _cachedSnapPixelsList.first,
+      _cachedSnapPixelsList.last,
+    );
   }
 
   @override

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -157,7 +157,7 @@ mixin _SnapToNearestMixin implements SnappingSheetBehavior {
   double get minFlingSpeed;
 
   @protected
-  ({double left, double right}) _findSnapRangeContains(SheetMetrics metrics);
+  (double, double) _findSnapRangeContains(SheetMetrics metrics);
 
   @override
   double? findSnapPixels(double velocity, SheetMetrics metrics) {
@@ -167,13 +167,13 @@ mixin _SnapToNearestMixin implements SnappingSheetBehavior {
       return null;
     }
 
-    final snapRange = _findSnapRangeContains(metrics);
+    final (nearestSmaller, nearestGreater) = _findSnapRangeContains(metrics);
     if (velocity.abs() < minFlingSpeed) {
-      return metrics.pixels.nearest(snapRange.left, snapRange.right);
+      return metrics.pixels.nearest(nearestSmaller, nearestGreater);
     } else if (velocity < 0) {
-      return snapRange.left;
+      return nearestSmaller;
     } else {
-      return snapRange.right;
+      return nearestGreater;
     }
   }
 }
@@ -206,8 +206,8 @@ class SnapToNearestEdge with _SnapToNearestMixin {
   final double minFlingSpeed;
 
   @override
-  ({double left, double right}) _findSnapRangeContains(SheetMetrics metrics) {
-    return (left: metrics.minPixels, right: metrics.maxPixels);
+  (double, double) _findSnapRangeContains(SheetMetrics metrics) {
+    return (metrics.minPixels, metrics.maxPixels);
   }
 
   @override
@@ -254,10 +254,10 @@ class SnapToNearest with _SnapToNearestMixin {
   }
 
   @override
-  ({double left, double right}) _findSnapRangeContains(SheetMetrics metrics) {
+  (double, double) _findSnapRangeContains(SheetMetrics metrics) {
     _ensureCacheIsValid(metrics);
     if (_snapTo.length == 1) {
-      return (left: _snapTo.first, right: _snapTo.first);
+      return (_snapTo.first, _snapTo.first);
     }
 
     var nearestSmaller = _snapTo[0];
@@ -271,7 +271,7 @@ class SnapToNearest with _SnapToNearestMixin {
       }
     }
 
-    return (left: nearestSmaller, right: nearestGreater);
+    return (nearestSmaller, nearestGreater);
   }
 
   @override

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -7,6 +7,9 @@ import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
 
+const _minSettlingDuration = Duration(milliseconds: 160);
+const _defaultSettlingSpeed = 600.0; // logical pixels per second
+
 abstract class SheetPhysics {
   const SheetPhysics({
     this.parent,
@@ -86,8 +89,8 @@ abstract class SheetPhysics {
       end: settleTo,
       curve: Curves.easeInOut,
       durationInSeconds: max(
-        (metrics.pixels - settleTo).abs() / defaultSettlingSpeed,
-        minSettlingDuration.inMicroseconds / Duration.microsecondsPerSecond,
+        (metrics.pixels - settleTo).abs() / _defaultSettlingSpeed,
+        _minSettlingDuration.inMicroseconds / Duration.microsecondsPerSecond,
       ),
     );
   }
@@ -110,9 +113,6 @@ abstract class SheetPhysics {
   @override
   int get hashCode => Object.hash(runtimeType, parent);
 }
-
-const minSettlingDuration = Duration(milliseconds: 160);
-const defaultSettlingSpeed = 600.0; // logical pixels per second
 
 class _InterpolationSimulation extends Simulation {
   _InterpolationSimulation({

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -170,7 +170,7 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
   /// [SheetExtent.minPixels] or [SheetExtent.maxPixels].
   const SnapToNearestEdge({
     this.minFlingGestureSpeed = _defaultMinFlingGestureSpeed,
-  });
+  }): assert(minFlingGestureSpeed >= 0);
 
   /// The lowest speed (in logical pixels per second)
   /// at which a gesture is considered to be a fling.

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -411,4 +411,19 @@ class StretchingSheetPhysics extends SheetPhysics {
 
     return newPixels - currentPixels;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is StretchingSheetPhysics &&
+          stretchingRange == other.stretchingRange &&
+          frictionCurve == other.frictionCurve &&
+          super == other);
+
+  @override
+  int get hashCode => Object.hash(
+        stretchingRange,
+        frictionCurve,
+        super.hashCode,
+      );
 }

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -156,7 +156,6 @@ class SnapToNearest implements SnappingSheetBehavior {
   final List<Extent> snapTo;
   final double maxFlingVelocityToSnap;
 
-  // TODO: Cache the result in a Expando.
   ({double min, double max}) _getSnapRange(SheetMetrics metrics) {
     var minPixels = double.infinity;
     var maxPixels = double.negativeInfinity;
@@ -180,7 +179,6 @@ class SnapToNearest implements SnappingSheetBehavior {
 
   double _findNearestPixelsIn(List<Extent> snapTo, SheetMetrics metrics) {
     assert(snapTo.isNotEmpty);
-    // TODO: Cache the snap positions in a Expando.
     return snapTo
         .map((extent) => extent.resolve(metrics.contentDimensions))
         .reduce((nearest, next) => metrics.pixels.nearest(nearest, next));

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -153,7 +153,7 @@ abstract interface class SnappingSheetBehavior {
 /// the gesture velocity.
 ///
 /// If the absolute value of the gesture velocity is less than
-/// [minFlingGestureSpeed], the sheet will snap to the nearest of
+/// [minFlingSpeed], the sheet will snap to the nearest of
 /// [SheetExtent.minPixels] and [SheetExtent.maxPixels].
 /// Otherwise, the gesture is considered to be a fling, and the sheet will snap
 /// towards the direction of the fling. For example, if the sheet is flung up,
@@ -166,19 +166,19 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
   /// Creates a [SnappingSheetBehavior] that snaps to either
   /// [SheetExtent.minPixels] or [SheetExtent.maxPixels].
   ///
-  /// The [minFlingGestureSpeed] defaults to [kMinFlingVelocity],
+  /// The [minFlingSpeed] defaults to [kMinFlingVelocity],
   /// and must be non-negative.
   const SnapToNearestEdge({
-    this.minFlingGestureSpeed = kMinFlingVelocity,
-  }) : assert(minFlingGestureSpeed >= 0);
+    this.minFlingSpeed = kMinFlingVelocity,
+  }) : assert(minFlingSpeed >= 0);
 
   /// The lowest speed (in logical pixels per second)
   /// at which a gesture is considered to be a fling.
-  final double minFlingGestureSpeed;
+  final double minFlingSpeed;
 
   @override
   double? findSnapPixels(double velocity, SheetMetrics metrics) {
-    if (velocity.abs() < minFlingGestureSpeed) {
+    if (velocity.abs() < minFlingSpeed) {
       return metrics.pixels.nearest(metrics.minPixels, metrics.maxPixels);
     } else if (velocity < 0) {
       return metrics.minPixels;
@@ -192,24 +192,24 @@ class SnapToNearestEdge implements SnappingSheetBehavior {
       identical(this, other) ||
       (other is SnapToNearestEdge &&
           runtimeType == other.runtimeType &&
-          minFlingGestureSpeed == other.minFlingGestureSpeed);
+          minFlingSpeed == other.minFlingSpeed);
 
   @override
   int get hashCode => Object.hash(
         runtimeType,
-        minFlingGestureSpeed,
+        minFlingSpeed,
       );
 }
 
 class SnapToNearest implements SnappingSheetBehavior {
   SnapToNearest({
     required this.snapTo,
-    this.minFlingGestureSpeed = kMinFlingVelocity,
+    this.minFlingSpeed = kMinFlingVelocity,
   })  : assert(snapTo.isNotEmpty),
-        assert(minFlingGestureSpeed >= 0);
+        assert(minFlingSpeed >= 0);
 
   final List<Extent> snapTo;
-  final double minFlingGestureSpeed;
+  final double minFlingSpeed;
 
   /// Cached results of [Extent.resolve] for each snap position in [snapTo].
   ///
@@ -265,7 +265,7 @@ class SnapToNearest implements SnappingSheetBehavior {
       }
     }
 
-    if (velocity.abs() < minFlingGestureSpeed) {
+    if (velocity.abs() < minFlingSpeed) {
       return metrics.pixels.nearest(nearestSmaller, nearestGreater);
     } else if (velocity < 0) {
       return nearestSmaller;
@@ -284,13 +284,13 @@ class SnapToNearest implements SnappingSheetBehavior {
       identical(this, other) ||
       (other is SnapToNearest &&
           runtimeType == other.runtimeType &&
-          minFlingGestureSpeed == other.minFlingGestureSpeed &&
+          minFlingSpeed == other.minFlingSpeed &&
           const DeepCollectionEquality().equals(snapTo, other.snapTo));
 
   @override
   int get hashCode => Object.hash(
         runtimeType,
-        minFlingGestureSpeed,
+        minFlingSpeed,
         snapTo,
       );
 }

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -158,10 +158,13 @@ abstract interface class SnappingSheetBehavior {
 /// If the absolute value of the gesture velocity is less than
 /// [minFlingGestureSpeed], the sheet will snap to the nearest of
 /// [SheetExtent.minPixels] and [SheetExtent.maxPixels].
-///
 /// Otherwise, the gesture is considered to be a fling, and the sheet will snap
 /// towards the direction of the fling. For example, if the sheet is flung up,
 /// it will snap to [SheetExtent.maxPixels].
+///
+/// Using this behavior is functionally identical to using [SnapToNearest]
+/// with the snap positions of [SheetExtent.minExtent] and
+/// [SheetExtent.maxExtent], but more simplified and efficient.
 class SnapToNearestEdge implements SnappingSheetBehavior {
   /// Creates a [SnappingSheetBehavior] that snaps to either
   /// [SheetExtent.minPixels] or [SheetExtent.maxPixels].

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -55,6 +55,9 @@ abstract class SheetPhysics {
     if (parent != null) {
       return parent!.createBallisticSimulation(velocity, metrics);
     } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
+      // The simulation velocity is intentionally set to 0
+      // as flinging an over-dragged/under-dragged sheet
+      // tends to make unstable motion.
       return ScrollSpringSimulation(
           spring, metrics.pixels, metrics.minPixels, 0);
     } else if (metrics.pixels.isGreaterThan(metrics.maxPixels)) {

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -54,18 +54,20 @@ abstract class SheetPhysics {
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {
     if (parent case final parent?) {
       return parent.createBallisticSimulation(velocity, metrics);
-    } else if (metrics.pixels.isLessThan(metrics.minPixels)) {
-      // The simulation velocity is intentionally set to 0
-      // as flinging an over-dragged/under-dragged sheet
-      // tends to make unstable motion.
-      return ScrollSpringSimulation(
-          spring, metrics.pixels, metrics.minPixels, 0);
+    }
+
+    final double destination;
+    if (metrics.pixels.isLessThan(metrics.minPixels)) {
+      destination = metrics.minPixels;
     } else if (metrics.pixels.isGreaterThan(metrics.maxPixels)) {
-      return ScrollSpringSimulation(
-          spring, metrics.pixels, metrics.maxPixels, 0);
+      destination = metrics.maxPixels;
     } else {
       return null;
     }
+
+    // The simulation velocity is intentionally set to 0 as flinging
+    // an over-dragged/under-dragged sheet tends to make unstable motion.
+    return ScrollSpringSimulation(spring, metrics.pixels, destination, 0);
   }
 
   Simulation? createSettlingSimulation(SheetMetrics metrics) {

--- a/package/lib/src/internal/double_utils.dart
+++ b/package/lib/src/internal/double_utils.dart
@@ -15,10 +15,10 @@ extension DoubleUtils on double {
   bool isGreaterThanOrApprox(double value) =>
       isGreaterThan(value) || isApprox(value);
 
-  bool isOutOfRange(double min, double max) =>
+  bool isOutOfBounds(double min, double max) =>
       isLessThan(min) || isGreaterThan(max);
 
-  bool isInRange(double min, double max) => !isOutOfRange(min, max);
+  bool isInBounds(double min, double max) => !isOutOfBounds(min, max);
 
   double clampAbs(double norm) => min(max(-norm, this), norm);
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -3,10 +3,12 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
 import 'package:smooth_sheets/src/foundation/single_child_sheet.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
 import 'package:smooth_sheets/src/internal/into.dart';
 import 'package:smooth_sheets/src/scrollable/content_scroll_position.dart';
+import 'package:smooth_sheets/src/scrollable/scrollable_sheet_physics.dart';
 
 class ScrollableSheetExtentFactory extends SingleChildSheetExtentFactory {
   const ScrollableSheetExtentFactory({
@@ -33,9 +35,13 @@ class ScrollableSheetExtent extends SingleChildSheetExtent {
     required super.initialExtent,
     required super.minExtent,
     required super.maxExtent,
-    required super.physics,
     required super.context,
-  }) {
+    required SheetPhysics physics,
+  }) : super(
+          physics: physics is ScrollableSheetPhysics
+              ? physics
+              : ScrollableSheetPhysics(parent: physics),
+        ) {
     goIdle();
   }
 
@@ -301,8 +307,12 @@ class _ContentBallisticScrollDrivenSheetActivity
       dispatchUpdateNotification();
     }
 
-    if (delegate.physics.shouldGoBallistic(velocity, delegate.metrics)) {
-      delegate.goBallistic(velocity);
+    final physics = delegate.physics;
+    if (((position.extentBefore.isApprox(0) && velocity < 0) ||
+            (position.extentAfter.isApprox(0) && velocity > 0)) &&
+        physics is ScrollableSheetPhysics &&
+        physics.shouldInterruptBallisticScroll(velocity, delegate.metrics)) {
+      delegate.goBallistic(0);
     }
 
     return DelegationResult.handled(overscroll);

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -205,7 +205,8 @@ sealed class _ContentScrollDrivenSheetActivity extends SheetActivity
       return const DelegationResult.notHandled();
     }
 
-    if (delegate.physics.shouldGoBallistic(velocity, delegate.metrics)) {
+    if (position.pixels.isApprox(position.minScrollExtent) &&
+        delegate.physics.shouldGoBallistic(velocity, delegate.metrics)) {
       delegate.goBallistic(velocity);
       return DelegationResult.handled(IdleScrollActivity(position));
     }

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -69,15 +69,10 @@ class ScrollableSheetExtent extends SingleChildSheetExtent {
       );
 
   @override
-  void goBallistic(double velocity) {
-    final simulation = physics.createBallisticSimulation(velocity, metrics);
-    if (simulation != null) {
-      beginActivity(
-        _DragInterruptibleBallisticSheetActivity(simulation: simulation),
-      );
-    } else {
-      goIdle();
-    }
+  void goBallisticWith(Simulation simulation) {
+    beginActivity(
+      _DragInterruptibleBallisticSheetActivity(simulation: simulation),
+    );
   }
 
   @override
@@ -211,10 +206,13 @@ sealed class _ContentScrollDrivenSheetActivity extends SheetActivity
       return const DelegationResult.notHandled();
     }
 
-    if (position.pixels.isApprox(position.minScrollExtent) &&
-        delegate.physics.shouldGoBallistic(velocity, delegate.metrics)) {
-      delegate.goBallistic(velocity);
-      return DelegationResult.handled(IdleScrollActivity(position));
+    if (position.pixels.isApprox(position.minScrollExtent)) {
+      final simulation = delegate.physics
+          .createBallisticSimulation(velocity, delegate.metrics);
+      if (simulation != null) {
+        delegate.goBallisticWith(simulation);
+        return DelegationResult.handled(IdleScrollActivity(position));
+      }
     }
 
     final scrollSimulation = position.physics.createBallisticSimulation(

--- a/package/lib/src/scrollable/scrollable_sheet_physics.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_physics.dart
@@ -1,0 +1,22 @@
+import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
+
+mixin ScrollableSheetPhysicsMixin on SheetPhysics {
+  bool shouldInterruptBallisticScroll(double velocity, SheetMetrics metrics);
+}
+
+class ScrollableSheetPhysics extends SheetPhysics
+    with ScrollableSheetPhysicsMixin {
+  const ScrollableSheetPhysics({
+    super.parent,
+    super.spring,
+    this.maxScrollSpeedToInterrupt = double.infinity,
+  }) : assert(maxScrollSpeedToInterrupt >= 0);
+
+  final double maxScrollSpeedToInterrupt;
+
+  @override
+  bool shouldInterruptBallisticScroll(double velocity, SheetMetrics metrics) {
+    return velocity.abs() < maxScrollSpeedToInterrupt;
+  }
+}


### PR DESCRIPTION
Closes #20, closes #29.

### New Features

- Added `SnapToNearestEdge`, a `SheetSnappingBehavior` that snaps to the nearest edge either `minPixels` or `maxPixels`.
- Added convenient getters to `MaybeSheetMetrics`, `isPixelsInBounds` and `isPixelsOutOfBounds`.
- Added `ScrollableSheetPhysics` as the replacement for the deleted `SnapToNearest.maxFlingVelocityToSnap` property.
- Made `SnapToNearest` aware of fling gestures.

### Breaking Changes

- Deleted `SnapToNearest.maxFlingVelocityToSnap`.
- `SnapToNearest` can no longer be a `const`, in exchange for performance improvement.
Due to the above reason, `SnapToNearestEdge` has been used as the default value for `SnappingSheetPhysics.snappingBehavior` instead of `SnapToNearest`.