### PR TITLE
Reland "Fix publish workflow"

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,9 @@ jobs:
         uses: ./.github/actions/setup_flutter
         with:
           target: package
+      
+      - name: Setup OIDC token
+        uses: dart-lang/setup-dart@v1
 
       - name: Publish to pub.dev
         run: flutter pub publish --force


### PR DESCRIPTION
Fixes #47. Based on the [documentation](https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pub-dev), it appears that using `dart-lang/setup-dart@v1` is necessary in the publishing workflow to resolve the authentication issue.

> The workflow authenticates to pub.dev using a temporary [GitHub-signed OIDC token](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), the token is created and configured in the dart-lang/setup-dart step. To publish to pub.dev, subsequent steps can run dart pub publish --force.