### PR TITLE
Add a way to specify default physics and default ancestor physics

### DIFF
--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -24,6 +24,24 @@ abstract class SheetPhysics {
     return _spring ?? const ScrollPhysics().spring;
   }
 
+  /// Create a copy of this object appending the [ancestor] to
+  /// the physics chain, much like [ScrollPhysics.applyTo].
+  ///
+  /// Can be used to dynamically create an inheritance relationship
+  /// between [SheetPhysics] objects. For example, [SheetPhysics] `x`
+  /// and `y` in the following code will have the same behavior.
+  /// ```dart
+  /// final x = FooSheetPhysics().applyTo(BarSheetPhysics());
+  /// final y = FooSheetPhysics(parent: BarSheetPhysics());
+  /// ```
+  SheetPhysics applyTo(SheetPhysics ancestor) {
+    return copyWith(parent: parent?.applyTo(ancestor) ?? ancestor);
+  }
+
+  /// Create a copy of this object with the given fields replaced
+  /// by the new values.
+  SheetPhysics copyWith({SheetPhysics? parent, SpringDescription? spring});
+
   double computeOverflow(double offset, SheetMetrics metrics) {
     if (parent case final parent?) {
       return parent.computeOverflow(offset, metrics);
@@ -313,6 +331,19 @@ class SnappingSheetPhysics extends SheetPhysics {
   final SnappingSheetBehavior snappingBehavior;
 
   @override
+  SheetPhysics copyWith({
+    SheetPhysics? parent,
+    SpringDescription? spring,
+    SnappingSheetBehavior? snappingBehavior,
+  }) {
+    return SnappingSheetPhysics(
+      parent: parent ?? this.parent,
+      spring: spring ?? this.spring,
+      snappingBehavior: snappingBehavior ?? this.snappingBehavior,
+    );
+  }
+
+  @override
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics) {
     final snapPixels = snappingBehavior.findSnapPixels(velocity, metrics);
     if (snapPixels != null && !metrics.pixels.isApprox(snapPixels)) {
@@ -338,6 +369,11 @@ class ClampingSheetPhysics extends SheetPhysics {
   const ClampingSheetPhysics({
     super.parent,
   });
+
+  @override
+  SheetPhysics copyWith({SheetPhysics? parent, SpringDescription? spring}) {
+    return ClampingSheetPhysics(parent: parent ?? this.parent);
+  }
 }
 
 class StretchingSheetPhysics extends SheetPhysics {
@@ -349,6 +385,20 @@ class StretchingSheetPhysics extends SheetPhysics {
 
   final Extent stretchingRange;
   final Curve frictionCurve;
+
+  @override
+  SheetPhysics copyWith({
+    SheetPhysics? parent,
+    SpringDescription? spring,
+    Extent? stretchingRange,
+    Curve? frictionCurve,
+  }) {
+    return StretchingSheetPhysics(
+      parent: parent ?? this.parent,
+      stretchingRange: stretchingRange ?? this.stretchingRange,
+      frictionCurve: frictionCurve ?? this.frictionCurve,
+    );
+  }
 
   @override
   double computeOverflow(double offset, SheetMetrics metrics) {

--- a/package/lib/src/foundation/theme.dart
+++ b/package/lib/src/foundation/theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
+
 import 'keyboard_dismissible.dart';
+import 'physics.dart';
 
 /// A theme for descendant sheets.
 ///
@@ -48,19 +50,35 @@ class SheetThemeData {
   /// behavior of a sheet.
   const SheetThemeData({
     this.keyboardDismissBehavior,
+    this.physics,
+    this.basePhysics,
   });
 
   /// Determines when the on-screen keyboard should be dismissed.
   final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
 
+  /// The physics that are used by the sheet.
+  final SheetPhysics? physics;
+
+  /// The parent of the [SheetPhysics] that are used by the sheet.
+  ///
+  /// If the sheet's physics has no explicit parent, then this physics
+  /// is used as the default parent. Note that this value does not affect
+  /// the parent of the [SheetThemeData.physics].
+  final SheetPhysics? basePhysics;
+
   /// Creates a copy of this object but with the given fields replaced with
   /// the new values.
   SheetThemeData copyWith({
     SheetKeyboardDismissBehavior? keyboardDismissBehavior,
+    SheetPhysics? physics,
+    SheetPhysics? basePhysics,
   }) =>
       SheetThemeData(
         keyboardDismissBehavior:
             keyboardDismissBehavior ?? this.keyboardDismissBehavior,
+        physics: physics ?? this.physics,
+        basePhysics: basePhysics ?? this.basePhysics,
       );
 
   @override
@@ -68,11 +86,15 @@ class SheetThemeData {
       identical(this, other) ||
       other is SheetThemeData &&
           runtimeType == other.runtimeType &&
-          keyboardDismissBehavior == other.keyboardDismissBehavior;
+          keyboardDismissBehavior == other.keyboardDismissBehavior &&
+          physics == other.physics &&
+          basePhysics == other.basePhysics;
 
   @override
   int get hashCode => Object.hash(
         runtimeType,
         keyboardDismissBehavior,
+        physics,
+        basePhysics,
       );
 }

--- a/package/lib/src/foundation/theme.dart
+++ b/package/lib/src/foundation/theme.dart
@@ -57,14 +57,13 @@ class SheetThemeData {
   /// Determines when the on-screen keyboard should be dismissed.
   final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
 
-  /// The physics that are used by the sheet.
+  /// The physics that is used by the sheet.
   final SheetPhysics? physics;
 
-  /// The parent of the [SheetPhysics] that are used by the sheet.
+  /// The most distant ancestor of the physics that is used by the sheet.
   ///
-  /// If the sheet's physics has no explicit parent, then this physics
-  /// is used as the default parent. Note that this value does not affect
-  /// the parent of the [SheetThemeData.physics].
+  /// Note that this value is ignored if the sheet uses [SheetThemeData.physics]
+  /// as its physics.
   final SheetPhysics? basePhysics;
 
   /// Creates a copy of this object but with the given fields replaced with

--- a/package/lib/src/navigation/navigation_routes.dart
+++ b/package/lib/src/navigation/navigation_routes.dart
@@ -175,6 +175,7 @@ class _PageBasedScrollableNavigationSheetRoute<T>
   Duration get transitionDuration => page.transitionDuration;
 
   @override
+  // TODO: Prefer to directly create a config object than storing it in a field.
   ScrollableSheetExtentConfig get pageExtentConfig => _pageExtentConfig!;
   ScrollableSheetExtentConfig? _pageExtentConfig;
 
@@ -267,6 +268,7 @@ class _PageBasedDraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
   Duration get transitionDuration => page.transitionDuration;
 
   @override
+  // TODO: Prefer to directly create a config object than storing it in a field.
   DraggableSheetExtentConfig get pageExtentConfig => _pageExtentConfig!;
   DraggableSheetExtentConfig? _pageExtentConfig;
 

--- a/package/lib/src/navigation/navigation_routes.dart
+++ b/package/lib/src/navigation/navigation_routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../draggable/draggable_sheet.dart';
 import '../draggable/sheet_draggable.dart';
 import '../foundation/physics.dart';
@@ -17,7 +18,7 @@ class ScrollableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics = const StretchingSheetPhysics(parent: SnappingSheetPhysics()),
+    this.physics,
     this.transitionsBuilder,
     required this.builder,
   }) : pageExtentConfig = ScrollableSheetExtentConfig(
@@ -33,7 +34,7 @@ class ScrollableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
   final Extent initialExtent;
   final Extent minExtent;
   final Extent maxExtent;
-  final SheetPhysics physics;
+  final SheetPhysics? physics;
 
   @override
   final bool maintainState;
@@ -73,7 +74,7 @@ class DraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics = const StretchingSheetPhysics(parent: SnappingSheetPhysics()),
+    this.physics,
     this.transitionsBuilder,
     required this.builder,
   }) : pageExtentConfig = DraggableSheetExtentConfig(
@@ -86,7 +87,7 @@ class DraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
   final Extent initialExtent;
   final Extent minExtent;
   final Extent maxExtent;
-  final SheetPhysics physics;
+  final SheetPhysics? physics;
 
   @override
   final bool maintainState;
@@ -131,7 +132,7 @@ class ScrollableNavigationSheetPage<T> extends Page<T> {
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics = const StretchingSheetPhysics(parent: SnappingSheetPhysics()),
+    this.physics,
     this.transitionsBuilder,
     required this.child,
   });
@@ -145,7 +146,7 @@ class ScrollableNavigationSheetPage<T> extends Page<T> {
   final Extent minExtent;
   final Extent maxExtent;
 
-  final SheetPhysics physics;
+  final SheetPhysics? physics;
 
   final RouteTransitionsBuilder? transitionsBuilder;
 
@@ -223,7 +224,7 @@ class DraggableNavigationSheetPage<T> extends Page<T> {
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics = const StretchingSheetPhysics(parent: SnappingSheetPhysics()),
+    this.physics,
     this.transitionsBuilder,
     required this.child,
   });
@@ -237,7 +238,7 @@ class DraggableNavigationSheetPage<T> extends Page<T> {
   final Extent minExtent;
   final Extent maxExtent;
 
-  final SheetPhysics physics;
+  final SheetPhysics? physics;
 
   final RouteTransitionsBuilder? transitionsBuilder;
 

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
+
 import '../foundation/framework.dart';
 import '../foundation/keyboard_dismissible.dart';
 import '../foundation/physics.dart';
@@ -16,9 +17,7 @@ class ScrollableSheet extends StatelessWidget {
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics = const StretchingSheetPhysics(
-      parent: SnappingSheetPhysics(),
-    ),
+    this.physics,
     this.controller,
     required this.child,
   });
@@ -36,7 +35,7 @@ class ScrollableSheet extends StatelessWidget {
   final Extent maxExtent;
 
   /// {@macro SheetExtent.physics}
-  final SheetPhysics physics;
+  final SheetPhysics? physics;
 
   /// An object that can be used to control and observe the sheet height.
   final SheetController? controller;

--- a/package/lib/src/scrollable/scrollable_sheet_physics.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_physics.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/physics.dart';
+
 import '../foundation/physics.dart';
 import '../foundation/sheet_extent.dart';
 
@@ -9,6 +11,20 @@ class ScrollableSheetPhysics extends SheetPhysics {
   }) : assert(maxScrollSpeedToInterrupt >= 0);
 
   final double maxScrollSpeedToInterrupt;
+
+  @override
+  SheetPhysics copyWith({
+    SheetPhysics? parent,
+    SpringDescription? spring,
+    double? maxScrollSpeedToInterrupt,
+  }) {
+    return ScrollableSheetPhysics(
+      parent: parent ?? this.parent,
+      spring: spring ?? this.spring,
+      maxScrollSpeedToInterrupt:
+          maxScrollSpeedToInterrupt ?? this.maxScrollSpeedToInterrupt,
+    );
+  }
 
   bool shouldInterruptBallisticScroll(double velocity, SheetMetrics metrics) {
     return velocity.abs() < maxScrollSpeedToInterrupt;

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: lines_longer_than_80_chars
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
@@ -36,6 +37,36 @@ final _positionAtMiddle = _referenceSheetMetrics.copyWith(
 );
 
 void main() {
+  group('$SheetPhysics subclasses', () {
+    test('can create dynamic inheritance relationships', () {
+      const clamp = ClampingSheetPhysics();
+      const stretch = StretchingSheetPhysics();
+      const snap = SnappingSheetPhysics();
+
+      List<Type> getChain(SheetPhysics physics) {
+        return switch (physics.parent) {
+          null => [physics.runtimeType],
+          final parent => [physics.runtimeType, ...getChain(parent)],
+        };
+      }
+
+      expect(
+        getChain(clamp.applyTo(stretch).applyTo(snap)).join(' -> '),
+        'ClampingSheetPhysics -> StretchingSheetPhysics -> SnappingSheetPhysics',
+      );
+
+      expect(
+        getChain(snap.applyTo(stretch).applyTo(clamp)).join(' -> '),
+        'SnappingSheetPhysics -> StretchingSheetPhysics -> ClampingSheetPhysics',
+      );
+
+      expect(
+        getChain(stretch.applyTo(clamp).applyTo(snap)).join(' -> '),
+        'StretchingSheetPhysics -> ClampingSheetPhysics -> SnappingSheetPhysics',
+      );
+    });
+  });
+
   group('Default configuration of $SheetPhysics', () {
     late SheetPhysics physicsUnderTest;
 

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -5,6 +5,11 @@ import 'package:smooth_sheets/src/foundation/sheet_status.dart';
 
 class _SheetPhysicsWithDefaultConfiguration extends SheetPhysics {
   const _SheetPhysicsWithDefaultConfiguration();
+
+  @override
+  SheetPhysics copyWith({SheetPhysics? parent, SpringDescription? spring}) {
+    return const _SheetPhysicsWithDefaultConfiguration();
+  }
 }
 
 const _referenceSheetMetrics = SheetMetricsSnapshot(


### PR DESCRIPTION
The following APIs are added in this PR to enable specifying the default physics and the default ancestor physics that is used by sheets.
- `SheetPhysics.applyTo`
- `SheetPhysics.copyWith`
- `SheetTheme.physics`
- `SheetTheme.basePhysics`
