### PR TITLE
Use pana directly instead of dart-package-analyzer

### DIFF
--- a/.github/workflows/dry_publish.yaml
+++ b/.github/workflows/dry_publish.yaml
@@ -17,11 +17,14 @@ jobs:
         with:
           target: package
 
-      - uses: axel-op/dart-package-analyzer@master
+      - name: Install pana
+        run: dart pub global activate pana
+
+      - name: Run pana
         id: analysis
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          relativePath: package
+        run: |
+          JSON_OUTPUT=$(pana --json package)
+          echo "::set-output name=json_output::$JSON_OUTPUT"
 
       - uses: fujidaiti/dart-package-inspector@v1
         with:


### PR DESCRIPTION
A workaround for #59. 

Attempted to add `$GITHUB_WORKSPACE` to `safe.directory` of Git in #58, but it didn't work. For now, I disabled the `dart-package-analyzer` and changed to directly run the `pana` instead.

I'll try again in the feature.