### PR TITLE
Make bottom bar visibility more customizable

### DIFF
--- a/cookbook/lib/showcase/ai_playlist_generator.dart
+++ b/cookbook/lib/showcase/ai_playlist_generator.dart
@@ -627,27 +627,29 @@ class _BottomActionBar extends StatelessWidget {
     // Insert bottom padding only if there's no system viewport bottom inset.
     final systemBottomInset = MediaQuery.of(context).padding.bottom;
 
-    return ColoredBox(
-      color: Theme.of(context).colorScheme.surface,
-      child: SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (showDivider) const Divider(height: 1),
-            Padding(
-              padding: EdgeInsets.fromLTRB(
-                horizontalPadding,
-                verticalPadding,
-                horizontalPadding,
-                systemBottomInset == 0 ? verticalPadding : 0,
+    return StickyBottomBarVisibility(
+      child: ColoredBox(
+        color: Theme.of(context).colorScheme.surface,
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (showDivider) const Divider(height: 1),
+              Padding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  verticalPadding,
+                  horizontalPadding,
+                  systemBottomInset == 0 ? verticalPadding : 0,
+                ),
+                child: FilledButton(
+                  onPressed: onPressed,
+                  style: _largeFilledButtonStyle,
+                  child: Text(label),
+                ),
               ),
-              child: FilledButton(
-                onPressed: onPressed,
-                style: _largeFilledButtonStyle,
-                child: Text(label),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/cookbook/lib/showcase/todo_list/todo_editor.dart
+++ b/cookbook/lib/showcase/todo_list/todo_editor.dart
@@ -115,13 +115,15 @@ class _TodoEditorState extends State<TodoEditor> {
       ),
     );
 
-    final bottomBar = BottomAppBar(
-      child: Row(
-        children: [
-          _FolderSelector(controller),
-          const Spacer(),
-          _SubmitButton(controller),
-        ],
+    final bottomBar = StickyBottomBarVisibility(
+      child: BottomAppBar(
+        child: Row(
+          children: [
+            _FolderSelector(controller),
+            const Spacer(),
+            _SubmitButton(controller),
+          ],
+        ),
       ),
     );
 
@@ -144,6 +146,10 @@ class _TodoEditorState extends State<TodoEditor> {
             clipBehavior: Clip.antiAlias,
             decoration: sheetShape,
             child: SheetContentScaffold(
+              resizeBehavior: const ResizeScaffoldBehavior.avoidBottomInset(
+                // Make the bottom bar visible when the keyboard is open.
+                maintainBottomBar: true,
+              ),
               body: body,
               bottomBar: bottomBar,
             ),

--- a/cookbook/lib/tutorial/keyboard_dismiss_behavior.dart
+++ b/cookbook/lib/tutorial/keyboard_dismiss_behavior.dart
@@ -137,9 +137,11 @@ class _ExampleHomeState extends State<_ExampleHome> {
     Navigator.push(
       context,
       ModalSheetRoute(
-        builder: (context) => _ExampleSheet(
-          isFullScreen: isFullScreen,
-          keyboardDismissBehavior: keyboardDismissBehavior,
+        builder: (context) => SheetDismissible(
+          child: _ExampleSheet(
+            isFullScreen: isFullScreen,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+          ),
         ),
       ),
     );
@@ -177,19 +179,21 @@ class _ExampleSheet extends StatelessWidget {
         child: SheetContentScaffold(
           appBar: AppBar(),
           body: body,
-          bottomBar: BottomAppBar(
-            child: Row(
-              children: [
-                IconButton(
-                  onPressed: () {},
-                  icon: const Icon(Icons.menu),
-                ),
-                const Spacer(),
-                IconButton(
-                  onPressed: () {},
-                  icon: const Icon(Icons.more_vert),
-                ),
-              ],
+          bottomBar: StickyBottomBarVisibility(
+            child: BottomAppBar(
+              child: Row(
+                children: [
+                  IconButton(
+                    onPressed: () {},
+                    icon: const Icon(Icons.menu),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    onPressed: () {},
+                    icon: const Icon(Icons.more_vert),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -12,6 +12,7 @@ class _SheetContentScaffoldExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       home: Scaffold(
+        resizeToAvoidBottomInset: false,
         body: Stack(
           children: [
             Placeholder(),
@@ -37,7 +38,18 @@ class _ExampleSheet extends StatelessWidget {
       // 500px + (app bar height) + (bottom bar height).
       body: Container(height: 500),
       appBar: buildAppBar(context),
-      bottomBar: buildBottomBar(),
+      // BottomBarVisibility widgets can be used to control the visibility
+      // of the bottom bar based on the sheet's position.
+      // For example, the following configuration keeps the bottom bar visible
+      // as long as the keyboard is closed and at least 50% of the sheet is visible.
+      bottomBar: ConditionalStickyBottomBarVisibility(
+        getIsVisible: (metrics) =>
+            metrics.viewportDimensions.insets.bottom == 0 &&
+            metrics.pixels >
+                const Extent.proportional(0.5)
+                    .resolve(metrics.contentDimensions),
+        child: buildBottomBar(),
+      ),
     );
 
     final physics = StretchingSheetPhysics(

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -33,9 +33,6 @@ class _ExampleSheet extends StatelessWidget {
     // However, it differs in that its height reduces to fit the 'body' widget.
     final content = SheetContentScaffold(
       backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-      // The bottom bar sticks to the bottom unless the sheet extent becomes
-      // smaller than this threshold extent.
-      requiredMinExtentForStickyBottomBar: const Extent.proportional(0.5),
       // With the following configuration, the sheet height will be
       // 500px + (app bar height) + (bottom bar height).
       body: Container(height: 500),

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -43,11 +43,13 @@ class _ExampleSheet extends StatelessWidget {
       // For example, the following configuration keeps the bottom bar visible
       // as long as the keyboard is closed and at least 50% of the sheet is visible.
       bottomBar: ConditionalStickyBottomBarVisibility(
-        getIsVisible: (metrics) =>
-            metrics.viewportDimensions.insets.bottom == 0 &&
-            metrics.pixels >
-                const Extent.proportional(0.5)
-                    .resolve(metrics.contentDimensions),
+        // This callback is called whenever the sheet's metrics changes.
+        getIsVisible: (metrics) {
+          return metrics.viewportDimensions.insets.bottom == 0 &&
+              metrics.pixels >
+                  const Extent.proportional(0.5)
+                      .resolve(metrics.contentDimensions);
+        },
         child: buildBottomBar(),
       ),
     );

--- a/docs/migration-guide-0.3.x.md
+++ b/docs/migration-guide-0.3.x.md
@@ -4,7 +4,8 @@
 
 The `enablePullToDismiss` property, that enables the pull-to-dismiss action for the modal sheets, was removed from the constructors of `ModalSheetRoute`, `ModalSheetPage`, `CupertinoModalSheetRoute,` and `CupertinoModalSheetPage`. Instead, wrap the sheet with a `SheetDismissible` to create the same behavior. See the [tutorial code](https://github.com/fujidaiti/smooth_sheets/blob/90c8f10b89db5b18c1fd382692cfba3a09be67f1/cookbook/lib/tutorial/imperative_modal_sheet.dart#L52) for more detailed usage.
 
-BEFORE:
+**BEFORE:**
+
 ```dart
 ModalSheetRoute(
   enablePullToDismiss: true,
@@ -12,7 +13,8 @@ ModalSheetRoute(
 );
 ```
 
-AFTER:
+**AFTER:**
+
 ```dart
 ModalSheetRoute(
   (context) => SheetDismissible(
@@ -26,7 +28,7 @@ ModalSheetRoute(
 
 `SnapToNearest` can no longer be a `const` in exchange for performance improvement. Due to this, `SnapToNearestEdge` is now used as the default value for `SnappingSheetPhysics.snappingBehavior` instead. If you want the sheet to snap only to the `minPixels` and the `maxPixels`, it is preferable to use `SnapToNearestEdge` rather than `SnapToNearest` as it is more simplified and performant.
 
-BEFORE:
+**BEFORE:**
 
 ```dart
 physics: const StretchingSheetPhysics(
@@ -42,7 +44,7 @@ physics: const StretchingSheetPhysics(
 ),
 ```
 
-AFTER:
+**AFTER:**
 
 ```dart
 physics: StretchingSheetPhysics( // Can no longer be a const

--- a/docs/migration-guide-0.4.x.md
+++ b/docs/migration-guide-0.4.x.md
@@ -1,0 +1,34 @@
+# Migration guide to 0.4.x from 0.3.x
+
+## requiredMinExtentForStickyBottomBar removed from SheetContentScaffold
+
+As of introducing of `BottomBarVisibility` widgets, the `requiredMinExtentForStickyBottomBar` property was removed from the `SheetContentScaffold`. Use one of subclasses of the `BottomBarVisibility` such as `StickyBottomBarVisibility` and `ConditionalStickyBottomBarVisibility`. See [the API documentation](https://pub.dev/documentation/smooth_sheets/latest/smooth_sheets/BottomBarVisibility-class.html) for more details.
+
+**BEFORE:**
+
+```dart
+SheetContentScaffold(
+  requiredMinExtentForStickyBottomBar: const Extent.proportional(0.5),
+  body: SizedBox.expand(),
+  bottomBar: BottomBar(),
+);
+```
+
+**AFTER:**
+
+```dart
+SheetContentScaffold(
+  body: SizedBox.expand(),
+  // This widget keeps the child BottomBar always visible
+  // regardless of the sheet position as long as the `getIsVisible`
+  // callback returns true.
+  bottomBar: ConditionalStickyBottomBarVisibility(
+    getIsVisible: (metrics) {
+      final halfSize = Extent.proportional(0.5).resolve(metrics.contentDimensions);
+      return metrics.pixels > halfSize;
+    },
+    child: BottomBar(),
+  ),
+);
+```
+

--- a/docs/migration-guide-0.4.x.md
+++ b/docs/migration-guide-0.4.x.md
@@ -31,4 +31,3 @@ SheetContentScaffold(
   ),
 );
 ```
-

--- a/docs/migration-guide-0.4.x.md
+++ b/docs/migration-guide-0.4.x.md
@@ -31,3 +31,28 @@ SheetContentScaffold(
   ),
 );
 ```
+
+## resizeToAvoidBottomInset removed from SheetContentScaffold
+
+The `resizeBehavior` property has been added to the `SheetContentScaffold` to replace the `resizeToAvoidBottomInset` property which is less flexible. See [the API documentation](https://pub.dev/documentation/smooth_sheets/latest/smooth_sheets/ResizeScaffoldBehavior-class.html) for more details.
+
+**BEFORE:**
+
+```dart
+SheetContentScaffold(
+  resizeToAvoidBottomInset: true,
+  body: SizedBox.expand(),
+);
+```
+
+**AFTER:**
+
+```dart
+SheetContentScaffold(
+  resizeBehavior: const ResizeScaffoldBehavior.avoidBottomInset(
+    // Make the bottom bar visible even when the keyboard is open.
+    maintainBottomBar: true,
+  ),
+  body: SizedBox.expand(),
+);
+```

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0 Mar 17, 2024
+## 0.4.0 Mar 20, 2024
 
 - Add `BottomBarVisibility` widgets (#15, #19)
 

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0 Mar 17, 2024
+
+- Add `BottomBarVisibility` widgets (#15, #19)
+
 ## 0.3.4 Mar 9, 2024
 
 - Fix crash when clicking on the modal barrier while dragging the sheet (#54)

--- a/package/README.md
+++ b/package/README.md
@@ -82,6 +82,7 @@ See [here](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/) for older
         <li>SheetContentScaffold</li>
         <li>SheetKeyboardDismissBehavior</li>
         <li>SheetDismissible</li>
+        <li>StickyBottomBarVisibility</li>
       </ul>
     </td>
   </tr>
@@ -255,13 +256,15 @@ See also:
 </div>
 
 
-A special kind of [Scaffold](https://api.flutter.dev/flutter/material/Scaffold-class.html) designed for use in a sheet. It has slots for an app bar and a sticky bottom bar, similar to Scaffold. However, it differs in that its height reduces to fit the content widget.
+A special kind of [Scaffold](https://api.flutter.dev/flutter/material/Scaffold-class.html) designed for use in a sheet. It has slots for an app bar and a bottom bar, similar to Scaffold. However, it differs in that its height reduces to fit the content widget.
 
 
 
 See also:
 
-- [sheet_content_scaffold.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/cookbook/lib/tutorial/sheet_content_scaffold.dart) for basic usage.
+- [tutorial/sheet_content_scaffold.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/cookbook/lib/tutorial/sheet_content_scaffold.dart), which shows the basic usage of this widget.
+- [SheetContentScaffold](https://pub.dev/documentation/smooth_sheets/latest/smooth_sheets/SheetContentScaffold-class.html), the API documentation.
+- [BottomBarVisibility](https://pub.dev/documentation/smooth_sheets/latest/smooth_sheets/BottomBarVisibility-class.html), which can be used to control the visibility of the bottom bar based on the sheet position.
 
 <br/>
 

--- a/package/README.md
+++ b/package/README.md
@@ -21,7 +21,9 @@ This library is currently in the experimental stage. The API may undergo changes
 
 ## Migration guide
 
-- [0.2.x to 0.3.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.3.x.md) 🆕
+- [0.3.x to 0.4.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.4.x.md) 🆕
+
+- [0.2.x to 0.3.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.3.x.md)
 
 See [here](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/) for older versions.
 
@@ -87,6 +89,7 @@ See [here](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/) for older
     </td>
   </tr>
 </table>
+
 
 
 

--- a/package/analysis_options.yaml
+++ b/package/analysis_options.yaml
@@ -10,3 +10,4 @@ linter:
     prefer_int_literals: false
     flutter_style_todos: false
     cascade_invocations: false
+    join_return_with_assignment: false

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -2,9 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:smooth_sheets/src/draggable/sheet_draggable.dart';
-import 'package:smooth_sheets/src/foundation/framework.dart';
-import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
 
 class SheetContentScaffold extends StatelessWidget {
   const SheetContentScaffold({
@@ -38,13 +36,6 @@ class SheetContentScaffold extends StatelessWidget {
     final appBar = this.appBar != null && appbarDraggable
         ? _AppBarDraggable(appBar: this.appBar!)
         : this.appBar;
-
-    var bottomBar = this.bottomBar;
-    if (this.bottomBar != null) {
-      bottomBar = _BottomBarContainer(
-        child: this.bottomBar,
-      );
-    }
 
     final mediaQueryData = MediaQuery.of(context);
     final viewPadding = mediaQueryData.viewPadding;
@@ -113,62 +104,441 @@ class _AppBarDraggable extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-class _BottomBarContainer extends SingleChildRenderObjectWidget {
-  const _BottomBarContainer({
-    required super.child,
-  });
-
-  @override
-  RenderObject createRenderObject(BuildContext context) {
-    return _RenderBottomBarContainer(
-      extent: SheetExtentScope.of(context),
-    );
-  }
-
-  @override
-  void updateRenderObject(
-    BuildContext context,
-    _RenderBottomBarContainer renderObject,
-  ) {
-    super.updateRenderObject(context, renderObject);
-    renderObject.extent = SheetExtentScope.of(context);
-  }
+/// The base class of widgets that manage the visibility of the [child]
+/// based on the enclosing sheet's position.
+///
+/// Intended to be used as the [SheetContentScaffold.bottomBar].
+/// For example, the [StickyBottomBarVisibility] can be used to keep
+/// the [child] always visible regardless of the sheet position
+/// including when the onscreen keyboard is open.
+///
+/// {@macro StickyBottomBarVisibility:example}
+///
+/// See also:
+///  - [FixedBottomBarVisibility], which places the [child] at the bottom
+///    of the sheet.
+///  - [StickyBottomBarVisibility], which keeps the [child] always visible
+///    regardless of the sheet position.
+/// - [ConditionalStickyBottomBarVisibility], which changes the visibility
+///   of the [child] based on a condition.
+/// - [AnimatedBottomBarVisibility], which animates the visibility
+///   of the [child].
+// ignore: avoid_implementing_value_types
+abstract class BottomBarVisibility implements Widget {
+  /// The widget to manage the visibility of.
+  Widget? get child;
 }
 
-class _RenderBottomBarContainer extends RenderTransform {
-  _RenderBottomBarContainer({
+abstract class _RenderBottomBarVisibility extends RenderTransform {
+  _RenderBottomBarVisibility({
     required SheetExtent extent,
   })  : _extent = extent,
         super(transform: Matrix4.zero(), transformHitTests: true) {
-    _extent.addListener(_invalidateOffset);
+    _extent.addListener(invalidateVisibility);
   }
 
   SheetExtent _extent;
   // ignore: avoid_setters_without_getters
   set extent(SheetExtent value) {
     if (_extent != value) {
-      _extent.removeListener(_invalidateOffset);
-      _extent = value..addListener(_invalidateOffset);
-      markNeedsPaint();
+      _extent.removeListener(invalidateVisibility);
+      _extent = value..addListener(invalidateVisibility);
+      invalidateVisibility();
     }
+  }
+
+  @override
+  void dispose() {
+    _extent.removeListener(invalidateVisibility);
+    super.dispose();
   }
 
   // Cache the last measured size because we can't access
   // 'size' property from outside of the layout phase.
-  late Size _lastMeasuredSize;
+  Size? _bottomBarSize;
 
   @override
   void performLayout() {
     super.performLayout();
-    _lastMeasuredSize = size;
+    _bottomBarSize = size;
+    invalidateVisibility();
   }
 
-  void _invalidateOffset() {
-    if (_extent.hasPixels) {
+  void invalidateVisibility() {
+    final size = _bottomBarSize;
+    if (size != null && _extent.hasPixels) {
       final metrics = _extent.metrics;
-      final translation = max(metrics.pixels, _lastMeasuredSize.height) -
-          metrics.viewportDimensions.height;
-      transform = Matrix4.translationValues(0, min(0.0, translation), 0);
+      final baseTransition =
+          (metrics.pixels - metrics.viewportDimensions.height)
+              .clamp(size.height - metrics.viewportDimensions.height, 0.0);
+      final visibility = computeVisibility(metrics, size);
+      assert(0 <= visibility && visibility <= 1);
+      final invisibleHeight = size.height * (1 - visibility);
+      final transition = baseTransition + invisibleHeight;
+      transform = Matrix4.translationValues(0, transition, 0);
     }
+  }
+
+  double computeVisibility(SheetMetrics sheetMetrics, Size bottomBarSize);
+}
+
+/// A widget that places the [child] at the bottom of the enclosing sheet.
+///
+/// Intended to be used as the [SheetContentScaffold.bottomBar].
+///
+/// The following example shows the [FixedBottomBarVisibility],
+/// which keeps the enclosed [BottomAppBar] always at the bottom
+/// of the sheet, including when the onscreen keyboard is open.
+///
+/// ```dart
+/// final scaffold = SheetContentScaffold(
+///   body: SizedBox.expand(),
+///   bottomBar: FixedBottomBarVisibility(
+///     showOnKeyboard: true,
+///     child: BottomAppBar(),
+///   ),
+/// );
+/// ```
+class FixedBottomBarVisibility extends SingleChildRenderObjectWidget
+    implements BottomBarVisibility {
+  /// Creates a widget that places the [child] always at the bottom
+  /// of the sheet.
+  ///
+  /// Set [showOnKeyboard] to true to keep the bottom bar visible when
+  /// the onscreen keyboard is open.
+  const FixedBottomBarVisibility({
+    super.key,
+    this.showOnKeyboard = false,
+    required super.child,
+  });
+
+  /// Whether the [child] should be shown when the onscreen keyboard is open.
+  final bool showOnKeyboard;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderFixedBottomBarVisibility(
+      extent: SheetExtentScope.of(context),
+      showOnKeyboard: showOnKeyboard,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    super.updateRenderObject(context, renderObject);
+    (renderObject as _RenderFixedBottomBarVisibility)
+      ..extent = SheetExtentScope.of(context)
+      ..showOnKeyboard = showOnKeyboard;
+  }
+}
+
+class _RenderFixedBottomBarVisibility extends _RenderBottomBarVisibility {
+  _RenderFixedBottomBarVisibility({
+    required super.extent,
+    required bool showOnKeyboard,
+  }) : _showOnKeyboard = showOnKeyboard;
+
+  bool _showOnKeyboard;
+  // ignore: avoid_setters_without_getters
+  set showOnKeyboard(bool value) {
+    if (_showOnKeyboard != value) {
+      _showOnKeyboard = value;
+      invalidateVisibility();
+    }
+  }
+
+  @override
+  double computeVisibility(SheetMetrics sheetMetrics, Size bottomBarSize) {
+    final invisibleSheetHeight =
+        (sheetMetrics.contentDimensions.height - sheetMetrics.pixels)
+            .clamp(0.0, sheetMetrics.contentDimensions.height);
+
+    final visibleBarHeight =
+        max(0.0, bottomBarSize.height - invisibleSheetHeight);
+    final visibility = visibleBarHeight / bottomBarSize.height;
+
+    if (_showOnKeyboard) {
+      return visibility;
+    }
+
+    final bottomInset = sheetMetrics.viewportDimensions.insets.bottom;
+    return (visibility - bottomInset / bottomBarSize.height).clamp(0.0, 1.0);
+  }
+}
+
+/// A widget that keeps the [child] always visible regardless of
+/// the sheet position.
+///
+/// Intended to be used as the [SheetContentScaffold.bottomBar].
+///
+/// The following example shows the [StickyBottomBarVisibility],
+/// which keeps the enclosed [BottomAppBar] always visible including
+/// when the onscreen keyboard is open.
+///
+/// {@template StickyBottomBarVisibility:example}
+/// ```dart
+/// final scaffold = SheetContentScaffold(
+///   body: SizedBox.expand(),
+///   bottomBar: StickyBottomBarVisibility(
+///     showOnKeyboard: true,
+///     child: BottomAppBar(),
+///   ),
+/// );
+/// ```
+/// {@endtemplate}
+class StickyBottomBarVisibility extends SingleChildRenderObjectWidget
+    implements BottomBarVisibility {
+  /// Creates a widget that keeps the [child] always visible
+  /// regardless of the sheet position.
+  ///
+  /// Set [showOnKeyboard] to true to keep the bottom bar visible when
+  /// the onscreen keyboard is open.
+  const StickyBottomBarVisibility({
+    super.key,
+    this.showOnKeyboard = false,
+    required super.child,
+  });
+
+  /// Whether the [child] should be shown when the onscreen keyboard is open.
+  final bool showOnKeyboard;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderStickyBottomBarVisibility(
+      extent: SheetExtentScope.of(context),
+      showOnKeyboard: showOnKeyboard,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    super.updateRenderObject(context, renderObject);
+    (renderObject as _RenderStickyBottomBarVisibility)
+      ..extent = SheetExtentScope.of(context)
+      ..showOnKeyboard = showOnKeyboard;
+  }
+}
+
+class _RenderStickyBottomBarVisibility extends _RenderBottomBarVisibility {
+  _RenderStickyBottomBarVisibility({
+    required super.extent,
+    required bool showOnKeyboard,
+  }) : _showOnKeyboard = showOnKeyboard;
+
+  bool _showOnKeyboard;
+  // ignore: avoid_setters_without_getters
+  set showOnKeyboard(bool value) {
+    if (_showOnKeyboard != value) {
+      _showOnKeyboard = value;
+      invalidateVisibility();
+    }
+  }
+
+  @override
+  double computeVisibility(SheetMetrics sheetMetrics, Size bottomBarSize) {
+    if (_showOnKeyboard) {
+      return 1.0;
+    }
+
+    final bottomInset = sheetMetrics.viewportDimensions.insets.bottom;
+    return (1 - bottomInset / bottomBarSize.height).clamp(0.0, 1.0);
+  }
+}
+
+/// A widget that animates the visibility of the [child].
+///
+/// Intended to be used as the [SheetContentScaffold.bottomBar].
+class AnimatedBottomBarVisibility extends SingleChildRenderObjectWidget
+    implements BottomBarVisibility {
+  /// Creates a widget that animates the visibility of the [child].
+  ///
+  /// The [visibility] animation must be between 0 and 1, where 0 means
+  /// the [child] is completely invisible and 1 means it's completely visible.
+  const AnimatedBottomBarVisibility({
+    super.key,
+    required this.visibility,
+    required super.child,
+  });
+
+  /// The animation driving the visibility of the [child].
+  final Animation<double> visibility;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderAnimatedBottomBarVisibility(
+      extent: SheetExtentScope.of(context),
+      visibility: visibility,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    super.updateRenderObject(context, renderObject);
+    (renderObject as _RenderAnimatedBottomBarVisibility)
+      ..extent = SheetExtentScope.of(context)
+      ..visibility = visibility;
+  }
+}
+
+class _RenderAnimatedBottomBarVisibility extends _RenderBottomBarVisibility {
+  _RenderAnimatedBottomBarVisibility({
+    required super.extent,
+    required Animation<double> visibility,
+  }) : _visibility = visibility {
+    _visibility.addListener(invalidateVisibility);
+  }
+
+  Animation<double> _visibility;
+  // ignore: avoid_setters_without_getters
+  set visibility(Animation<double> value) {
+    if (_visibility != value) {
+      _visibility.removeListener(invalidateVisibility);
+      _visibility = value..addListener(markNeedsLayout);
+    }
+  }
+
+  @override
+  void dispose() {
+    _visibility.removeListener(invalidateVisibility);
+    super.dispose();
+  }
+
+  @override
+  double computeVisibility(SheetMetrics sheetMetrics, Size bottomBarSize) {
+    return _visibility.value;
+  }
+}
+
+/// A widget that animates the visibility of the [child] based on a condition.
+///
+/// Intended to be used as the [SheetContentScaffold.bottomBar].
+///
+/// The [getIsVisible] callback is called whenever the sheet metrics changes.
+/// Returning true keeps the [child] visible regardless of the sheet position,
+/// and false hides it with an animation which has the [duration] and
+/// the [curve].
+///
+/// The following example shows the [ConditionalStickyBottomBarVisibility],
+/// which keeps the enclosed [BottomAppBar] visible as long as the onscreen
+/// is hidden (`insets.bottom == 0`) and at least 50% of the sheet is visible.
+///
+/// ```dart
+/// final scaffold = SheetContentScaffold(
+///   body: SizedBox.expand(),
+///   bottomBar: ConditionalStickyBottomBarVisibility(
+///     getIsVisible: (metrics) =>
+///         metrics.viewportDimensions.insets.bottom == 0 &&
+///         metrics.pixels >
+///             const Extent.proportional(0.5)
+///                 .resolve(metrics.contentDimensions),
+///     child: BottomAppBar(),
+///   ),
+/// );
+/// ```
+class ConditionalStickyBottomBarVisibility extends StatefulWidget
+    implements BottomBarVisibility {
+  /// Creates a widget that animates the visibility of the [child]
+  /// based on a condition.
+  const ConditionalStickyBottomBarVisibility({
+    super.key,
+    required this.getIsVisible,
+    this.duration = const Duration(milliseconds: 150),
+    this.curve = Curves.easeInOut,
+    required this.child,
+  });
+
+  /// Whether the [child] should be visible.
+  ///
+  /// Called whenever the sheet metrics changes.
+  /// Returning true keeps the [child] visible regardless of the sheet position,
+  /// and false hides it with an animation which has the [duration] and
+  /// the [curve].
+  final bool Function(SheetMetrics) getIsVisible;
+
+  /// The duration of the visibility animation.
+  final Duration duration;
+
+  /// The curve of the visibility animation.
+  final Curve curve;
+
+  @override
+  final Widget? child;
+
+  @override
+  State<ConditionalStickyBottomBarVisibility> createState() =>
+      _ConditionalStickyBottomBarVisibilityState();
+}
+
+class _ConditionalStickyBottomBarVisibilityState
+    extends State<ConditionalStickyBottomBarVisibility>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late Animation<double> _curveAnimation;
+  SheetExtent? _extent;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      value: 0.0,
+      duration: widget.duration,
+    );
+
+    _curveAnimation = _createCurvedAnimation();
+  }
+
+  @override
+  void dispose() {
+    _extent!.removeListener(_didSheetMetricsChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final extent = SheetExtentScope.of(context);
+    if (_extent != extent) {
+      _extent?.removeListener(_didSheetMetricsChanged);
+      _extent = extent..addListener(_didSheetMetricsChanged);
+      _didSheetMetricsChanged();
+    }
+  }
+
+  @override
+  void didUpdateWidget(ConditionalStickyBottomBarVisibility oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.duration = widget.duration;
+    if (widget.curve != oldWidget.curve) {
+      _curveAnimation = _createCurvedAnimation();
+    }
+  }
+
+  Animation<double> _createCurvedAnimation() {
+    return _controller.drive(CurveTween(curve: widget.curve));
+  }
+
+  void _didSheetMetricsChanged() {
+    final isVisible =
+        _extent!.hasPixels && widget.getIsVisible(_extent!.metrics);
+
+    if (isVisible) {
+      if (_controller.status != AnimationStatus.forward) {
+        _controller.forward();
+      }
+    } else {
+      if (_controller.status != AnimationStatus.reverse) {
+        _controller.reverse();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBottomBarVisibility(
+      visibility: _curveAnimation,
+      child: widget.child,
+    );
   }
 }

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -234,7 +234,7 @@ abstract class SheetExtent with ChangeNotifier, MaybeSheetMetrics {
             _markAsDimensionsWillChangeCallCount > 0
                 ? 'markAsDimensionsWillChange() was called more times'
                     'than markAsDimensionsChanged() in a frame.'
-                : 'markAsDimensionsChanged() was called more times'
+                : 'markAsDimensionsChanged() was called more times '
                     'than markAsDimensionsWillChange() in a frame.',
           );
         });

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.3.4
+version: 0.4.0
 repository: https://github.com/fujidaiti/smooth_sheets
 
 environment:


### PR DESCRIPTION
This PR closes #15 and closes #19.

**New Features**

- Added the `BottomBarVisibility` widgets, which can be used to flexibly control the visibility of the scaffold's bottom bar based on the sheet position.
- Added the `ResizeScaffoldBehavior`, which is a more flexible version of the `SheetContentScaffold.resizeToAvoidBottomInset` property.

**Breaking Changes**

- Removed the `requiredMinExtentForStickyBottomBar` property from the scaffold with the introduction of `BottomBarVisibility`.
- Removed the `resizeToAvoidBottomInset` property from the scaffold and added the `resizeBehavior` property as a replacement.

**Misc**

- Bumped the package version to 0.4.0.
- Added the migration guide from 0.3.x to 0.4.x.
- Mention the `BottomBarVisibility` widgets in the README.
