### PR TITLE
Fix mistakes in documentation

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1 Mar 20, 2024
+
+- Fix mistakes in the documentation of `BottomBarVisibility` and `ConditionalStickyBottomBarVisibility` which may mislead readers.
+
 ## 0.4.0 Mar 20, 2024
 
 - Add `BottomBarVisibility` widgets (#15, #19)

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -194,8 +194,10 @@ class _ScaffoldBodyContainer extends StatelessWidget {
 ///
 /// Intended to be used as the [SheetContentScaffold.bottomBar].
 /// For example, the [StickyBottomBarVisibility] can be used to keep
-/// the [child] always visible regardless of the sheet position
-/// including when the onscreen keyboard is open.
+/// the [child] always visible regardless of the sheet position. You may want
+/// to use the [ResizeScaffoldBehavior.avoidBottomInset] with setting
+/// `maintainBottomBar` to true to keep the bottom bar visible even when
+/// the onscreen keyboard is open.
 ///
 /// {@macro StickyBottomBarVisibility:example}
 ///
@@ -352,8 +354,11 @@ class _RenderFixedBottomBarVisibility extends _RenderBottomBarVisibility {
 /// Intended to be used as the [SheetContentScaffold.bottomBar].
 ///
 /// The following example shows the [StickyBottomBarVisibility],
-/// which keeps the enclosed [BottomAppBar] always visible including
-/// when the onscreen keyboard is open.
+/// which keeps the enclosed [BottomAppBar] always visible regardless
+/// of the sheet position. You may want to use the
+/// [ResizeScaffoldBehavior.avoidBottomInset] with setting `maintainBottomBar`
+/// to true to keep the bottom bar visible even when the onscreen keyboard
+/// is open.
 ///
 /// {@template StickyBottomBarVisibility:example}
 /// ```dart
@@ -496,7 +501,7 @@ class _RenderAnimatedBottomBarVisibility extends _RenderBottomBarVisibility {
 /// the [curve].
 ///
 /// The following example shows the [ConditionalStickyBottomBarVisibility],
-/// which keeps the enclosed [BottomAppBar] visible as long as the onscreen
+/// which keeps the enclosed [BottomAppBar] visible as long as the keyboard
 /// is hidden (`insets.bottom == 0`) and at least 50% of the sheet is visible.
 ///
 /// ```dart

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/fujidaiti/smooth_sheets
 
 environment:


### PR DESCRIPTION
Fix mistakes in the documentation of `BottomBarVisibility` and `ConditionalStickyBottomBarVisibility` which may mislead readers.