### PR TITLE
Add conditional modal sheet popping feature

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -88,7 +88,6 @@ jobs:
   code-check:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Final Results
     needs: [analysis, testing]
     steps:
       # Fails if any of the previous jobs failed.

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -83,3 +83,18 @@ jobs:
           name: Test Report
           path: ${{ env.FLUTTER_TEST_REPORT }}
           reporter: flutter-json
+
+  # Final results (Used for status checks)
+  code-check:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [analysis, testing]
+    steps:
+      # Fails if any of the previous jobs failed.
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/cookbook/lib/showcase/ai_playlist_generator.dart
+++ b/cookbook/lib/showcase/ai_playlist_generator.dart
@@ -56,12 +56,9 @@ final _sheetShellRoute = ShellRoute(
   pageBuilder: (context, state, navigator) {
     // Use ModalSheetPage to show a modal sheet.
     return ModalSheetPage(
-      child: SafeArea(
-        bottom: false,
-        child: NavigationSheet(
-          transitionObserver: sheetTransitionObserver,
-          child: _SheetShell(navigator: navigator),
-        ),
+      child: _SheetShell(
+        navigator: navigator,
+        transitionObserver: sheetTransitionObserver,
       ),
     );
   },
@@ -143,19 +140,61 @@ class _Root extends StatelessWidget {
 
 class _SheetShell extends StatelessWidget {
   const _SheetShell({
+    required this.transitionObserver,
     required this.navigator,
   });
 
+  final NavigationSheetTransitionObserver transitionObserver;
   final Widget navigator;
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      // Add circular corners to the sheet.
-      borderRadius: BorderRadius.circular(16),
-      clipBehavior: Clip.antiAlias,
-      color: Theme.of(context).colorScheme.surface,
-      child: navigator,
+    void showCancelDialog() {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Are you sure?'),
+            content:
+                const Text('Do you want to cancel the playlist generation?'),
+            actions: [
+              TextButton(
+                onPressed: () => context.go('/'),
+                child: const Text('Yes'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('No'),
+              ),
+            ],
+          );
+        },
+      );
+    }
+
+    return SafeArea(
+      bottom: false,
+      // Wrap the sheet in a SheetDismissible to enable pull-to-dismiss action.
+      child: SheetDismissible(
+        // This callback is invoked when the user tries
+        // to dismiss the sheet by dragging it down.
+        onDismiss: () {
+          // Prompt the user to confirm if they want to dismiss the sheet.
+          showCancelDialog();
+          // Returns false to disable automatic modal sheet popping.
+          return false;
+        },
+        child: NavigationSheet(
+          transitionObserver: sheetTransitionObserver,
+          child: Material(
+            // Add circular corners to the sheet.
+            borderRadius: BorderRadius.circular(16),
+            clipBehavior: Clip.antiAlias,
+            color: Theme.of(context).colorScheme.surface,
+            child: navigator,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/cookbook/lib/showcase/safari/actions.dart
+++ b/cookbook/lib/showcase/safari/actions.dart
@@ -6,7 +6,11 @@ void showEditActionsSheet(BuildContext context) {
   Navigator.push(
     context,
     CupertinoModalSheetRoute(
-      builder: (context) => const EditActionsSheet(),
+      builder: (context) {
+        return const SheetDismissible(
+          child: EditActionsSheet(),
+        );
+      },
     ),
   );
 }

--- a/cookbook/lib/showcase/safari/menu.dart
+++ b/cookbook/lib/showcase/safari/menu.dart
@@ -9,7 +9,11 @@ void showMenuSheet(BuildContext context) {
   Navigator.push(
     context,
     CupertinoModalSheetRoute(
-      builder: (context) => const MenuSheet(),
+      builder: (context) {
+        return const SheetDismissible(
+          child: MenuSheet(),
+        );
+      },
     ),
   );
 }

--- a/cookbook/lib/showcase/todo_list/todo_editor.dart
+++ b/cookbook/lib/showcase/todo_list/todo_editor.dart
@@ -34,6 +34,36 @@ class _TodoEditorState extends State<TodoEditor> {
     super.dispose();
   }
 
+  bool onDismiss() {
+    if (!controller.canCompose.value) {
+      // Dismiss immediately if there are no unsaved changes.
+      return true;
+    }
+
+    // Show a confirmation dialog.
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Discard changes?'),
+          actions: [
+            TextButton(
+              onPressed: () =>
+                  Navigator.popUntil(context, (route) => route.isFirst),
+              child: const Text('Discard'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+          ],
+        );
+      },
+    );
+
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     final titleInput = _MultiLineInput(
@@ -103,16 +133,20 @@ class _TodoEditorState extends State<TodoEditor> {
 
     return SafeArea(
       bottom: false,
-      child: ScrollableSheet(
-        keyboardDismissBehavior: const SheetKeyboardDismissBehavior.onDragDown(
-          isContentScrollAware: true,
-        ),
-        child: Container(
-          clipBehavior: Clip.antiAlias,
-          decoration: sheetShape,
-          child: SheetContentScaffold(
-            body: body,
-            bottomBar: bottomBar,
+      child: SheetDismissible(
+        onDismiss: onDismiss,
+        child: ScrollableSheet(
+          keyboardDismissBehavior:
+              const SheetKeyboardDismissBehavior.onDragDown(
+            isContentScrollAware: true,
+          ),
+          child: Container(
+            clipBehavior: Clip.antiAlias,
+            decoration: sheetShape,
+            child: SheetContentScaffold(
+              body: body,
+              bottomBar: bottomBar,
+            ),
           ),
         ),
       ),

--- a/cookbook/lib/tutorial/declarative_modal_sheet.dart
+++ b/cookbook/lib/tutorial/declarative_modal_sheet.dart
@@ -24,7 +24,11 @@ final _router = GoRouter(
             // It works with any *Sheet provided by this package!
             return ModalSheetPage(
               key: state.pageKey,
-              child: const _ExampleSheet(),
+              // Wrap your sheet with a SheetDismissible to make it
+              // dismissible by dragging it down.
+              child: const SheetDismissible(
+                child: _ExampleSheet(),
+              ),
             );
           },
         ),

--- a/cookbook/lib/tutorial/imperative_modal_sheet.dart
+++ b/cookbook/lib/tutorial/imperative_modal_sheet.dart
@@ -47,18 +47,52 @@ class _ExampleSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DraggableSheet(
-      child: Card(
-        color: Theme.of(context).colorScheme.secondaryContainer,
-        margin: EdgeInsets.zero,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: const SizedBox(
-          height: 500,
-          width: double.infinity,
+    // Wrap your sheet with a SheetDismissible to make it
+    // dismissible by dragging it down.
+    return SheetDismissible(
+      // This callback is called when the user tries to dismiss the sheet
+      // by dragging it down. Return true to dismiss the sheet immediately,
+      // or false otherwise. This is useful when, for example, you want to
+      // show a confirmation dialog before dismissing the sheet.
+      onDismiss: () {
+        showConfirmDialog(context);
+        return false;
+      },
+      child: DraggableSheet(
+        child: Card(
+          color: Theme.of(context).colorScheme.secondaryContainer,
+          margin: EdgeInsets.zero,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: const SizedBox(
+            height: 500,
+            width: double.infinity,
+          ),
         ),
       ),
+    );
+  }
+
+  void showConfirmDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Are you sure?'),
+          actions: [
+            TextButton(
+              onPressed: () =>
+                  Navigator.popUntil(context, (route) => route.isFirst),
+              child: const Text('Yes'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('No'),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/package/lib/src/modal/cupertino.dart
+++ b/package/lib/src/modal/cupertino.dart
@@ -470,9 +470,6 @@ class _PageBasedCupertinoModalSheetRoute<T>
   bool get barrierDismissible => _page.barrierDismissible;
 
   @override
-  bool get enablePullToDismiss => _page.enablePullToDismiss;
-
-  @override
   Curve get transitionCurve => _page.transitionCurve;
 
   @override
@@ -490,7 +487,6 @@ class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
     super.settings,
     super.fullscreenDialog,
     required this.builder,
-    this.enablePullToDismiss = true,
     this.maintainState = true,
     this.barrierDismissible = true,
     this.barrierLabel,
@@ -509,9 +505,6 @@ class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
 
   @override
   final String? barrierLabel;
-
-  @override
-  final bool enablePullToDismiss;
 
   @override
   final bool maintainState;

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -146,6 +146,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   @override
   bool get opaque => false;
 
+  @protected
   late final SheetController sheetController;
 
   /// Re-exposed [ModalRoute.controller] for use in [SheetDismissible].

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
@@ -20,7 +19,6 @@ class ModalSheetPage<T> extends Page<T> {
     super.arguments,
     super.restorationId,
     this.maintainState = true,
-    this.enablePullToDismiss = true,
     this.barrierDismissible = true,
     this.fullscreenDialog = false,
     this.barrierLabel,
@@ -43,8 +41,6 @@ class ModalSheetPage<T> extends Page<T> {
   final bool barrierDismissible;
 
   final String? barrierLabel;
-
-  final bool enablePullToDismiss;
 
   final Duration transitionDuration;
 
@@ -81,9 +77,6 @@ class _PageBasedModalSheetRoute<T> extends PageRoute<T>
   bool get barrierDismissible => _page.barrierDismissible;
 
   @override
-  bool get enablePullToDismiss => _page.enablePullToDismiss;
-
-  @override
   Curve get transitionCurve => _page.transitionCurve;
 
   @override
@@ -101,7 +94,6 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
     super.settings,
     super.fullscreenDialog,
     required this.builder,
-    this.enablePullToDismiss = true,
     this.maintainState = true,
     this.barrierDismissible = true,
     this.barrierLabel,
@@ -122,9 +114,6 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
   final String? barrierLabel;
 
   @override
-  final bool enablePullToDismiss;
-
-  @override
   final bool maintainState;
 
   @override
@@ -140,7 +129,6 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
 }
 
 mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
-  bool get enablePullToDismiss;
   Curve get transitionCurve;
 
   @override
@@ -172,17 +160,9 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     Animation<double> animation,
     Animation<double> secondaryAnimation,
   ) {
-    var content = buildContent(context);
-
-    if (enablePullToDismiss) {
-      content = SheetDismissible(
-        child: content,
-      );
-    }
-
     return SheetControllerScope(
       controller: sheetController,
-      child: content,
+      child: buildContent(context),
     );
   }
 

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -190,9 +190,11 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
 class SheetDismissible extends StatefulWidget {
   const SheetDismissible({
     super.key,
+    this.onDismiss,
     required this.child,
   });
 
+  final ValueGetter<bool>? onDismiss;
   final Widget child;
 
   @override
@@ -204,7 +206,6 @@ class _SheetDismissibleState extends State<SheetDismissible> {
   late ModalSheetRouteMixin<dynamic> _parentRoute;
   late final _PullToDismissGestureRecognizer _gestureRecognizer;
   ScrollMetrics? _lastReportedScrollMetrics;
-  AsyncValueGetter<bool>? _shouldDismissCallback;
 
   AnimationController get _transitionController =>
       _parentRoute._transitionController;
@@ -257,17 +258,18 @@ class _SheetDismissibleState extends State<SheetDismissible> {
 
   Future<void> handleDragEnd(DragEndDetails details) async {
     final velocity = details.velocity.pixelsPerSecond.dy / context.size!.height;
+    final shouldDismissCallback = widget.onDismiss ?? () => true;
 
     final bool willPop;
     if (velocity > 0) {
       // Flings down.
       willPop = velocity.abs() > _minFlingVelocityToDismiss &&
           !_transitionController.isAnimating &&
-          (_shouldDismissCallback == null || await _shouldDismissCallback!());
+          shouldDismissCallback();
     } else if (velocity.isApprox(0)) {
       willPop = _draggedDistance.abs() > _minDragDistanceToDismiss &&
           !_transitionController.isAnimating &&
-          (_shouldDismissCallback == null || await _shouldDismissCallback!());
+          shouldDismissCallback();
     } else {
       // Flings up.
       willPop = false;


### PR DESCRIPTION
Closes #18.

# New Feature
- Add `SheetDismissible`, which enables the enclosed sheet to be dismissed by a drag-down gesture. It accepts an `onDismiss` callback, which will be invoked when the user tries to dismiss the sheet by dragging it down, providing an opportunity to determine if the sheet should be dismissed.

# Changes
- Add tutorial code for `SheetDismissible`.
- Update the Safari and the AI playlist generator example to use `SheetDismissible` to show a confirmation dialog to discard changes.

# Breaking Changes
- Remove `ModalSheetRouteMixin.enablePullToDismiss`.