### PR TITLE
Add missing checkout

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       dart-files: ${{ steps.filter.outputs.dart-files }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
`dorny/paths-filter` fails if it runs on the default branch (`main`) with no checkout step.