### PR TITLE
Documentation updates

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1 Feb 26, 2024
+
+Documentation updates.
+
 ## 0.3.0 Feb 24, 2024
 
 - Add iOS 15 style modal sheet transition (#21)

--- a/package/README.md
+++ b/package/README.md
@@ -10,13 +10,9 @@
 
 <br/>
 
-> [!CAUTION]
->
-> This library is currently in the experimental stage. The API may undergo changes without prior notice. 
+**CAUTION🚨**
 
-> [!NOTE]
-> 
-> For documentation of the latest published version, please visit the [package site](https://pub.dev/packages/smooth_sheets) on pub.dev.
+This library is currently in the experimental stage. The API may undergo changes without prior notice. For documentation of the latest published version, please visit the [package site](https://pub.dev/packages/smooth_sheets) on pub.dev.
 
 <br/>
 

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
-import 'package:smooth_sheets/src/foundation/single_child_sheet.dart';
+import 'package:smooth_sheets/src/foundation/sized_content_sheet.dart';
 
-class DraggableSheet extends SingleChildSheet {
+class DraggableSheet extends SizedContentSheet {
   const DraggableSheet({
     super.key,
     this.hitTestBehavior = HitTestBehavior.translucent,
@@ -18,12 +18,12 @@ class DraggableSheet extends SingleChildSheet {
   final HitTestBehavior hitTestBehavior;
 
   @override
-  SingleChildSheetState<SingleChildSheet> createState() {
+  SizedContentSheetState<SizedContentSheet> createState() {
     return _DraggableSheetState();
   }
 }
 
-class _DraggableSheetState extends SingleChildSheetState<DraggableSheet> {
+class _DraggableSheetState extends SizedContentSheetState<DraggableSheet> {
   @override
   SheetExtentFactory createExtentFactory() {
     return DraggableSheetExtentFactory(
@@ -43,7 +43,7 @@ class _DraggableSheetState extends SingleChildSheetState<DraggableSheet> {
   }
 }
 
-class DraggableSheetExtentFactory extends SingleChildSheetExtentFactory {
+class DraggableSheetExtentFactory extends SizedContentSheetExtentFactory {
   const DraggableSheetExtentFactory({
     required super.initialExtent,
     required super.minExtent,
@@ -63,7 +63,7 @@ class DraggableSheetExtentFactory extends SingleChildSheetExtentFactory {
   }
 }
 
-class DraggableSheetExtent extends SingleChildSheetExtent {
+class DraggableSheetExtent extends SizedContentSheetExtent {
   DraggableSheetExtent({
     required super.context,
     required super.physics,

--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -1,15 +1,36 @@
 import 'package:flutter/widgets.dart';
+import 'package:smooth_sheets/src/draggable/draggable_sheet.dart';
 import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/scrollable/scrollable_sheet.dart';
 
+/// A widget that makes its child as a drag-handle for a sheet.
+///
+/// Typically, this widget is used when placing non-scrollable widget(s)
+/// in a [ScrollableSheet], since it only works with scrollable widgets,
+/// so you can't drag the sheet by touching a non-scrollable area.
+///
+/// Note that [SheetDraggable] is not needed when using [DraggableSheet]
+/// since it implicitly wraps the child widget with [SheetDraggable].
+///
+/// See also:
+/// - [A tutorial](https://github.com/fujidaiti/smooth_sheets/blob/main/cookbook/lib/tutorial/sheet_draggable.dart),
+///   in which a [SheetDraggable] is used to create a drag-handle for
+///   a [ScrollableSheet].
 class SheetDraggable extends StatefulWidget {
+  /// Creates a drag-handle for a sheet.
+  ///
+  /// The [behavior] defaults to [HitTestBehavior.translucent].
   const SheetDraggable({
     super.key,
     this.behavior = HitTestBehavior.translucent,
     required this.child,
   });
 
+  /// How to behave during hit testing.
   final HitTestBehavior behavior;
+
+  /// The widget below this widget in the tree.
   final Widget child;
 
   @override

--- a/package/lib/src/foundation/sized_content_sheet.dart
+++ b/package/lib/src/foundation/sized_content_sheet.dart
@@ -5,8 +5,8 @@ import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
 
-abstract class SingleChildSheetExtent extends SheetExtent {
-  SingleChildSheetExtent({
+abstract class SizedContentSheetExtent extends SheetExtent {
+  SizedContentSheetExtent({
     required super.context,
     required super.physics,
     required super.minExtent,
@@ -17,8 +17,8 @@ abstract class SingleChildSheetExtent extends SheetExtent {
   final Extent initialExtent;
 }
 
-abstract class SingleChildSheetExtentFactory extends SheetExtentFactory {
-  const SingleChildSheetExtentFactory({
+abstract class SizedContentSheetExtentFactory extends SheetExtentFactory {
+  const SizedContentSheetExtentFactory({
     required this.initialExtent,
     required this.minExtent,
     required this.maxExtent,
@@ -32,8 +32,8 @@ abstract class SingleChildSheetExtentFactory extends SheetExtentFactory {
 }
 
 /// A base class for sheets that have a single content.
-abstract class SingleChildSheet extends StatefulWidget {
-  const SingleChildSheet({
+abstract class SizedContentSheet extends StatefulWidget {
+  const SizedContentSheet({
     super.key,
     this.keyboardDismissBehavior,
     this.initialExtent = const Extent.proportional(1),
@@ -55,10 +55,10 @@ abstract class SingleChildSheet extends StatefulWidget {
   final Widget child;
 
   @override
-  SingleChildSheetState createState();
+  SizedContentSheetState createState();
 }
 
-abstract class SingleChildSheetState<T extends SingleChildSheet>
+abstract class SizedContentSheetState<T extends SizedContentSheet>
     extends State<T> {
   late SheetExtentFactory _factory;
   SheetExtentFactory get factory => _factory;
@@ -103,7 +103,7 @@ abstract class SingleChildSheetState<T extends SingleChildSheet>
   /// Builds the content of the sheet.
   ///
   /// Consider overriding this method if you want to
-  /// insert widgets above the [SingleChildSheet.child].
+  /// insert widgets above the [SizedContentSheet.child].
   @protected
   Widget buildContent(BuildContext context) {
     return widget.child;

--- a/package/lib/src/navigation/navigation_routes.dart
+++ b/package/lib/src/navigation/navigation_routes.dart
@@ -3,7 +3,7 @@ import 'package:smooth_sheets/src/draggable/draggable_sheet.dart';
 import 'package:smooth_sheets/src/draggable/sheet_draggable.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
-import 'package:smooth_sheets/src/foundation/single_child_sheet.dart';
+import 'package:smooth_sheets/src/foundation/sized_content_sheet.dart';
 import 'package:smooth_sheets/src/navigation/navigation_route.dart';
 import 'package:smooth_sheets/src/navigation/navigation_sheet.dart';
 import 'package:smooth_sheets/src/scrollable/scrollable_sheet.dart';
@@ -39,7 +39,7 @@ abstract class SingleChildNavigationSheetRoute<T>
   final WidgetBuilder builder;
 
   @override
-  SingleChildSheetExtentFactory get pageExtentFactory;
+  SizedContentSheetExtentFactory get pageExtentFactory;
 
   @override
   Widget buildTransitions(
@@ -102,8 +102,8 @@ abstract class PageBasedSingleChildNavigationSheetRoute<T,
   Duration get transitionDuration => page.transitionDuration;
 
   @override
-  SingleChildSheetExtentFactory get pageExtentFactory => _pageExtentFactory!;
-  SingleChildSheetExtentFactory? _pageExtentFactory;
+  SizedContentSheetExtentFactory get pageExtentFactory => _pageExtentFactory!;
+  SizedContentSheetExtentFactory? _pageExtentFactory;
 
   @override
   void changedInternalState() {
@@ -113,7 +113,7 @@ abstract class PageBasedSingleChildNavigationSheetRoute<T,
     }
   }
 
-  SingleChildSheetExtentFactory createPageExtentFactory();
+  SizedContentSheetExtentFactory createPageExtentFactory();
 
   bool shouldUpdatePageExtentFactory() {
     return page.initialExtent != _pageExtentFactory?.initialExtent ||
@@ -223,7 +223,7 @@ class _PageBasedScrollableNavigationSheetRoute<T>
   _PageBasedScrollableNavigationSheetRoute({required super.page});
 
   @override
-  SingleChildSheetExtentFactory createPageExtentFactory() {
+  SizedContentSheetExtentFactory createPageExtentFactory() {
     return ScrollableSheetExtentFactory(
       initialExtent: page.initialExtent,
       minExtent: page.minExtent,
@@ -269,7 +269,7 @@ class _PageBasedDraggableNavigationSheetRoute<T>
   _PageBasedDraggableNavigationSheetRoute({required super.page});
 
   @override
-  SingleChildSheetExtentFactory createPageExtentFactory() {
+  SizedContentSheetExtentFactory createPageExtentFactory() {
     return DraggableSheetExtentFactory(
       initialExtent: page.initialExtent,
       minExtent: page.minExtent,

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
-import 'package:smooth_sheets/src/foundation/single_child_sheet.dart';
+import 'package:smooth_sheets/src/foundation/sized_content_sheet.dart';
 import 'package:smooth_sheets/src/internal/into.dart';
 import 'package:smooth_sheets/src/scrollable/content_scroll_position.dart';
 import 'package:smooth_sheets/src/scrollable/scrollable_sheet_extent.dart';
 
-class ScrollableSheet extends SingleChildSheet {
+class ScrollableSheet extends SizedContentSheet {
   const ScrollableSheet({
     super.key,
     super.keyboardDismissBehavior,
@@ -19,12 +19,12 @@ class ScrollableSheet extends SingleChildSheet {
   });
 
   @override
-  SingleChildSheetState<SingleChildSheet> createState() {
+  SizedContentSheetState<SizedContentSheet> createState() {
     return _ScrollableSheetState();
   }
 }
 
-class _ScrollableSheetState extends SingleChildSheetState<ScrollableSheet> {
+class _ScrollableSheetState extends SizedContentSheetState<ScrollableSheet> {
   @override
   SheetExtentFactory createExtentFactory() {
     return ScrollableSheetExtentFactory(

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -4,13 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
-import 'package:smooth_sheets/src/foundation/single_child_sheet.dart';
+import 'package:smooth_sheets/src/foundation/sized_content_sheet.dart';
 import 'package:smooth_sheets/src/internal/double_utils.dart';
 import 'package:smooth_sheets/src/internal/into.dart';
 import 'package:smooth_sheets/src/scrollable/content_scroll_position.dart';
 import 'package:smooth_sheets/src/scrollable/scrollable_sheet_physics.dart';
 
-class ScrollableSheetExtentFactory extends SingleChildSheetExtentFactory {
+class ScrollableSheetExtentFactory extends SizedContentSheetExtentFactory {
   const ScrollableSheetExtentFactory({
     required super.initialExtent,
     required super.minExtent,
@@ -30,7 +30,7 @@ class ScrollableSheetExtentFactory extends SingleChildSheetExtentFactory {
   }
 }
 
-class ScrollableSheetExtent extends SingleChildSheetExtent {
+class ScrollableSheetExtent extends SizedContentSheetExtent {
   ScrollableSheetExtent({
     required super.initialExtent,
     required super.minExtent,

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/fujidaiti/smooth_sheets
 
 environment:


### PR DESCRIPTION
## Changes made

- Add doc comments to `sheet_extent.dart`.
- Avoid using GitHub alert syntax. (Fixes #23)
- Rename `SingleChildSheet*` to `SizedContentSheet*`.