### PR TITLE
React to drag gesture even when scrollable widget can still be scrolled down

### DIFF
--- a/package/lib/src/draggable/sheet_draggable.dart
+++ b/package/lib/src/draggable/sheet_draggable.dart
@@ -27,11 +27,15 @@ class SheetDraggable extends StatefulWidget {
   const SheetDraggable({
     super.key,
     this.behavior = HitTestBehavior.translucent,
+    this.alwaysDraggable = false,
     required this.child,
   });
 
   /// How to behave during hit testing.
   final HitTestBehavior behavior;
+
+  /// React to drag gesture even when scrollable widget can be scrolled down
+  final bool alwaysDraggable;
 
   /// The widget below this widget in the tree.
   final Widget child;

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -89,7 +89,7 @@ class _AppBarDraggable extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SheetDraggable(child: appBar);
+    return SheetDraggable(alwaysDraggable: true, child: appBar,);
   }
 }
 

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -3,11 +3,11 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:smooth_sheets/src/draggable/sheet_draggable.dart';
-import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
-import 'package:smooth_sheets/src/foundation/sheet_status.dart';
-import 'package:smooth_sheets/src/internal/double_utils.dart';
-import 'package:smooth_sheets/src/internal/monodrag.dart';
+import '../draggable/sheet_draggable.dart';
+import '../foundation/sheet_controller.dart';
+import '../foundation/sheet_status.dart';
+import '../internal/double_utils.dart';
+import '../internal/monodrag.dart';
 
 const _minFlingVelocityToDismiss = 1.0;
 const _minDragDistanceToDismiss = 100.0; // Logical pixels.


### PR DESCRIPTION
Been trying to resolve this issue: https://github.com/fujidaiti/smooth_sheets/issues/84

Ended up with working solution without major changes to the plugin. I took a similar approach from [Flutter Hero widget](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/heroes.dart#L300) to look for a `SheetDraggable` at a pointer position when user starts to scroll. And if it finds such `SheetDraggable` with a `alwaysDraggable` parameter set to `true`, it would ignore the scrollable content offset.