### PR TITLE
Reimplement core architecture

### DIFF
--- a/cookbook/lib/showcase/airbnb_mobile_app.dart
+++ b/cookbook/lib/showcase/airbnb_mobile_app.dart
@@ -80,8 +80,8 @@ class _MapButton extends StatelessWidget {
     final sheetController = DefaultSheetController.of(context);
 
     void onPressed() {
-      final metrics = sheetController.metrics;
-      if (metrics != null) {
+      final metrics = sheetController.value;
+      if (metrics.hasDimensions) {
         // Collapse the sheet to reveal the map behind.
         sheetController.animateTo(
           Extent.pixels(metrics.minPixels),

--- a/cookbook/lib/tutorial/bottom_bar_visibility.dart
+++ b/cookbook/lib/tutorial/bottom_bar_visibility.dart
@@ -167,7 +167,7 @@ class _ExampleSheet extends StatelessWidget {
                   // The bottom bar is visible when at least 50% of the sheet is visible.
                   return metrics.pixels >=
                       const Extent.proportional(0.5)
-                          .resolve(metrics.contentDimensions);
+                          .resolve(metrics.contentSize);
                 },
                 child: bottomBar,
               ),

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -47,8 +47,7 @@ class _ExampleSheet extends StatelessWidget {
         getIsVisible: (metrics) {
           return metrics.viewportDimensions.insets.bottom == 0 &&
               metrics.pixels >
-                  const Extent.proportional(0.5)
-                      .resolve(metrics.contentDimensions);
+                  const Extent.proportional(0.5).resolve(metrics.contentSize);
         },
         child: buildBottomBar(),
       ),

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -45,7 +45,7 @@ class _ExampleSheet extends StatelessWidget {
       bottomBar: ConditionalStickyBottomBarVisibility(
         // This callback is called whenever the sheet's metrics changes.
         getIsVisible: (metrics) {
-          return metrics.viewportDimensions.insets.bottom == 0 &&
+          return metrics.viewportInsets.bottom == 0 &&
               metrics.pixels >
                   const Extent.proportional(0.5).resolve(metrics.contentSize);
         },

--- a/cookbook/lib/tutorial/sheet_controller.dart
+++ b/cookbook/lib/tutorial/sheet_controller.dart
@@ -50,9 +50,9 @@ class _ExampleHomeState extends State<_ExampleHome> {
               // SheetController can be used to observe changes in the sheet extent.
               child: ValueListenableBuilder(
                 valueListenable: controller,
-                builder: (context, value, child) {
+                builder: (context, metrics, child) {
                   return Text(
-                    'Extent: ${value?.toStringAsFixed(1)}',
+                    'Extent: ${metrics.maybePixels?.toStringAsFixed(1)}',
                     style: Theme.of(context).textTheme.displaySmall,
                   );
                 },

--- a/docs/migration-guide-0.5.x.md
+++ b/docs/migration-guide-0.5.x.md
@@ -1,0 +1,96 @@
+# Migration guide to 0.5.x from 0.4.x
+
+The changes in v0.5.0 are summarized in the following list. The breaking changes are marked with :boom:.
+
+## Changes in SheetController
+
+- :boom: Now it implements `ValueListenable<SheetMetrics>` instead of `ValueListenable<double?>`.
+- Added `SheetStatus status`.
+- Added `createSheetExtent()`.
+
+## Changes in SheetNotification
+
+- Added `SheetStatus status`.
+
+## Changes in SheetMetrics
+
+- Added `double? maybePixels`.
+- Added `double? maybeMinPixels`.
+- Added `double? maybeMaxPixels`.
+- Added `Size? maybeContentSize`.
+- Added `Size? maybeViewportSize`.
+- Added `EdgeInsets? maybeViewportInsets`.
+- :boom: ​`pixels` is no longer nullable.
+
+- :boom: ​`minPixels` is no longer nullable.
+- :boom: ​`maxPixels` is no longer nullable.
+- :boom: ​`viewPixels` is no longer nullable.
+- :boom: ​`minViewPixels` is no longer nullable.
+- :boom: ​`maxViewPixels` is no longer nullable.
+- :boom: ​Changed `Size? contentDimensions` to `Size contentSize`.
+- Added `Size? viewportSize`.
+- Added `EdgeInsets? viewportInsets`.
+- :boom: ​Removed `ViewportDimensions viewportDimensions`.
+  - Use `viewportSize` and `viewportInsets` instead.
+- Added `double? maybeViewPixels`.
+- Added `double? maybeMinViewPixels`.
+- Added `double? maybeMaxViewPixels`.
+- :boom: ​Changed the signature of `copyWith()`.
+  - Renamed `contentDimensions` to `contentSize`.
+  - Removed `viewportDimensions`.
+  - Added `viewportSize` and `viewportInsets`.
+
+## Changes in SheetExtent
+
+- Now it implements `ValueListenable<SheetMetrics>`.
+- :boom: ​ `MaybeSheetMetrics` is no longer mixed in.
+
+- Added `SheetExtentConfig config`.
+- Added `SheetExtentDelegate delegate`.
+- Added `SheetMetrics metrics`.
+- Added `applyNewConfig()`.
+- Added `setPixels()`.
+- Added `correctPixels()`.
+- Added `SheetMetrics value`.
+- :boom: ​Removed `SheetMetricsSnapshot snapshot`
+- :boom: ​Removed `SheetPhysics physics`.
+  - Use `config.physics` instead.
+- :boom: ​Removed `Extent minExtent`.
+  - Use `config.minExtent` instead.
+- :boom: ​Removed `double? pixels`
+  - Use `metrics.pixels` instead.
+- :boom: ​Removed `double? minPixels`
+  - Use `metrics.minPixels` instead.
+- :boom: ​Removed `double? maxPixels`.
+  - Use `metrics.maxPixels` instead.
+- :boom: ​Renamed `applyNewContentDimensions()` to `applyNewContentSize()`.
+- :boom: ​Changed the signature of `applyNewDimensions()`.
+  - `void (ViewportDimensions)` → `void (Size, EdgeInsets)`
+
+### Added sub-components
+
+- `SheetExtentConfig`
+- `SheetExtentDelegate`
+
+### Removed sub-components
+
+- :boom: ​`MaybeSheetMetrics`
+  - Use `SheetMetrics.maybe*` instead to handle cases where values are null.
+- :boom: ​`ViewportDimensions`
+
+## Changes in SheetActivity
+
+- :boom: ​It is no longer a sub-class of `ChangeNotifier`.
+
+- :boom: ​Renamed `delegate` to `owner`.
+- :boom: ​Renamed `didChangeContentDimensions()` to `didChangeContentSize()`.
+
+- :boom: ​Removed `double? pixels`.
+- :boom: ​Removed `correctPixels()`.
+- :boom: ​Removed `setPixels()`.
+- :boom: ​Changed the signature of `didChangeViewportDimensions()`.
+  - `void (ViewportDimensions)` → `void (Size, EdgeInsets)`
+
+## Others
+
+- Added `kDefaultSheetPhysics`, which is the default `SheetPhysics` used by the sheet widgets.

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0 May 4, 2024
+
+This version contains some breaking changes. See the [migration guide](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.5.x.md) for more details.
+
+- Attach default controller to sheet if not explicitly specified (#102)
+- Reimplement core architecture (#106)
+
 ## 0.4.2 Apr 21, 2024
 
 - Add new SheetNotifications for drag events (#92)

--- a/package/README.md
+++ b/package/README.md
@@ -21,7 +21,9 @@ This library is currently in the experimental stage. The API may undergo changes
 
 ## Migration guide
 
-- [0.3.x to 0.4.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.4.x.md) 🆕
+- [0.4.x to 0.5.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.5.x.md) 🆕
+
+- [0.3.x to 0.4.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.4.x.md)
 
 - [0.2.x to 0.3.x](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.3.x.md)
 
@@ -313,7 +315,7 @@ A sheet dispatches a [SheetNotification](https://pub.dev/documentation/smooth_sh
 ```dart
 NotificationListener<SheetNotification>(
   onNotification: (notification) {
-    debugPrint('$notification');
+    debugPrint('${notification.metrics}');
     return false;
   },
   child: DraggableSheet(...),

--- a/package/lib/smooth_sheets.dart
+++ b/package/lib/smooth_sheets.dart
@@ -18,7 +18,6 @@ export 'src/foundation/sheet_extent.dart';
 export 'src/foundation/theme.dart';
 export 'src/modal/cupertino.dart';
 export 'src/modal/modal_sheet.dart';
-export 'src/navigation/navigation_route.dart';
 export 'src/navigation/navigation_routes.dart';
 export 'src/navigation/navigation_sheet.dart';
 export 'src/scrollable/scrollable_sheet.dart'

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -68,6 +68,7 @@ class DraggableSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
+    final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
     final keyboardDismissBehavior =
         this.keyboardDismissBehavior ?? theme?.keyboardDismissBehavior;
 
@@ -76,11 +77,13 @@ class DraggableSheet extends StatelessWidget {
       builder: (context, controller) {
         return SheetContainer(
           controller: controller,
+          delegate: const DraggableSheetExtentDelegate(),
           config: DraggableSheetExtentConfig(
             initialExtent: initialExtent,
             minExtent: minExtent,
             maxExtent: maxExtent,
             physics: physics,
+            debugLabel: 'DraggableSheet',
           ),
           child: SheetDraggable(
             behavior: hitTestBehavior,
@@ -101,99 +104,47 @@ class DraggableSheet extends StatelessWidget {
   }
 }
 
-/// A configuration of a [DraggableSheetExtent].
+class DraggableSheetExtentDelegate with SheetExtentDelegate {
+  const DraggableSheetExtentDelegate();
+
+  @override
+  SheetActivity createIdleActivity() {
+    return _IdleDraggableSheetActivity();
+  }
+}
+
 class DraggableSheetExtentConfig extends SheetExtentConfig {
   const DraggableSheetExtentConfig({
     required this.initialExtent,
-    required this.minExtent,
-    required this.maxExtent,
-    required this.physics,
-  });
-
-  /// {@macro DraggableSheetExtent.initialExtent}
-  final Extent initialExtent;
-
-  /// {@macro SheetExtent.minExtent}
-  final Extent minExtent;
-
-  /// {@macro SheetExtent.maxExtent}
-  final Extent maxExtent;
-
-  /// {@macro SheetExtent.physics}
-  final SheetPhysics? physics;
-
-  @override
-  bool shouldRebuild(BuildContext context, SheetExtent oldExtent) {
-    return oldExtent is! DraggableSheetExtent ||
-        oldExtent.minExtent != minExtent ||
-        oldExtent.maxExtent != maxExtent ||
-        oldExtent.initialExtent != initialExtent ||
-        oldExtent.physics != _resolvePhysics(context);
-  }
-
-  @override
-  SheetExtent build(BuildContext context, SheetContext sheetContext) {
-    return DraggableSheetExtent(
-      context: sheetContext,
-      initialExtent: initialExtent,
-      minExtent: minExtent,
-      maxExtent: maxExtent,
-      physics: _resolvePhysics(context),
-    );
-  }
-
-  SheetPhysics _resolvePhysics(BuildContext context) {
-    const fallback = StretchingSheetPhysics(parent: SnappingSheetPhysics());
-    final theme = SheetTheme.maybeOf(context);
-    final base = theme?.basePhysics;
-    if (physics case final physics?) {
-      return base != null ? physics.applyTo(base) : physics;
-    } else if (theme?.physics case final inherited?) {
-      // Do not apply the base physics to the inherited physics.
-      return inherited;
-    } else {
-      return base != null ? fallback.applyTo(base) : fallback;
-    }
-  }
-}
-
-/// [SheetExtent] for a [DraggableSheet].
-class DraggableSheetExtent extends SheetExtent {
-  DraggableSheetExtent({
-    required super.context,
-    required super.physics,
     required super.minExtent,
     required super.maxExtent,
-    required this.initialExtent,
-  }) {
-    goIdle();
-  }
+    required super.physics,
+    super.debugLabel,
+  });
 
-  /// {@template DraggableSheetExtent.initialExtent}
-  /// The initial extent of the sheet when it is first shown.
-  /// {@endtemplate}
   final Extent initialExtent;
 
   @override
-  void goIdle() {
-    beginActivity(_IdleDraggableSheetActivity(
-      initialExtent: initialExtent,
-    ));
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DraggableSheetExtentConfig &&
+        other.initialExtent == initialExtent &&
+        super == other;
   }
+
+  @override
+  int get hashCode => Object.hash(initialExtent, super.hashCode);
 }
 
 class _IdleDraggableSheetActivity extends IdleSheetActivity {
-  _IdleDraggableSheetActivity({
-    required this.initialExtent,
-  });
-
-  final Extent initialExtent;
+  _IdleDraggableSheetActivity();
 
   @override
   void didChangeContentDimensions(Size? oldDimensions) {
     super.didChangeContentDimensions(oldDimensions);
-    if (pixels == null) {
-      setPixels(initialExtent.resolve(delegate.contentDimensions!));
+    final config = delegate.config;
+    if (pixels == null && config is DraggableSheetExtentConfig) {
+      setPixels(config.initialExtent.resolve(delegate.contentDimensions!));
     }
   }
 }

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -42,16 +42,15 @@ class DraggableSheet extends StatelessWidget {
   /// The strategy to dismiss the on-screen keyboard when the sheet is dragged.
   final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
 
-  /// {@macro SizedContentSheetExtent.initialExtent}
   final Extent initialExtent;
 
-  /// {@macro SheetExtent.minExtent}
+  /// {@macro SheetExtentConfig.minExtent}
   final Extent minExtent;
 
-  /// {@macro SheetExtent.maxExtent}
+  /// {@macro SheetExtentConfig.maxExtent}
   final Extent maxExtent;
 
-  /// {@macro SheetExtent.physics}
+  /// {@macro SheetExtentConfig.physics}
   final SheetPhysics? physics;
 
   /// An object that can be used to control and observe the sheet height.
@@ -143,8 +142,9 @@ class _IdleDraggableSheetActivity extends IdleSheetActivity {
   void didChangeContentDimensions(Size? oldDimensions) {
     super.didChangeContentDimensions(oldDimensions);
     final config = delegate.config;
+    final metrics = delegate.metrics;
     if (pixels == null && config is DraggableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(delegate.contentDimensions!));
+      setPixels(config.initialExtent.resolve(metrics.contentDimensions));
     }
   }
 }

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -139,12 +139,12 @@ class _IdleDraggableSheetActivity extends IdleSheetActivity {
   _IdleDraggableSheetActivity();
 
   @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    super.didChangeContentDimensions(oldDimensions);
+  void didChangeContentSize(Size? oldDimensions) {
+    super.didChangeContentSize(oldDimensions);
     final config = delegate.config;
     final metrics = delegate.metrics;
     if (pixels == null && config is DraggableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(metrics.contentDimensions));
+      setPixels(config.initialExtent.resolve(metrics.contentSize));
     }
   }
 }

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -141,10 +141,10 @@ class _IdleDraggableSheetActivity extends IdleSheetActivity {
   @override
   void didChangeContentSize(Size? oldDimensions) {
     super.didChangeContentSize(oldDimensions);
-    final config = delegate.config;
-    final metrics = delegate.metrics;
-    if (pixels == null && config is DraggableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(metrics.contentSize));
+    final config = owner.config;
+    final metrics = owner.metrics;
+    if (metrics.maybePixels == null && config is DraggableSheetExtentConfig) {
+      owner.setPixels(config.initialExtent.resolve(metrics.contentSize));
     }
   }
 }

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -61,7 +61,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchUpdateNotification() {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetUpdateNotification(
           metrics: delegate.metrics,
@@ -71,7 +71,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragStartNotification(DragStartDetails details) {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetDragStartNotification(
           metrics: delegate.metrics,
@@ -82,7 +82,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragEndNotification(DragEndDetails details) {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetDragEndNotification(
           metrics: delegate.metrics,
@@ -93,7 +93,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragUpdateNotification({required double delta}) {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetDragUpdateNotification(
           metrics: delegate.metrics,
@@ -104,7 +104,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragCancelNotification() {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetDragCancelNotification(
           metrics: delegate.metrics,
@@ -114,7 +114,7 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchOverflowNotification(double overflow) {
-    if (delegate.metrics.hasPixels) {
+    if (delegate.metrics.hasDimensions) {
       dispatchNotification(
         SheetOverflowNotification(
           metrics: delegate.metrics,
@@ -161,7 +161,7 @@ abstract class SheetActivity extends ChangeNotifier {
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);
-    assert(delegate.metrics.hasPixels);
+    assert(delegate.metrics.hasDimensions);
 
     if (oldContentDimensions == null && oldViewportDimensions == null) {
       // The sheet was laid out, but not changed in size.
@@ -360,7 +360,7 @@ mixin UserControlledSheetActivityMixin on SheetActivity {
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);
-    assert(delegate.metrics.hasPixels);
+    assert(delegate.metrics.hasDimensions);
 
     final newInsets = delegate.metrics.viewportDimensions.insets;
     final oldInsets = oldViewportDimensions?.insets ?? newInsets;

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -282,7 +282,7 @@ class UserDragSheetActivity extends SheetActivity
     if (!mounted) return;
     final delta = -1 * details.primaryDelta!;
     final physicsAppliedDelta =
-        delegate.physics.applyPhysicsToOffset(delta, delegate.metrics);
+        delegate.config.physics.applyPhysicsToOffset(delta, delegate.metrics);
     if (physicsAppliedDelta != 0) {
       setPixels(pixels! + physicsAppliedDelta);
       dispatchDragUpdateNotification(delta: physicsAppliedDelta);

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -145,8 +145,7 @@ abstract class SheetActivity extends ChangeNotifier {
     }
   }
 
-  // TODO: Rename to 'didChangeContentSize'
-  void didChangeContentDimensions(Size? oldDimensions) {}
+  void didChangeContentSize(Size? oldSize) {}
 
   // TODO: Rename to 'didChangeViewportSize'
   void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {}
@@ -157,13 +156,13 @@ abstract class SheetActivity extends ChangeNotifier {
   ) {}
 
   void didFinalizeDimensions(
-    Size? oldContentDimensions,
+    Size? oldContentSize,
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);
     assert(delegate.metrics.hasDimensions);
 
-    if (oldContentDimensions == null && oldViewportDimensions == null) {
+    if (oldContentSize == null && oldViewportDimensions == null) {
       // The sheet was laid out, but not changed in size.
       return;
     }
@@ -356,7 +355,7 @@ mixin UserControlledSheetActivityMixin on SheetActivity {
 
   @override
   void didFinalizeDimensions(
-    Size? oldContentDimensions,
+    Size? oldContentSize,
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -147,8 +147,7 @@ abstract class SheetActivity extends ChangeNotifier {
 
   void didChangeContentSize(Size? oldSize) {}
 
-  // TODO: Rename to 'didChangeViewportSize'
-  void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {}
+  void didChangeViewportDimensions(Size? oldSize, EdgeInsets? oldInsets) {}
 
   void didChangeBoundaryConstraints(
     double? oldMinPixels,
@@ -157,20 +156,21 @@ abstract class SheetActivity extends ChangeNotifier {
 
   void didFinalizeDimensions(
     Size? oldContentSize,
-    ViewportDimensions? oldViewportDimensions,
+    Size? oldViewportSize,
+    EdgeInsets? oldViewportInsets,
   ) {
     assert(pixels != null);
     assert(delegate.metrics.hasDimensions);
 
-    if (oldContentSize == null && oldViewportDimensions == null) {
+    if (oldContentSize == null && oldViewportSize == null) {
       // The sheet was laid out, but not changed in size.
       return;
     }
 
     final oldPixels = pixels!;
     final metrics = delegate.metrics;
-    final newInsets = metrics.viewportDimensions.insets;
-    final oldInsets = oldViewportDimensions?.insets ?? newInsets;
+    final newInsets = metrics.viewportInsets;
+    final oldInsets = oldViewportInsets ?? newInsets;
     final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
 
     switch (deltaInsetBottom) {
@@ -356,13 +356,14 @@ mixin UserControlledSheetActivityMixin on SheetActivity {
   @override
   void didFinalizeDimensions(
     Size? oldContentSize,
-    ViewportDimensions? oldViewportDimensions,
+    Size? oldViewportSize,
+    EdgeInsets? oldViewportInsets,
   ) {
     assert(pixels != null);
     assert(delegate.metrics.hasDimensions);
 
-    final newInsets = delegate.metrics.viewportDimensions.insets;
-    final oldInsets = oldViewportDimensions?.insets ?? newInsets;
+    final newInsets = delegate.metrics.viewportInsets;
+    final oldInsets = oldViewportInsets ?? newInsets;
     final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
     // Appends the delta of the bottom inset (typically the keyboard height)
     // to keep the visual sheet position unchanged.

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -65,6 +65,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetUpdateNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
         ),
       );
     }
@@ -75,6 +76,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetDragStartNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
           dragDetails: details,
         ),
       );
@@ -86,6 +88,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetDragEndNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
           dragDetails: details,
         ),
       );
@@ -97,6 +100,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetDragUpdateNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
           delta: delta,
         ),
       );
@@ -108,6 +112,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetDragCancelNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
         ),
       );
     }
@@ -118,6 +123,7 @@ abstract class SheetActivity extends ChangeNotifier {
       dispatchNotification(
         SheetOverflowNotification(
           metrics: delegate.metrics,
+          status: delegate.status,
           overflow: overflow,
         ),
       );

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
+
 import 'notifications.dart';
 import 'sheet_extent.dart';
 import 'sheet_status.dart';
@@ -60,20 +61,20 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchUpdateNotification() {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetUpdateNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
         ),
       );
     }
   }
 
   void dispatchDragStartNotification(DragStartDetails details) {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetDragStartNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
           dragDetails: details,
         ),
       );
@@ -81,10 +82,10 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragEndNotification(DragEndDetails details) {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetDragEndNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
           dragDetails: details,
         ),
       );
@@ -92,10 +93,10 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragUpdateNotification({required double delta}) {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetDragUpdateNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
           delta: delta,
         ),
       );
@@ -103,20 +104,20 @@ abstract class SheetActivity extends ChangeNotifier {
   }
 
   void dispatchDragCancelNotification() {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetDragCancelNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
         ),
       );
     }
   }
 
   void dispatchOverflowNotification(double overflow) {
-    if (delegate.hasPixels) {
+    if (delegate.metrics.hasPixels) {
       dispatchNotification(
         SheetOverflowNotification(
-          metrics: delegate.snapshot,
+          metrics: delegate.metrics,
           overflow: overflow,
         ),
       );
@@ -144,16 +145,23 @@ abstract class SheetActivity extends ChangeNotifier {
     }
   }
 
+  // TODO: Rename to 'didChangeContentSize'
   void didChangeContentDimensions(Size? oldDimensions) {}
 
+  // TODO: Rename to 'didChangeViewportSize'
   void didChangeViewportDimensions(ViewportDimensions? oldDimensions) {}
+
+  void didChangeBoundaryConstraints(
+    double? oldMinPixels,
+    double? oldMaxPixels,
+  ) {}
 
   void didFinalizeDimensions(
     Size? oldContentDimensions,
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);
-    assert(delegate.hasPixels);
+    assert(delegate.metrics.hasPixels);
 
     if (oldContentDimensions == null && oldViewportDimensions == null) {
       // The sheet was laid out, but not changed in size.
@@ -352,9 +360,9 @@ mixin UserControlledSheetActivityMixin on SheetActivity {
     ViewportDimensions? oldViewportDimensions,
   ) {
     assert(pixels != null);
-    assert(delegate.hasPixels);
+    assert(delegate.metrics.hasPixels);
 
-    final newInsets = delegate.viewportDimensions!.insets;
+    final newInsets = delegate.metrics.viewportDimensions.insets;
     final oldInsets = oldViewportDimensions?.insets ?? newInsets;
     final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
     // Appends the delta of the bottom inset (typically the keyboard height)

--- a/package/lib/src/foundation/animations.dart
+++ b/package/lib/src/foundation/animations.dart
@@ -42,8 +42,8 @@ class ExtentDrivenAnimation extends Animation<double> {
 
   @override
   double get value {
-    final metrics = _controller.metrics;
-    if (metrics == null) {
+    final metrics = _controller.value;
+    if (!metrics.hasDimensions) {
       return initialValue;
     }
 

--- a/package/lib/src/foundation/animations.dart
+++ b/package/lib/src/foundation/animations.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/animation.dart';
+
 import 'sheet_controller.dart';
 import 'sheet_extent.dart';
 
@@ -47,9 +48,9 @@ class ExtentDrivenAnimation extends Animation<double> {
     }
 
     final startPixels =
-        startExtent?.resolve(metrics.contentDimensions) ?? metrics.minPixels;
+        startExtent?.resolve(metrics.contentSize) ?? metrics.minPixels;
     final endPixels =
-        endExtent?.resolve(metrics.contentDimensions) ?? metrics.maxPixels;
+        endExtent?.resolve(metrics.contentSize) ?? metrics.maxPixels;
     final distance = endPixels - startPixels;
 
     if (distance.isFinite && distance > 0) {

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -294,7 +294,7 @@ class _RenderSheetContentLayoutObserver extends RenderPositionedBox {
     _extent?.markAsDimensionsWillChange();
     super.performLayout();
     if (child != null && _isPrimary()) {
-      _extent?.applyNewContentDimensions(child!.size);
+      _extent?.applyNewContentSize(child!.size);
     }
     _extent?.markAsDimensionsChanged();
   }

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -128,7 +128,7 @@ class _RenderSheetViewport extends RenderTransform {
     );
 
     assert(
-      _extent.metrics.hasPixels,
+      _extent.metrics.hasDimensions,
       'The sheet extent and the dimensions values '
       'must be finalized during the layout phase.',
     );

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -95,11 +95,10 @@ class _RenderSheetViewport extends RenderTransform {
       _insets = value;
 
       if (_lastMeasuredSize != null) {
-        _extent.applyNewViewportDimensions(ViewportDimensions(
-          width: _lastMeasuredSize!.width,
-          height: _lastMeasuredSize!.height,
-          insets: value,
-        ));
+        _extent.applyNewViewportDimensions(
+          Size(_lastMeasuredSize!.width, _lastMeasuredSize!.height),
+          value,
+        );
 
         _invalidateTranslationValue();
       }
@@ -114,11 +113,11 @@ class _RenderSheetViewport extends RenderTransform {
     // Notify the SheetExtent about the viewport size changes
     // before performing the layout so that the descendant widgets
     // can use the viewport size during the layout phase.
-    _extent.applyNewViewportDimensions(ViewportDimensions(
-      width: _lastMeasuredSize!.width,
-      height: _lastMeasuredSize!.height,
-      insets: _insets,
-    ));
+    _extent.applyNewViewportDimensions(
+      Size(_lastMeasuredSize!.width, _lastMeasuredSize!.height),
+      _insets,
+    );
+
     super.performLayout();
 
     assert(

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -128,7 +128,7 @@ class _RenderSheetViewport extends RenderTransform {
     );
 
     assert(
-      _extent.hasPixels,
+      _extent.metrics.hasPixels,
       'The sheet extent and the dimensions values '
       'must be finalized during the layout phase.',
     );
@@ -144,7 +144,7 @@ class _RenderSheetViewport extends RenderTransform {
   }
 
   void _invalidateTranslationValue() {
-    final currentExtent = _extent.pixels;
+    final currentExtent = _extent.metrics.maybePixels;
     final viewportSize = _lastMeasuredSize;
     if (currentExtent != null && viewportSize != null) {
       final dy = viewportSize.height - _insets.bottom - currentExtent;

--- a/package/lib/src/foundation/framework.dart
+++ b/package/lib/src/foundation/framework.dart
@@ -5,18 +5,21 @@ import 'package:flutter/widgets.dart';
 import 'sheet_controller.dart';
 import 'sheet_extent.dart';
 
+// TODO: Move this class to a separate file.
 class SheetContainer extends StatelessWidget {
   const SheetContainer({
     super.key,
-    this.onExtentChanged,
+    this.initializer,
     required this.controller,
     required this.config,
     required this.child,
+    this.delegate = const SheetExtentDelegate(),
   });
 
   final SheetController controller;
-  final ValueChanged<SheetExtent?>? onExtentChanged;
   final SheetExtentConfig config;
+  final SheetExtentDelegate delegate;
+  final SheetExtentInitializer? initializer;
   final Widget child;
 
   @override
@@ -24,7 +27,8 @@ class SheetContainer extends StatelessWidget {
     return SheetExtentScope(
       config: config,
       controller: controller,
-      onExtentChanged: onExtentChanged,
+      initializer: initializer,
+      delegate: delegate,
       child: Builder(
         builder: (context) {
           return SheetViewport(

--- a/package/lib/src/foundation/notifications.dart
+++ b/package/lib/src/foundation/notifications.dart
@@ -38,7 +38,7 @@ sealed class SheetNotification extends Notification {
       ..add('minExtent: ${metrics.minPixels}')
       ..add('maxExtent: ${metrics.maxPixels}')
       ..add('viewportDimensions: ${metrics.viewportDimensions}')
-      ..add('contentDimensions: ${metrics.contentDimensions}');
+      ..add('contentSize: ${metrics.contentSize}');
   }
 }
 

--- a/package/lib/src/foundation/notifications.dart
+++ b/package/lib/src/foundation/notifications.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import 'physics.dart';
 import 'sheet_extent.dart';
+import 'sheet_status.dart';
 
 /// A [Notification] that is dispatched when the sheet extent changes.
 ///
@@ -25,10 +26,16 @@ import 'sheet_extent.dart';
 /// - [NotificationListener], which can be used to listen for notifications
 ///   in a subtree.
 sealed class SheetNotification extends Notification {
-  const SheetNotification({required this.metrics});
+  const SheetNotification({
+    required this.metrics,
+    required this.status,
+  });
 
   /// A snapshot of the sheet metrics at the time this notification was sent.
   final SheetMetrics metrics;
+
+  /// The status of the sheet at the time this notification was sent.
+  final SheetStatus status;
 
   @override
   void debugFillDescription(List<String> description) {
@@ -39,20 +46,25 @@ sealed class SheetNotification extends Notification {
       ..add('maxExtent: ${metrics.maxPixels}')
       ..add('viewportSize: ${metrics.viewportSize}')
       ..add('viewportInsets: ${metrics.viewportInsets}')
-      ..add('contentSize: ${metrics.contentSize}');
+      ..add('contentSize: ${metrics.contentSize}')
+      ..add('status: $status');
   }
 }
 
 /// A [SheetNotification] that is dispatched when the sheet extent
 /// is updated by other than user interaction such as animation.
 class SheetUpdateNotification extends SheetNotification {
-  const SheetUpdateNotification({required super.metrics});
+  const SheetUpdateNotification({
+    required super.metrics,
+    required super.status,
+  });
 }
 
 /// A [SheetNotification] that is dispatched when the sheet is dragged.
 class SheetDragUpdateNotification extends SheetNotification {
   const SheetDragUpdateNotification({
     required super.metrics,
+    required super.status,
     required this.delta,
   });
 
@@ -73,6 +85,7 @@ class SheetDragStartNotification extends SheetNotification {
   /// starts dragging the sheet.
   const SheetDragStartNotification({
     required super.metrics,
+    required super.status,
     required this.dragDetails,
   });
 
@@ -93,6 +106,7 @@ class SheetDragEndNotification extends SheetNotification {
   /// stops dragging the sheet.
   const SheetDragEndNotification({
     required super.metrics,
+    required super.status,
     required this.dragDetails,
   });
 
@@ -111,7 +125,10 @@ class SheetDragEndNotification extends SheetNotification {
 class SheetDragCancelNotification extends SheetNotification {
   /// Create a notification that is dispatched when the user
   /// cancels dragging the sheet.
-  const SheetDragCancelNotification({required super.metrics});
+  const SheetDragCancelNotification({
+    required super.metrics,
+    required super.status,
+  });
 }
 
 /// A [SheetNotification] that is dispatched when the user tries
@@ -120,6 +137,7 @@ class SheetDragCancelNotification extends SheetNotification {
 class SheetOverflowNotification extends SheetNotification {
   const SheetOverflowNotification({
     required super.metrics,
+    required super.status,
     required this.overflow,
   });
 

--- a/package/lib/src/foundation/notifications.dart
+++ b/package/lib/src/foundation/notifications.dart
@@ -37,7 +37,8 @@ sealed class SheetNotification extends Notification {
       ..add('pixels: ${metrics.pixels}')
       ..add('minExtent: ${metrics.minPixels}')
       ..add('maxExtent: ${metrics.maxPixels}')
-      ..add('viewportDimensions: ${metrics.viewportDimensions}')
+      ..add('viewportSize: ${metrics.viewportSize}')
+      ..add('viewportInsets: ${metrics.viewportInsets}')
       ..add('contentSize: ${metrics.contentSize}');
   }
 }

--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -266,13 +266,13 @@ class SnapToNearest with _SnapToNearestMixin {
   /// Always call [_ensureCacheIsValid] before accessing this list
   /// to ensure that the cache is up-to-date and sorted in ascending order.
   List<double> _snapTo = const [];
-  Size? _cachedContentDimensions;
+  Size? _cachedContentSize;
 
   void _ensureCacheIsValid(SheetMetrics metrics) {
-    if (_cachedContentDimensions != metrics.contentDimensions) {
-      _cachedContentDimensions = metrics.contentDimensions;
+    if (_cachedContentSize != metrics.contentSize) {
+      _cachedContentSize = metrics.contentSize;
       _snapTo = snapTo
-          .map((e) => e.resolve(metrics.contentDimensions))
+          .map((e) => e.resolve(metrics.contentSize))
           .toList(growable: false)
         ..sort();
 
@@ -397,8 +397,7 @@ class StretchingSheetPhysics extends SheetPhysics with SheetPhysicsMixin {
 
   @override
   double computeOverflow(double offset, SheetMetrics metrics) {
-    final stretchingRange =
-        this.stretchingRange.resolve(metrics.contentDimensions);
+    final stretchingRange = this.stretchingRange.resolve(metrics.contentSize);
 
     if (stretchingRange != 0) {
       return 0;
@@ -421,8 +420,7 @@ class StretchingSheetPhysics extends SheetPhysics with SheetPhysicsMixin {
       return offset;
     }
 
-    final stretchingRange =
-        this.stretchingRange.resolve(metrics.contentDimensions);
+    final stretchingRange = this.stretchingRange.resolve(metrics.contentSize);
 
     if (stretchingRange.isApprox(0)) {
       return 0;

--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -20,8 +20,12 @@ const kDefaultSheetSpring = SpringDescription(
   damping: 15.5563491861, // 1.1 * 2.0 * sqrt(0.5 * 100.0)
 );
 
-const _minSettlingDuration = Duration(milliseconds: 160);
-const _defaultSettlingSpeed = 600.0; // logical pixels per second
+const _kMinSettlingDuration = Duration(milliseconds: 160);
+const _kDefaultSettlingSpeed = 600.0; // logical pixels per second
+
+/// The default [SheetPhysics] used by sheet widgets.
+const kDefaultSheetPhysics =
+    StretchingSheetPhysics(parent: SnappingSheetPhysics());
 
 abstract class SheetPhysics {
   const SheetPhysics({this.parent});
@@ -128,8 +132,8 @@ mixin SheetPhysicsMixin on SheetPhysics {
       end: settleTo,
       curve: Curves.easeInOut,
       durationInSeconds: max(
-        (metrics.pixels - settleTo).abs() / _defaultSettlingSpeed,
-        _minSettlingDuration.inMicroseconds / Duration.microsecondsPerSecond,
+        (metrics.pixels - settleTo).abs() / _kDefaultSettlingSpeed,
+        _kMinSettlingDuration.inMicroseconds / Duration.microsecondsPerSecond,
       ),
     );
   }

--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -215,23 +215,23 @@ mixin _SnapToNearestMixin implements SnappingSheetBehavior {
   }
 }
 
-/// A [SnappingSheetBehavior] that snaps to either [SheetExtent.minPixels]
-/// or [SheetExtent.maxPixels] based on the current sheet position and
+/// A [SnappingSheetBehavior] that snaps to either [SheetMetrics.minPixels]
+/// or [SheetMetrics.maxPixels] based on the current sheet position and
 /// the gesture velocity.
 ///
 /// If the absolute value of the gesture velocity is less than
 /// [minFlingSpeed], the sheet will snap to the nearest of
-/// [SheetExtent.minPixels] and [SheetExtent.maxPixels].
+/// [SheetMetrics.minPixels] and [SheetMetrics.maxPixels].
 /// Otherwise, the gesture is considered to be a fling, and the sheet will snap
 /// towards the direction of the fling. For example, if the sheet is flung up,
-/// it will snap to [SheetExtent.maxPixels].
+/// it will snap to [SheetMetrics.maxPixels].
 ///
 /// Using this behavior is functionally identical to using [SnapToNearest]
 /// with the snap positions of [SheetExtent.minExtent] and
 /// [SheetExtent.maxExtent], but more simplified and efficient.
 class SnapToNearestEdge with _SnapToNearestMixin {
   /// Creates a [SnappingSheetBehavior] that snaps to either
-  /// [SheetExtent.minPixels] or [SheetExtent.maxPixels].
+  /// [SheetMetrics.minPixels] or [SheetMetrics.maxPixels].
   ///
   /// The [minFlingSpeed] defaults to [kMinFlingVelocity],
   /// and must be non-negative.
@@ -280,7 +280,7 @@ class SnapToNearest with _SnapToNearestMixin {
         _snapTo.first.isGreaterThanOrApprox(metrics.minPixels) &&
             _snapTo.last.isLessThanOrApprox(metrics.maxPixels),
         'The snap positions must be within the range of '
-        "'SheetExtent.minPixels' and 'SheetExtent.maxPixels'.",
+        "'SheetMetrics.minPixels' and 'SheetMetrics.maxPixels'.",
       );
     }
   }

--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -227,7 +227,7 @@ mixin _SnapToNearestMixin implements SnappingSheetBehavior {
 /// it will snap to [SheetMetrics.maxPixels].
 ///
 /// Using this behavior is functionally identical to using [SnapToNearest]
-/// with the snap positions of [SheetExtent.minExtent] and
+/// with the snap positions of [SheetExtentConfig.minExtent] and
 /// [SheetExtent.maxExtent], but more simplified and efficient.
 class SnapToNearestEdge with _SnapToNearestMixin {
   /// Creates a [SnappingSheetBehavior] that snaps to either

--- a/package/lib/src/foundation/physics.dart
+++ b/package/lib/src/foundation/physics.dart
@@ -228,7 +228,7 @@ mixin _SnapToNearestMixin implements SnappingSheetBehavior {
 ///
 /// Using this behavior is functionally identical to using [SnapToNearest]
 /// with the snap positions of [SheetExtentConfig.minExtent] and
-/// [SheetExtent.maxExtent], but more simplified and efficient.
+/// [SheetExtentConfig.maxExtent], but more simplified and efficient.
 class SnapToNearestEdge with _SnapToNearestMixin {
   /// Creates a [SnappingSheetBehavior] that snaps to either
   /// [SheetMetrics.minPixels] or [SheetMetrics.maxPixels].

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -256,7 +256,7 @@ abstract class _RenderBottomBarVisibility extends RenderTransform {
 
   void invalidateVisibility() {
     final size = _bottomBarSize;
-    if (size != null && _extent.metrics.hasPixels) {
+    if (size != null && _extent.metrics.hasDimensions) {
       final metrics = _extent.metrics;
       final baseTransition =
           (metrics.pixels - metrics.viewportDimensions.height)
@@ -606,7 +606,7 @@ class _ConditionalStickyBottomBarVisibilityState
 
   void _didSheetMetricsChanged() {
     final isVisible =
-        _extent!.metrics.hasPixels && widget.getIsVisible(_extent!.metrics);
+        _extent!.metrics.hasDimensions && widget.getIsVisible(_extent!.metrics);
 
     if (isVisible) {
       if (_controller.status != AnimationStatus.forward) {

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -256,7 +256,7 @@ abstract class _RenderBottomBarVisibility extends RenderTransform {
 
   void invalidateVisibility() {
     final size = _bottomBarSize;
-    if (size != null && _extent.hasPixels) {
+    if (size != null && _extent.metrics.hasPixels) {
       final metrics = _extent.metrics;
       final baseTransition =
           (metrics.pixels - metrics.viewportDimensions.height)
@@ -606,7 +606,7 @@ class _ConditionalStickyBottomBarVisibilityState
 
   void _didSheetMetricsChanged() {
     final isVisible =
-        _extent!.hasPixels && widget.getIsVisible(_extent!.metrics);
+        _extent!.metrics.hasPixels && widget.getIsVisible(_extent!.metrics);
 
     if (isVisible) {
       if (_controller.status != AnimationStatus.forward) {

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -258,9 +258,8 @@ abstract class _RenderBottomBarVisibility extends RenderTransform {
     final size = _bottomBarSize;
     if (size != null && _extent.metrics.hasDimensions) {
       final metrics = _extent.metrics;
-      final baseTransition =
-          (metrics.pixels - metrics.viewportDimensions.height)
-              .clamp(size.height - metrics.viewportDimensions.height, 0.0);
+      final baseTransition = (metrics.pixels - metrics.viewportSize.height)
+          .clamp(size.height - metrics.viewportSize.height, 0.0);
       final visibility = computeVisibility(metrics, size);
       assert(0 <= visibility && visibility <= 1);
       final invisibleHeight = size.height * (1 - visibility);
@@ -341,7 +340,7 @@ class _RenderFixedBottomBarVisibility extends _RenderBottomBarVisibility {
 
     switch (_resizeBehavior) {
       case _AvoidBottomInset(maintainBottomBar: false):
-        final bottomInset = sheetMetrics.viewportDimensions.insets.bottom;
+        final bottomInset = sheetMetrics.viewportInsets.bottom;
         return (visibility - bottomInset / bottomBarSize.height)
             .clamp(0.0, 1.0);
 
@@ -424,7 +423,7 @@ class _RenderStickyBottomBarVisibility extends _RenderBottomBarVisibility {
         return 1.0;
 
       case _AvoidBottomInset(maintainBottomBar: false):
-        final bottomInset = sheetMetrics.viewportDimensions.insets.bottom;
+        final bottomInset = sheetMetrics.viewportInsets.bottom;
         return (1 - bottomInset / bottomBarSize.height).clamp(0.0, 1.0);
     }
   }
@@ -512,7 +511,7 @@ class _RenderAnimatedBottomBarVisibility extends _RenderBottomBarVisibility {
 ///   body: SizedBox.expand(),
 ///   bottomBar: ConditionalStickyBottomBarVisibility(
 ///     getIsVisible: (metrics) =>
-///         metrics.viewportDimensions.insets.bottom == 0 &&
+///         metrics.viewportInsets.bottom == 0 &&
 ///         metrics.pixels >
 ///             const Extent.proportional(0.5)
 ///                 .resolve(metrics.contentSize),

--- a/package/lib/src/foundation/sheet_content_scaffold.dart
+++ b/package/lib/src/foundation/sheet_content_scaffold.dart
@@ -332,8 +332,8 @@ class _RenderFixedBottomBarVisibility extends _RenderBottomBarVisibility {
   @override
   double computeVisibility(SheetMetrics sheetMetrics, Size bottomBarSize) {
     final invisibleSheetHeight =
-        (sheetMetrics.contentDimensions.height - sheetMetrics.pixels)
-            .clamp(0.0, sheetMetrics.contentDimensions.height);
+        (sheetMetrics.contentSize.height - sheetMetrics.pixels)
+            .clamp(0.0, sheetMetrics.contentSize.height);
 
     final visibleBarHeight =
         max(0.0, bottomBarSize.height - invisibleSheetHeight);
@@ -515,7 +515,7 @@ class _RenderAnimatedBottomBarVisibility extends _RenderBottomBarVisibility {
 ///         metrics.viewportDimensions.insets.bottom == 0 &&
 ///         metrics.pixels >
 ///             const Extent.proportional(0.5)
-///                 .resolve(metrics.contentDimensions),
+///                 .resolve(metrics.contentSize),
 ///     child: BottomAppBar(),
 ///   ),
 /// );

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -52,6 +52,7 @@ class SheetController extends ChangeNotifier
     }
   }
 
+  @factory
   SheetExtent createSheetExtent({
     required SheetContext context,
     required SheetExtentConfig config,

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -4,8 +4,10 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 import 'sheet_extent.dart';
+import 'sheet_status.dart';
 
 class SheetController extends ChangeNotifier
+// TODO: Implement ValueListenable<SheetMetrics> instead of ValueListenable<double?>
     implements ValueListenable<double?> {
   SheetExtent? _client;
 
@@ -23,6 +25,8 @@ class SheetController extends ChangeNotifier
         final metrics? when metrics.hasDimensions => metrics,
         _ => null,
       };
+  
+  SheetStatus? get status => _client?.status;
 
   @override
   void addListener(VoidCallback listener, {bool fireImmediately = false}) {

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -16,7 +16,7 @@ class SheetController extends ChangeNotifier
   /// notified immediately when the [_client] fires, and the ones that should
   /// not be notified during the middle of a frame.
   final _immediateListeners = ChangeNotifier();
-  
+
   @override
   SheetMetrics get value => _client?.metrics ?? SheetMetrics.empty;
 

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -17,11 +17,12 @@ class SheetController extends ChangeNotifier
   final _immediateListeners = ChangeNotifier();
 
   @override
-  double? get value => _client?.pixels;
+  double? get value => metrics?.pixels;
 
-  SheetMetrics? get metrics {
-    return _client?.hasPixels == true ? _client!.metrics : null;
-  }
+  SheetMetrics? get metrics => switch (_client?.metrics) {
+    final metrics? when metrics.hasPixels => metrics,
+    _ => null,
+  }; 
 
   @override
   void addListener(VoidCallback listener, {bool fireImmediately = false}) {

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -20,9 +20,9 @@ class SheetController extends ChangeNotifier
   double? get value => metrics?.pixels;
 
   SheetMetrics? get metrics => switch (_client?.metrics) {
-    final metrics? when metrics.hasPixels => metrics,
-    _ => null,
-  }; 
+        final metrics? when metrics.hasDimensions => metrics,
+        _ => null,
+      };
 
   @override
   void addListener(VoidCallback listener, {bool fireImmediately = false}) {

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -53,6 +53,18 @@ class SheetController extends ChangeNotifier
     }
   }
 
+  SheetExtent createSheetExtent({
+    required SheetContext context,
+    required SheetExtentConfig config,
+    required SheetExtentDelegate delegate,
+  }) {
+    return SheetExtent(
+      context: context,
+      config: config,
+      delegate: delegate,
+    );
+  }
+
   @override
   void dispose() {
     detach(_client);

--- a/package/lib/src/foundation/sheet_controller.dart
+++ b/package/lib/src/foundation/sheet_controller.dart
@@ -7,8 +7,7 @@ import 'sheet_extent.dart';
 import 'sheet_status.dart';
 
 class SheetController extends ChangeNotifier
-// TODO: Implement ValueListenable<SheetMetrics> instead of ValueListenable<double?>
-    implements ValueListenable<double?> {
+    implements ValueListenable<SheetMetrics> {
   SheetExtent? _client;
 
   /// A notifier which notifies listeners immediately when the [_client] fires.
@@ -17,15 +16,10 @@ class SheetController extends ChangeNotifier
   /// notified immediately when the [_client] fires, and the ones that should
   /// not be notified during the middle of a frame.
   final _immediateListeners = ChangeNotifier();
-
-  @override
-  double? get value => metrics?.pixels;
-
-  SheetMetrics? get metrics => switch (_client?.metrics) {
-        final metrics? when metrics.hasDimensions => metrics,
-        _ => null,
-      };
   
+  @override
+  SheetMetrics get value => _client?.metrics ?? SheetMetrics.empty;
+
   SheetStatus? get status => _client?.status;
 
   @override
@@ -73,6 +67,7 @@ class SheetController extends ChangeNotifier
   @override
   void dispose() {
     detach(_client);
+    _immediateListeners.dispose();
     super.dispose();
   }
 

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -90,7 +90,7 @@ class FixedExtent implements Extent {
 /// As this value changes, the sheet translates its position, which changes the
 /// visible area of the content. The [SheetMetrics.minPixels] and
 /// [SheetMetrics.maxPixels] values limit the range of the *pixels*, but it can
-/// be outside of the range if the [physics] allows it.
+/// be outside of the range if the [SheetExtentConfig.physics] allows it.
 ///
 /// The current [activity] is responsible for how the *pixels* changes
 /// over time, for example, [AnimatedSheetActivity] animates the *pixels* to
@@ -126,9 +126,6 @@ class SheetExtent extends ChangeNotifier
 
   SheetExtentConfig get config => _config;
   SheetExtentConfig _config;
-
-  // TODO: Remove this
-  SheetPhysics get physics => config.physics;
 
   // TODO: Remove this
   Extent get minExtent => config.minExtent;
@@ -287,7 +284,8 @@ class SheetExtent extends ChangeNotifier
 
   void goBallistic(double velocity) {
     assert(metrics.hasDimensions);
-    final simulation = physics.createBallisticSimulation(velocity, metrics);
+    final simulation =
+        config.physics.createBallisticSimulation(velocity, metrics);
     if (simulation != null) {
       goBallisticWith(simulation);
     } else {
@@ -301,7 +299,7 @@ class SheetExtent extends ChangeNotifier
 
   void settle() {
     assert(metrics.hasDimensions);
-    final simulation = physics.createSettlingSimulation(metrics);
+    final simulation = config.physics.createSettlingSimulation(metrics);
     if (simulation != null) {
       // TODO: Begin a SettlingSheetActivity
       goBallisticWith(simulation);

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -127,9 +127,6 @@ class SheetExtent extends ChangeNotifier
   SheetExtentConfig get config => _config;
   SheetExtentConfig _config;
 
-  // TODO: Remove this
-  Extent get maxExtent => config.maxExtent;
-
   final SheetExtentDelegate delegate;
 
   /// Snapshot of the current sheet's state.

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -174,10 +174,7 @@ class SheetExtent extends ChangeNotifier
         metrics.maybeViewportInsets != insets) {
       _oldViewportSize = metrics.maybeViewportSize;
       _oldViewportInsets = metrics.maybeViewportInsets;
-      _metrics = metrics.copyWith(
-        viewportSize: size,
-        viewportInsets: insets,
-      );
+      _metrics = metrics.copyWith(viewportSize: size, viewportInsets: insets);
       activity.didChangeViewportDimensions(
         _oldViewportSize,
         _oldViewportInsets,
@@ -230,6 +227,12 @@ class SheetExtent extends ChangeNotifier
       }
       return true;
     }());
+
+    if (_markAsDimensionsWillChangeCallCount == 0) {
+      _oldContentSize = null;
+      _oldViewportSize = null;
+      _oldViewportInsets = null;
+    }
 
     _markAsDimensionsWillChangeCallCount++;
   }
@@ -651,7 +654,7 @@ class SheetExtentScope extends StatefulWidget {
   final Widget child;
 
   @override
-  State<SheetExtentScope> createState() => _SheetExtentScopeState();
+  State<SheetExtentScope> createState() => SheetExtentScopeState();
 
   /// Retrieves the [SheetExtent] from the closest [SheetExtentScope]
   /// that encloses the given context, if any.
@@ -675,9 +678,10 @@ class SheetExtentScope extends StatefulWidget {
   }
 }
 
-class _SheetExtentScopeState extends State<SheetExtentScope>
+class SheetExtentScopeState extends State<SheetExtentScope>
     with TickerProviderStateMixin
     implements SheetContext {
+  SheetExtent get extent => _extent;
   late SheetExtent _extent;
 
   @override

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -289,7 +289,7 @@ class SheetExtent extends ChangeNotifier
   }
 
   void goBallistic(double velocity) {
-    assert(metrics.hasPixels);
+    assert(metrics.hasDimensions);
     final simulation = physics.createBallisticSimulation(velocity, metrics);
     if (simulation != null) {
       goBallisticWith(simulation);
@@ -303,7 +303,7 @@ class SheetExtent extends ChangeNotifier
   }
 
   void settle() {
-    assert(metrics.hasPixels);
+    assert(metrics.hasDimensions);
     final simulation = physics.createSettlingSimulation(metrics);
     if (simulation != null) {
       // TODO: Begin a SettlingSheetActivity
@@ -332,7 +332,7 @@ class SheetExtent extends ChangeNotifier
     Curve curve = Curves.easeInOut,
     Duration duration = const Duration(milliseconds: 300),
   }) {
-    assert(metrics.hasPixels);
+    assert(metrics.hasDimensions);
     final destination = newExtent.resolve(metrics.contentDimensions);
     if (metrics.pixels == destination) {
       return Future.value();
@@ -543,24 +543,23 @@ class SheetMetrics {
   /// If the on-screen keyboard is visible, this value is the sum of
   /// [pixels] and the keyboard's height. Otherwise, it is equal to [pixels].
   double get viewPixels => pixels + viewportDimensions.insets.bottom;
-  double? get maybeViewPixels => hasPixels ? viewPixels : null;
+  double? get maybeViewPixels => hasDimensions ? viewPixels : null;
 
   /// The minimum visible height of the sheet measured from the bottom
   /// of the viewport.
   double get minViewPixels => minPixels + viewportDimensions.insets.bottom;
-  double? get maybeMinViewPixels => hasPixels ? minViewPixels : null;
+  double? get maybeMinViewPixels => hasDimensions ? minViewPixels : null;
 
   /// The maximum visible height of the sheet measured from the bottom
   /// of the viewport.
   double get maxViewPixels => maxPixels + viewportDimensions.insets.bottom;
-  double? get maybeMaxViewPixels => hasPixels ? maxViewPixels : null;
+  double? get maybeMaxViewPixels => hasDimensions ? maxViewPixels : null;
 
   /// Whether the all metrics are available.
   ///
   /// Returns true if all of [pixels], [minPixels], [maxPixels],
   /// [contentDimensions], and [viewportDimensions] are not null.
-  // TODO: Rename to 'hasPixels'
-  bool get hasPixels =>
+  bool get hasDimensions =>
       maybePixels != null &&
       maybeMinPixels != null &&
       maybeMaxPixels != null &&
@@ -570,7 +569,7 @@ class SheetMetrics {
   /// Whether the sheet is within the range of [minPixels] and [maxPixels]
   /// (inclusive of both bounds).
   bool get isPixelsInBounds =>
-      hasPixels && pixels.isInBounds(minPixels, maxPixels);
+      hasDimensions && pixels.isInBounds(minPixels, maxPixels);
 
   /// Whether the sheet is outside the range of [minPixels] and [maxPixels].
   bool get isPixelsOutOfBounds => !isPixelsInBounds;
@@ -636,7 +635,7 @@ class SheetMetrics {
   @override
   String toString() => (
         status: maybeStatus,
-        hasPixels: hasPixels,
+        hasPixels: hasDimensions,
         pixels: maybePixels,
         minPixels: maybeMinPixels,
         maxPixels: maybeMaxPixels,

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -120,7 +120,7 @@ class SheetExtent extends ChangeNotifier
 
   @override
   SheetMetrics get value => metrics;
-  
+
   SheetStatus get status => activity.status;
 
   /// A handle to the owner of this object.
@@ -272,23 +272,15 @@ class SheetExtent extends ChangeNotifier
 
   @mustCallSuper
   void beginActivity(SheetActivity activity) {
-    final oldActivity = _activity?..removeListener(_notifyPixels);
+    final oldActivity = _activity;
     // Update the current activity before initialization.
     _activity = activity;
-
-    activity
-      ..initWith(this)
-      ..addListener(_notifyPixels);
+    activity.initWith(this);
 
     if (oldActivity != null) {
       activity.takeOver(oldActivity);
       oldActivity.dispose();
     }
-  }
-
-  void _notifyPixels() {
-    _metrics = metrics.copyWith(pixels: activity.pixels);
-    notifyListeners();
   }
 
   void goIdle() {
@@ -323,11 +315,22 @@ class SheetExtent extends ChangeNotifier
 
   @override
   void dispose() {
-    activity
-      ..removeListener(notifyListeners)
-      ..dispose();
-
+    activity.dispose();
     super.dispose();
+  }
+
+  void setPixels(double pixels) {
+    final oldPixels = metrics.maybePixels;
+    correctPixels(pixels);
+    if (oldPixels != pixels) {
+      notifyListeners();
+    }
+  }
+
+  void correctPixels(double pixels) {
+    if (metrics.maybePixels != pixels) {
+      _metrics = metrics.copyWith(pixels: pixels);
+    }
   }
 
   /// Animates the extent to the given value.

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -128,9 +128,6 @@ class SheetExtent extends ChangeNotifier
   SheetExtentConfig _config;
 
   // TODO: Remove this
-  Extent get minExtent => config.minExtent;
-
-  // TODO: Remove this
   Extent get maxExtent => config.maxExtent;
 
   final SheetExtentDelegate delegate;

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -120,6 +120,8 @@ class SheetExtent extends ChangeNotifier
 
   @override
   SheetMetrics get value => metrics;
+  
+  SheetStatus get status => activity.status;
 
   /// A handle to the owner of this object.
   final SheetContext context;
@@ -432,15 +434,13 @@ mixin class SheetExtentDelegate {
 class SheetMetrics {
   /// Creates an immutable snapshot of the sheet's state.
   const SheetMetrics({
-    required SheetStatus? status,
     required double? pixels,
     required double? minPixels,
     required double? maxPixels,
     required Size? contentSize,
     required Size? viewportSize,
     required EdgeInsets? viewportInsets,
-  })  : maybeStatus = status,
-        maybePixels = pixels,
+  })  : maybePixels = pixels,
         maybeMinPixels = minPixels,
         maybeMaxPixels = maxPixels,
         maybeContentSize = contentSize,
@@ -448,7 +448,6 @@ class SheetMetrics {
         maybeViewportInsets = viewportInsets;
 
   static const empty = SheetMetrics(
-    status: null,
     pixels: null,
     minPixels: null,
     maxPixels: null,
@@ -457,20 +456,12 @@ class SheetMetrics {
     viewportInsets: null,
   );
 
-  final SheetStatus? maybeStatus;
   final double? maybePixels;
   final double? maybeMinPixels;
   final double? maybeMaxPixels;
   final Size? maybeContentSize;
   final Size? maybeViewportSize;
   final EdgeInsets? maybeViewportInsets;
-
-  /// The current status of the sheet.
-  // TODO: Move this to SheetNotification
-  SheetStatus get status {
-    assert(_debugAssertHasProperty('status', maybeStatus));
-    return maybeStatus!;
-  }
 
   /// The current extent of the sheet.
   double get pixels {
@@ -571,7 +562,6 @@ class SheetMetrics {
     EdgeInsets? viewportInsets,
   }) {
     return SheetMetrics(
-      status: status ?? maybeStatus,
       pixels: pixels ?? maybePixels,
       minPixels: minPixels ?? maybeMinPixels,
       maxPixels: maxPixels ?? maybeMaxPixels,
@@ -586,7 +576,6 @@ class SheetMetrics {
       identical(this, other) ||
       (other is SheetMetrics &&
           runtimeType == other.runtimeType &&
-          maybeStatus == other.status &&
           maybePixels == other.pixels &&
           maybeMinPixels == other.minPixels &&
           maybeMaxPixels == other.maxPixels &&
@@ -597,7 +586,6 @@ class SheetMetrics {
   @override
   int get hashCode => Object.hash(
         runtimeType,
-        maybeStatus,
         maybePixels,
         maybeMinPixels,
         maybeMaxPixels,
@@ -608,7 +596,6 @@ class SheetMetrics {
 
   @override
   String toString() => (
-        status: maybeStatus,
         hasPixels: hasDimensions,
         pixels: maybePixels,
         minPixels: maybeMinPixels,

--- a/package/lib/src/foundation/theme.dart
+++ b/package/lib/src/foundation/theme.dart
@@ -64,6 +64,7 @@ class SheetThemeData {
   ///
   /// Note that this value is ignored if the sheet uses [SheetThemeData.physics]
   /// as its physics.
+  // TODO: Remove this
   final SheetPhysics? basePhysics;
 
   /// Creates a copy of this object but with the given fields replaced with

--- a/package/lib/src/modal/cupertino.dart
+++ b/package/lib/src/modal/cupertino.dart
@@ -373,8 +373,8 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
           _cupertinoTransitionControllerOf[_previousRoute]?.value = min(
             controller!.value,
             inverseLerp(
-              metrics.viewportDimensions.height / 2,
-              metrics.viewportDimensions.height,
+              metrics.viewportSize.height / 2,
+              metrics.viewportSize.height,
               metrics.viewPixels,
             ),
           );

--- a/package/lib/src/modal/cupertino.dart
+++ b/package/lib/src/modal/cupertino.dart
@@ -369,7 +369,8 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
     switch (controller!.status) {
       case AnimationStatus.forward:
       case AnimationStatus.completed:
-        if (sheetController.metrics case final metrics?) {
+        final metrics = sheetController.value;
+        if (metrics.hasDimensions) {
           _cupertinoTransitionControllerOf[_previousRoute]?.value = min(
             controller!.value,
             inverseLerp(

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -413,7 +413,7 @@ class _PullToDismissGestureRecognizer extends VerticalDragGestureRecognizer {
   bool _isPointerOnSheet(Offset pointer) {
     final viewport = target.context.size!;
     final localY = viewport.height - pointer.dy;
-    final currentExtent = target._sheetController.metrics?.pixels;
+    final currentExtent = target._sheetController.value.maybePixels;
     return currentExtent != null && localY <= currentExtent;
   }
 
@@ -424,8 +424,8 @@ class _PullToDismissGestureRecognizer extends VerticalDragGestureRecognizer {
 
     final contentScrollableDistance =
         target._lastReportedScrollMetrics?.extentBefore;
-    final currentExtent = target._sheetController.metrics?.pixels;
-    final threshold = target._sheetController.metrics?.minPixels;
+    final currentExtent = target._sheetController.value.maybePixels;
+    final threshold = target._sheetController.value.maybeMinPixels;
 
     return (contentScrollableDistance == null ||
             contentScrollableDistance.isApprox(0)) &&

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -191,7 +191,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   Widget buildModalBarrier() {
     void onDismiss() {
       if (animation!.status == AnimationStatus.completed &&
-          sheetController.metrics?.status == SheetStatus.stable) {
+          sheetController.status == SheetStatus.stable) {
         navigator?.maybePop();
       }
     }

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -102,12 +102,16 @@ class _SheetExtentBox extends ChangeNotifier
     if (_source == value) return;
     _source?.removeListener(notifyListeners);
     _source = value?..addListener(notifyListeners);
-    if (_viewportDimensions != null) {
-      _source?.applyNewViewportDimensions(_viewportDimensions!);
+    if (_viewportSize != null && _viewportInsets != null) {
+      _source?.applyNewViewportDimensions(
+        _viewportSize!,
+        _viewportInsets!,
+      );
     }
   }
 
-  ViewportDimensions? _viewportDimensions;
+  Size? _viewportSize;
+  EdgeInsets? _viewportInsets;
 
   @override
   void dispose() {
@@ -119,10 +123,11 @@ class _SheetExtentBox extends ChangeNotifier
   SheetMetrics get metrics => _source?.metrics ?? SheetMetrics.empty;
 
   @override
-  void applyNewViewportDimensions(ViewportDimensions viewportDimensions) {
+  void applyNewViewportDimensions(Size size, EdgeInsets insets) {
     // Keep the given value in case the source is not set yet.
-    _viewportDimensions = viewportDimensions;
-    _source?.applyNewViewportDimensions(viewportDimensions);
+    _viewportSize = size;
+    _viewportInsets = insets;
+    _source?.applyNewViewportDimensions(size, insets);
   }
 
   @override

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 
 import '../foundation/activities.dart';
 import '../foundation/framework.dart';
+import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_status.dart';
 import 'navigation_sheet.dart';
 
 mixin NavigationSheetRouteMixin<T> on NavigationSheetRoute<T> {
   SheetExtentConfig get pageExtentConfig;
+  SheetExtentDelegate get pageExtentDelegate;
 
   @override
   NavigationSheetExtentDelegate get pageExtent => _pageExtent;
@@ -40,8 +42,11 @@ mixin NavigationSheetRouteMixin<T> on NavigationSheetRoute<T> {
     Animation<double> secondaryAnimation,
   ) {
     return SheetExtentScope(
+      isPrimary: false,
       config: pageExtentConfig,
-      onExtentChanged: (extent) => _pageExtent.source = extent,
+      delegate: pageExtentDelegate,
+      controller: SheetControllerScope.of(context),
+      initializer: (extent) => _pageExtent.source = extent,
       child: SheetContentViewport(
         child: buildContent(context),
       ),

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -4,6 +4,7 @@ import '../foundation/activities.dart';
 import '../foundation/framework.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
+import '../foundation/sheet_status.dart';
 import 'navigation_sheet.dart';
 
 mixin NavigationSheetRouteMixin<T> on NavigationSheetRoute<T> {
@@ -121,6 +122,9 @@ class _SheetExtentBox extends ChangeNotifier
 
   @override
   SheetMetrics get metrics => _source?.metrics ?? SheetMetrics.empty;
+  
+  @override
+  SheetStatus get status => _source?.status ?? SheetStatus.stable;
 
   @override
   void applyNewViewportDimensions(Size size, EdgeInsets insets) {

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -4,7 +4,6 @@ import '../foundation/activities.dart';
 import '../foundation/framework.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
-import '../foundation/sheet_status.dart';
 import 'navigation_sheet.dart';
 
 mixin NavigationSheetRouteMixin<T> on NavigationSheetRoute<T> {
@@ -117,19 +116,7 @@ class _SheetExtentBox extends ChangeNotifier
   }
 
   @override
-  SheetStatus get status => _source?.status ?? SheetStatus.stable;
-
-  @override
-  double? get pixels => _source?.pixels;
-
-  @override
-  double? get minPixels => _source?.minPixels;
-
-  @override
-  double? get maxPixels => _source?.maxPixels;
-
-  @override
-  Size? get contentDimensions => _source?.contentDimensions;
+  SheetMetrics get metrics => _source?.metrics ?? SheetMetrics.empty;
 
   @override
   void applyNewViewportDimensions(ViewportDimensions viewportDimensions) {

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -122,7 +122,7 @@ class _SheetExtentBox extends ChangeNotifier
 
   @override
   SheetMetrics get metrics => _source?.metrics ?? SheetMetrics.empty;
-  
+
   @override
   SheetStatus get status => _source?.status ?? SheetStatus.stable;
 

--- a/package/lib/src/navigation/navigation_routes.dart
+++ b/package/lib/src/navigation/navigation_routes.dart
@@ -18,23 +18,29 @@ class ScrollableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
-    this.physics,
+    this.physics = kDefaultSheetPhysics,
     this.transitionsBuilder,
     required this.builder,
   }) : pageExtentConfig = ScrollableSheetExtentConfig(
           initialExtent: initialExtent,
           minExtent: minExtent,
           maxExtent: maxExtent,
+          // TODO: Obtain the default physics from the theme.
           physics: physics,
+          debugLabel: 'ScrollableNavigationSheetRoute(${settings?.name})',
         );
 
   @override
-  final ScrollableSheetExtentConfig pageExtentConfig;
+  final SheetExtentConfig pageExtentConfig;
+
+  @override
+  SheetExtentDelegate get pageExtentDelegate =>
+      const ScrollableSheetExtentDelegate();
 
   final Extent initialExtent;
   final Extent minExtent;
   final Extent maxExtent;
-  final SheetPhysics? physics;
+  final SheetPhysics physics;
 
   @override
   final bool maintainState;
@@ -77,12 +83,7 @@ class DraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
     this.physics,
     this.transitionsBuilder,
     required this.builder,
-  }) : pageExtentConfig = DraggableSheetExtentConfig(
-          initialExtent: initialExtent,
-          minExtent: minExtent,
-          maxExtent: maxExtent,
-          physics: physics,
-        );
+  });
 
   final Extent initialExtent;
   final Extent minExtent;
@@ -100,7 +101,18 @@ class DraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
   final WidgetBuilder builder;
 
   @override
-  final DraggableSheetExtentConfig pageExtentConfig;
+  SheetExtentConfig get pageExtentConfig => DraggableSheetExtentConfig(
+        initialExtent: initialExtent,
+        minExtent: minExtent,
+        maxExtent: maxExtent,
+        // TODO: Obtain the default physics from the theme.
+        physics: physics ?? kDefaultSheetPhysics,
+        debugLabel: 'DraggableNavigationSheetRoute(${settings.name})',
+      );
+
+  @override
+  SheetExtentDelegate get pageExtentDelegate =>
+      const DraggableSheetExtentDelegate();
 
   @override
   Widget buildContent(BuildContext context) {
@@ -175,25 +187,18 @@ class _PageBasedScrollableNavigationSheetRoute<T>
   Duration get transitionDuration => page.transitionDuration;
 
   @override
-  // TODO: Prefer to directly create a config object than storing it in a field.
-  ScrollableSheetExtentConfig get pageExtentConfig => _pageExtentConfig!;
-  ScrollableSheetExtentConfig? _pageExtentConfig;
-
-  @override
-  void changedInternalState() {
-    super.changedInternalState();
-    if (page.initialExtent != _pageExtentConfig?.initialExtent ||
-        page.minExtent != _pageExtentConfig?.minExtent ||
-        page.maxExtent != _pageExtentConfig?.maxExtent ||
-        page.physics != _pageExtentConfig?.physics) {
-      _pageExtentConfig = ScrollableSheetExtentConfig(
+  SheetExtentConfig get pageExtentConfig => ScrollableSheetExtentConfig(
         initialExtent: page.initialExtent,
         minExtent: page.minExtent,
         maxExtent: page.maxExtent,
-        physics: page.physics,
+        // TODO: Obtain the default physics from the theme.
+        physics: page.physics ?? kDefaultSheetPhysics,
+        debugLabel: 'ScrollableNavigationSheetPage(${page.name})',
       );
-    }
-  }
+
+  @override
+  SheetExtentDelegate get pageExtentDelegate =>
+      const ScrollableSheetExtentDelegate();
 
   @override
   Widget buildTransitions(
@@ -268,25 +273,17 @@ class _PageBasedDraggableNavigationSheetRoute<T> extends NavigationSheetRoute<T>
   Duration get transitionDuration => page.transitionDuration;
 
   @override
-  // TODO: Prefer to directly create a config object than storing it in a field.
-  DraggableSheetExtentConfig get pageExtentConfig => _pageExtentConfig!;
-  DraggableSheetExtentConfig? _pageExtentConfig;
+  SheetExtentConfig get pageExtentConfig => DraggableSheetExtentConfig(
+      initialExtent: page.initialExtent,
+      minExtent: page.minExtent,
+      maxExtent: page.maxExtent,
+      // TODO: Obtain the default physics from the theme.
+      physics: page.physics ?? kDefaultSheetPhysics,
+      debugLabel: 'DraggableNavigationSHeetPage(${page.name})');
 
   @override
-  void changedInternalState() {
-    super.changedInternalState();
-    if (page.initialExtent != _pageExtentConfig?.initialExtent ||
-        page.minExtent != _pageExtentConfig?.minExtent ||
-        page.maxExtent != _pageExtentConfig?.maxExtent ||
-        page.physics != _pageExtentConfig?.physics) {
-      _pageExtentConfig = DraggableSheetExtentConfig(
-        initialExtent: page.initialExtent,
-        minExtent: page.minExtent,
-        maxExtent: page.maxExtent,
-        physics: page.physics,
-      );
-    }
-  }
+  SheetExtentDelegate get pageExtentDelegate =>
+      const DraggableSheetExtentDelegate();
 
   @override
   Widget buildTransitions(

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -263,7 +263,10 @@ class _TransitionSheetActivity extends SheetActivity {
         destinationExtent.metrics.hasDimensions) {
       final startPixels = originExtent.metrics.pixels;
       final endPixels = destinationExtent.metrics.pixels;
-      setPixels(lerpDouble(startPixels, endPixels, _curvedAnimation.value)!);
+      owner.setPixels(
+        lerpDouble(startPixels, endPixels, _curvedAnimation.value)!,
+      );
+
       dispatchUpdateNotification();
     }
   }
@@ -280,15 +283,6 @@ class _ProxySheetActivity extends SheetActivity {
   SheetStatus get status => target.status;
 
   @override
-  double? get pixels {
-    if (target.metrics.hasDimensions) {
-      // Sync the pixels to the delegate's pixels.
-      correctPixels(target.metrics.pixels);
-    }
-    return super.pixels;
-  }
-
-  @override
   void initWith(SheetExtent delegate) {
     super.initWith(delegate);
     target.addListener(_didChangeTargetExtent);
@@ -302,12 +296,12 @@ class _ProxySheetActivity extends SheetActivity {
   }
 
   void _didChangeTargetExtent() {
-    setPixels(target.metrics.pixels);
+    owner.setPixels(target.metrics.pixels);
   }
 
   void _syncPixelsImplicitly() {
     if (target.metrics.hasDimensions) {
-      correctPixels(target.metrics.pixels);
+      owner.correctPixels(target.metrics.pixels);
     }
   }
 
@@ -322,6 +316,12 @@ class _SheetExtentProxy implements SheetExtent {
   const _SheetExtentProxy({required this.inner});
 
   final SheetExtent inner;
+
+  @override
+  void setPixels(double pixels) => inner.setPixels(pixels);
+
+  @override
+  void correctPixels(double pixels) => inner.correctPixels(pixels);
 
   @override
   SheetActivity get activity => inner.activity;

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -341,9 +341,6 @@ class _SheetExtentProxy implements SheetExtent {
   Extent get minExtent => inner.minExtent;
 
   @override
-  SheetPhysics get physics => inner.physics;
-
-  @override
   void addListener(VoidCallback listener) => inner.addListener(listener);
 
   @override

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -305,8 +305,8 @@ class _ProxySheetActivity extends SheetActivity {
   }
 
   @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    super.didChangeContentDimensions(oldDimensions);
+  void didChangeContentSize(Size? oldSize) {
+    super.didChangeContentSize(oldSize);
     _syncPixelsImplicitly();
   }
 }
@@ -364,8 +364,8 @@ class _SheetExtentProxy implements SheetExtent {
   void applyNewConfig(SheetExtentConfig config) => inner.applyNewConfig(config);
 
   @override
-  void applyNewContentDimensions(Size contentDimensions) =>
-      inner.applyNewContentDimensions(contentDimensions);
+  void applyNewContentSize(Size contentSize) =>
+      inner.applyNewContentSize(contentSize);
 
   @override
   void applyNewViewportDimensions(ViewportDimensions viewportDimensions) =>

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -203,7 +203,7 @@ class _NavigationSheetExtentProxy extends _SheetExtentProxy {
   }
 
   void _dispatchViewportDimensions() {
-    if (metrics.hasPixels) {
+    if (metrics.hasDimensions) {
       switch (activity) {
         case final _ProxySheetActivity activity:
           activity.target
@@ -252,7 +252,8 @@ class _TransitionSheetActivity extends SheetActivity {
   }
 
   void _onAnimationTick() {
-    if (originExtent.metrics.hasPixels && destinationExtent.metrics.hasPixels) {
+    if (originExtent.metrics.hasDimensions &&
+        destinationExtent.metrics.hasDimensions) {
       final startPixels = originExtent.metrics.pixels;
       final endPixels = destinationExtent.metrics.pixels;
       setPixels(lerpDouble(startPixels, endPixels, _curvedAnimation.value)!);
@@ -273,7 +274,7 @@ class _ProxySheetActivity extends SheetActivity {
 
   @override
   double? get pixels {
-    if (target.metrics.hasPixels) {
+    if (target.metrics.hasDimensions) {
       // Sync the pixels to the delegate's pixels.
       correctPixels(target.metrics.pixels);
     }
@@ -298,7 +299,7 @@ class _ProxySheetActivity extends SheetActivity {
   }
 
   void _syncPixelsImplicitly() {
-    if (target.metrics.hasPixels) {
+    if (target.metrics.hasDimensions) {
       correctPixels(target.metrics.pixels);
     }
   }

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -338,9 +338,6 @@ class _SheetExtentProxy implements SheetExtent {
   SheetMetrics get metrics => inner.metrics;
 
   @override
-  Extent get minExtent => inner.minExtent;
-
-  @override
   void addListener(VoidCallback listener) => inner.addListener(listener);
 
   @override

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -38,7 +38,7 @@ class NavigationSheet extends StatefulWidget with TransitionAwareWidgetMixin {
 class NavigationSheetState extends State<NavigationSheet>
     with TransitionAwareStateMixin, TickerProviderStateMixin
     implements SheetContext {
-  _NavigationSheetExtent? _extent;
+  _NavigationSheetExtentProxy? _extent;
 
   @override
   TickerProvider get vsync => this;
@@ -105,10 +105,18 @@ class NavigationSheetState extends State<NavigationSheet>
       controller: widget.controller,
       builder: (context, controller) {
         return SheetContainer(
-          config: const _NavigationSheetExtentConfig(),
-          controller: widget.controller ?? DefaultSheetController.of(context),
-          onExtentChanged: (extent) {
-            _extent = extent as _NavigationSheetExtent?;
+          controller: controller,
+          config: const SheetExtentConfig(
+            minExtent: Extent.pixels(0),
+            maxExtent: Extent.proportional(1),
+            // TODO: Use more appropriate physics.
+            physics: ClampingSheetPhysics(),
+            debugLabel: 'NavigationSheet',
+          ),
+          initializer: (extent) {
+            final proxy = _NavigationSheetExtentProxy(inner: extent);
+            _extent = proxy;
+            return proxy;
           },
           child: widget.child,
         );
@@ -145,32 +153,26 @@ abstract class NavigationSheetExtentDelegate implements Listenable {
   void beginActivity(SheetActivity activity);
 }
 
-class _NavigationSheetExtentConfig extends SheetExtentConfig {
-  const _NavigationSheetExtentConfig();
+// class _NavigationSheetExtentConfig extends SheetExtentConfig {
+//   const _NavigationSheetExtentConfig();
 
-  @override
-  bool shouldRebuild(BuildContext context, SheetExtent oldExtent) {
-    return oldExtent is! _NavigationSheetExtent;
-  }
+//   @override
+//   bool shouldRebuild(BuildContext context, SheetExtent oldExtent) {
+//     return oldExtent is! _NavigationSheetExtent;
+//   }
 
-  @override
-  SheetExtent build(BuildContext context, SheetContext sheetContext) {
-    return _NavigationSheetExtent(
-      context: sheetContext,
-      // TODO: Use more appropriate physics.
-      physics: const ClampingSheetPhysics(),
-    );
-  }
-}
+//   @override
+//   SheetExtent build(BuildContext context, SheetContext sheetContext) {
+//     return _NavigationSheetExtent(
+//       context: sheetContext,
+//       // TODO: Use more appropriate physics.
+//       physics: const ClampingSheetPhysics(),
+//     );
+//   }
+// }
 
-class _NavigationSheetExtent extends SheetExtent {
-  _NavigationSheetExtent({
-    required super.context,
-    required super.physics,
-  }) : super(
-          minExtent: const Extent.pixels(0),
-          maxExtent: const Extent.proportional(1),
-        );
+class _NavigationSheetExtentProxy extends _SheetExtentProxy {
+  const _NavigationSheetExtentProxy({required super.inner});
 
   @override
   Size? get contentDimensions {
@@ -329,4 +331,135 @@ class _ProxySheetActivity extends SheetActivity {
     super.didChangeContentDimensions(oldDimensions);
     _syncPixelsImplicitly();
   }
+}
+
+class _SheetExtentProxy implements SheetExtent {
+  const _SheetExtentProxy({required this.inner});
+
+  final SheetExtent inner;
+
+  @override
+  SheetActivity get activity => inner.activity;
+
+  @override
+  SheetExtentConfig get config => inner.config;
+
+  @override
+  Size? get contentDimensions => inner.contentDimensions;
+
+  @override
+  SheetContext get context => inner.context;
+
+  @override
+  SheetExtentDelegate get delegate => inner.delegate;
+
+  @override
+  bool get hasListeners => inner.hasListeners;
+
+  @override
+  bool get hasPixels => inner.hasPixels;
+
+  @override
+  bool get isPixelsInBounds => inner.isPixelsInBounds;
+
+  @override
+  bool get isPixelsOutOfBounds => inner.isPixelsOutOfBounds;
+
+  @override
+  Extent get maxExtent => inner.maxExtent;
+
+  @override
+  double? get maxPixels => inner.maxPixels;
+
+  @override
+  double? get maxViewPixels => inner.maxViewPixels;
+
+  @override
+  SheetMetrics get metrics => inner.metrics;
+
+  @override
+  Extent get minExtent => inner.minExtent;
+
+  @override
+  double? get minPixels => inner.minPixels;
+
+  @override
+  double? get minViewPixels => inner.minViewPixels;
+
+  @override
+  SheetPhysics get physics => inner.physics;
+
+  @override
+  double? get pixels => inner.pixels;
+
+  @override
+  SheetMetricsSnapshot get snapshot => inner.snapshot;
+
+  @override
+  SheetStatus get status => inner.status;
+
+  @override
+  double? get viewPixels => inner.viewPixels;
+
+  @override
+  ViewportDimensions? get viewportDimensions => inner.viewportDimensions;
+
+  @override
+  void addListener(VoidCallback listener) => inner.addListener(listener);
+
+  @override
+  void notifyListeners() => inner.notifyListeners();
+
+  @override
+  void removeListener(VoidCallback listener) => inner.removeListener(listener);
+
+  @override
+  Future<void> animateTo(
+    Extent newExtent, {
+    Curve curve = Curves.easeInOut,
+    Duration duration = const Duration(milliseconds: 300),
+  }) =>
+      inner.animateTo(newExtent, curve: curve, duration: duration);
+
+  @override
+  void applyNewConfig(SheetExtentConfig config) => inner.applyNewConfig(config);
+
+  @override
+  void applyNewContentDimensions(Size contentDimensions) =>
+      inner.applyNewContentDimensions(contentDimensions);
+
+  @override
+  void applyNewViewportDimensions(ViewportDimensions viewportDimensions) =>
+      inner.applyNewViewportDimensions(viewportDimensions);
+
+  @override
+  void beginActivity(SheetActivity activity) => inner.beginActivity(activity);
+
+  @override
+  void dispose() => inner.dispose();
+
+  @override
+  void goBallistic(double velocity) => inner.goBallistic(velocity);
+
+  @override
+  void goBallisticWith(Simulation simulation) =>
+      inner.goBallisticWith(simulation);
+
+  @override
+  void goIdle() => inner.goIdle();
+
+  @override
+  void settle() => settle();
+
+  @override
+  void takeOver(SheetExtent other) => inner.takeOver(other);
+
+  @override
+  void markAsDimensionsChanged() => inner.markAsDimensionsChanged();
+
+  @override
+  void markAsDimensionsWillChange() => inner.markAsDimensionsWillChange();
+
+  @override
+  void onDimensionsFinalized() => inner.onDimensionsFinalized();
 }

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -145,6 +145,7 @@ abstract class NavigationSheetRoute<T> extends PageRoute<T> {
 // TODO: What a ugly interface!
 abstract class NavigationSheetExtentDelegate implements Listenable {
   SheetMetrics get metrics;
+  SheetStatus get status;
   void applyNewViewportDimensions(Size size, EdgeInsets insets);
   void beginActivity(SheetActivity activity);
 }
@@ -276,7 +277,7 @@ class _ProxySheetActivity extends SheetActivity {
   final NavigationSheetExtentDelegate target;
 
   @override
-  SheetStatus get status => target.metrics.status;
+  SheetStatus get status => target.status;
 
   @override
   double? get pixels {
@@ -324,6 +325,9 @@ class _SheetExtentProxy implements SheetExtent {
 
   @override
   SheetActivity get activity => inner.activity;
+
+  @override
+  SheetStatus get status => inner.status;
 
   @override
   SheetExtentConfig get config => inner.config;

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -145,7 +145,7 @@ abstract class NavigationSheetRoute<T> extends PageRoute<T> {
 // TODO: What a ugly interface!
 abstract class NavigationSheetExtentDelegate implements Listenable {
   SheetMetrics get metrics;
-  void applyNewViewportDimensions(ViewportDimensions viewportDimensions);
+  void applyNewViewportDimensions(Size size, EdgeInsets insets);
   void beginActivity(SheetActivity activity);
 }
 
@@ -178,8 +178,8 @@ class _NavigationSheetExtentProxy extends _SheetExtentProxy {
       };
 
   @override
-  void applyNewViewportDimensions(ViewportDimensions viewportDimensions) {
-    super.applyNewViewportDimensions(viewportDimensions);
+  void applyNewViewportDimensions(Size size, EdgeInsets insets) {
+    super.applyNewViewportDimensions(size, insets);
     _dispatchViewportDimensions();
   }
 
@@ -206,14 +206,20 @@ class _NavigationSheetExtentProxy extends _SheetExtentProxy {
     if (metrics.hasDimensions) {
       switch (activity) {
         case final _ProxySheetActivity activity:
-          activity.target
-              .applyNewViewportDimensions(metrics.viewportDimensions);
+          activity.target.applyNewViewportDimensions(
+            metrics.viewportSize,
+            metrics.viewportInsets,
+          );
 
         case final _TransitionSheetActivity activity:
-          activity.originExtent
-              .applyNewViewportDimensions(metrics.viewportDimensions);
-          activity.destinationExtent
-              .applyNewViewportDimensions(metrics.viewportDimensions);
+          activity.originExtent.applyNewViewportDimensions(
+            metrics.viewportSize,
+            metrics.viewportInsets,
+          );
+          activity.destinationExtent.applyNewViewportDimensions(
+            metrics.viewportSize,
+            metrics.viewportInsets,
+          );
       }
     }
   }
@@ -359,8 +365,8 @@ class _SheetExtentProxy implements SheetExtent {
       inner.applyNewContentSize(contentSize);
 
   @override
-  void applyNewViewportDimensions(ViewportDimensions viewportDimensions) =>
-      inner.applyNewViewportDimensions(viewportDimensions);
+  void applyNewViewportDimensions(Size size, EdgeInsets insets) =>
+      inner.applyNewViewportDimensions(size, insets);
 
   @override
   void beginActivity(SheetActivity activity) => inner.beginActivity(activity);

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -332,9 +332,6 @@ class _SheetExtentProxy implements SheetExtent {
   bool get hasListeners => inner.hasListeners;
 
   @override
-  Extent get maxExtent => inner.maxExtent;
-
-  @override
   SheetMetrics get metrics => inner.metrics;
 
   @override

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -47,9 +47,14 @@ class ScrollableSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
-    final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
     final keyboardDismissBehavior =
         this.keyboardDismissBehavior ?? theme?.keyboardDismissBehavior;
+    // TODO: Do this in ScrollableSheetConfig
+    final physics = switch (this.physics ?? theme?.physics) {
+      null => const ScrollableSheetPhysics(parent: kDefaultSheetPhysics),
+      final ScrollableSheetPhysics scrollablePhysics => scrollablePhysics,
+      final otherPhysics => ScrollableSheetPhysics(parent: otherPhysics),
+    };
 
     Widget result = ImplicitSheetControllerScope(
       controller: controller,
@@ -61,10 +66,7 @@ class ScrollableSheet extends StatelessWidget {
             initialExtent: initialExtent,
             minExtent: minExtent,
             maxExtent: maxExtent,
-            physics: switch (physics) {
-              final ScrollableSheetPhysics physics => physics,
-              _ => ScrollableSheetPhysics(parent: physics),
-            },
+            physics: physics,
             debugLabel: 'ScrollableSheet',
           ),
           child: PrimarySheetContentScrollController(child: child),
@@ -114,6 +116,7 @@ class PrimarySheetContentScrollController extends StatelessWidget {
   }
 }
 
+// TODO: Move this to a separate file.
 class SheetScrollable extends StatefulWidget {
   const SheetScrollable({
     super.key,

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -29,13 +29,13 @@ class ScrollableSheet extends StatelessWidget {
   /// {@macro ScrollableSheetExtent.initialExtent}
   final Extent initialExtent;
 
-  /// {@macro SheetExtent.minExtent}
+  /// {@macro SheetExtentConfig.minExtent}
   final Extent minExtent;
 
-  /// {@macro SheetExtent.maxExtent}
+  /// {@macro SheetExtentConfig.maxExtent}
   final Extent maxExtent;
 
-  /// {@macro SheetExtent.physics}
+  /// {@macro SheetExtentConfig.physics}
   final SheetPhysics? physics;
 
   /// An object that can be used to control and observe the sheet height.

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -309,12 +309,12 @@ class _ContentIdleScrollDrivenSheetActivity
   SheetStatus get status => SheetStatus.stable;
 
   @override
-  void didChangeContentDimensions(Size? oldDimensions) {
-    super.didChangeContentDimensions(oldDimensions);
+  void didChangeContentSize(Size? oldSize) {
+    super.didChangeContentSize(oldSize);
     final config = delegate.config;
     final metrics = delegate.metrics;
     if (pixels == null && config is ScrollableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(metrics.contentDimensions));
+      setPixels(config.initialExtent.resolve(metrics.contentSize));
     }
   }
 }

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -95,7 +95,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     DragStartDetails details,
     DelegatableScrollPosition position,
   ) {
-    delegate.beginActivity(
+    owner.beginActivity(
       _ContentUserScrollDrivenSheetActivity(
         contentScrollPosition: position,
       ),
@@ -123,7 +123,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
   DelegationResult<ScrollActivity> onContentGoIdle(
     DelegatableScrollPosition position,
   ) {
-    delegate.goIdle();
+    owner.goIdle();
     return super.onContentGoIdle(position);
   }
 
@@ -133,23 +133,23 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     bool shouldIgnorePointer,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasDimensions) {
+    final metrics = owner.metrics;
+    if (!metrics.hasDimensions) {
       return const DelegationResult.notHandled();
     }
 
     if (position.pixels.isApprox(position.minScrollExtent)) {
-      final simulation = delegate.config.physics
-          .createBallisticSimulation(velocity, delegate.metrics);
+      final simulation =
+          owner.config.physics.createBallisticSimulation(velocity, metrics);
       if (simulation != null) {
-        delegate.goBallisticWith(simulation);
+        owner.goBallisticWith(simulation);
         return DelegationResult.handled(IdleScrollActivity(position));
       }
     }
 
     final scrolledDistance = position.pixels;
-    final draggedDistance = pixels! - delegate.metrics.minPixels;
-    final draggableDistance =
-        delegate.metrics.maxPixels - delegate.metrics.minPixels;
+    final draggedDistance = metrics.pixels - metrics.minPixels;
+    final draggableDistance = metrics.maxPixels - metrics.minPixels;
     final scrollableDistance =
         position.maxScrollExtent - position.minScrollExtent;
     final pixelsForScrollPhysics = scrolledDistance + draggedDistance;
@@ -164,7 +164,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     final scrollSimulation = position.physics
         .createBallisticSimulation(scrollMetricsForScrollPhysics, velocity);
     if (scrollSimulation != null) {
-      delegate.beginActivity(
+      owner.beginActivity(
         _ContentBallisticScrollDrivenSheetActivity(
           contentScrollPosition: position,
         ),
@@ -197,32 +197,32 @@ abstract class _SingleContentScrollDrivenSheetActivity
   final DelegatableScrollPosition contentScrollPosition;
 
   double _applyPhysicsToOffset(double offset) {
-    return delegate.config.physics
-        .applyPhysicsToOffset(offset, delegate.metrics);
+    return owner.config.physics.applyPhysicsToOffset(offset, owner.metrics);
   }
 
   double _applyScrollOffset(double offset) {
     if (offset.isApprox(0)) return 0;
 
     final position = contentScrollPosition;
-    final maxPixels = delegate.metrics.maxPixels;
-    final oldPixels = pixels!;
+    final maxPixels = owner.metrics.maxPixels;
+    final oldPixels = owner.metrics.pixels;
     final oldScrollPixels = position.pixels;
     final minScrollPixels = position.minScrollExtent;
     final maxScrollPixels = position.maxScrollExtent;
+    var newPixels = oldPixels;
     var delta = offset;
 
     if (offset > 0) {
       // If the sheet is not at top, drag it up as much as possible
       // until it reaches at 'maxPixels'.
-      if (pixels!.isLessThanOrApprox(maxPixels)) {
+      if (newPixels.isLessThanOrApprox(maxPixels)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(physicsAppliedDelta.isLessThanOrApprox(delta));
-        correctPixels(min(pixels! + physicsAppliedDelta, maxPixels));
-        delta -= pixels! - oldPixels;
+        newPixels = min(newPixels + physicsAppliedDelta, maxPixels);
+        delta -= newPixels - oldPixels;
       }
       // If the sheet is at the top, scroll the content up as much as possible.
-      if (pixels!.isGreaterThanOrApprox(maxPixels) &&
+      if (newPixels.isGreaterThanOrApprox(maxPixels) &&
           position.extentAfter > 0) {
         position.correctPixels(min(position.pixels + delta, maxScrollPixels));
         delta -= position.pixels - oldScrollPixels;
@@ -232,21 +232,22 @@ abstract class _SingleContentScrollDrivenSheetActivity
       if (position.pixels.isApprox(maxScrollPixels)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(physicsAppliedDelta.isLessThanOrApprox(delta));
-        correctPixels(pixels! + physicsAppliedDelta);
+        newPixels += physicsAppliedDelta;
         delta -= physicsAppliedDelta;
       }
     } else if (offset < 0) {
       // If the sheet is beyond 'maxPixels', drag it down as much
       // as possible until it reaches at 'maxPixels'.
-      if (pixels!.isGreaterThanOrApprox(maxPixels)) {
+      if (newPixels.isGreaterThanOrApprox(maxPixels)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(physicsAppliedDelta.abs().isLessThanOrApprox(delta.abs()));
-        correctPixels(max(pixels! + physicsAppliedDelta, maxPixels));
-        delta -= pixels! - oldPixels;
+        newPixels = max(newPixels + physicsAppliedDelta, maxPixels);
+        delta -= newPixels - oldPixels;
       }
       // If the sheet is not beyond 'maxPixels', scroll the content down
       // as much as possible.
-      if (pixels!.isLessThanOrApprox(maxPixels) && position.extentBefore > 0) {
+      if (newPixels.isLessThanOrApprox(maxPixels) &&
+          position.extentBefore > 0) {
         position.correctPixels(max(position.pixels + delta, minScrollPixels));
         delta -= position.pixels - oldScrollPixels;
       }
@@ -255,7 +256,7 @@ abstract class _SingleContentScrollDrivenSheetActivity
       if (position.pixels.isApprox(minScrollPixels)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(physicsAppliedDelta.abs().isLessThanOrApprox(delta.abs()));
-        correctPixels(pixels! + physicsAppliedDelta);
+        newPixels += physicsAppliedDelta;
         delta -= physicsAppliedDelta;
       }
     }
@@ -266,12 +267,9 @@ abstract class _SingleContentScrollDrivenSheetActivity
         ..didUpdateScrollPositionBy(position.pixels - oldScrollPixels);
     }
 
-    if (pixels! != oldPixels) {
-      notifyListeners();
-    }
+    owner.setPixels(newPixels);
 
-    final overflow =
-        delegate.config.physics.computeOverflow(delta, delegate.metrics);
+    final overflow = owner.config.physics.computeOverflow(delta, owner.metrics);
     if (overflow.abs() > 0) {
       position.didOverscrollBy(overflow);
       dispatchOverflowNotification(overflow);
@@ -313,10 +311,10 @@ class _ContentIdleScrollDrivenSheetActivity
   @override
   void didChangeContentSize(Size? oldSize) {
     super.didChangeContentSize(oldSize);
-    final config = delegate.config;
-    final metrics = delegate.metrics;
-    if (pixels == null && config is ScrollableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(metrics.contentSize));
+    final config = owner.config;
+    final metrics = owner.metrics;
+    if (metrics.maybePixels == null && config is ScrollableSheetExtentConfig) {
+      owner.setPixels(config.initialExtent.resolve(metrics.contentSize));
     }
   }
 }
@@ -333,16 +331,17 @@ class _ContentUserScrollDrivenSheetActivity
     double delta,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasDimensions ||
+    if (!owner.metrics.hasDimensions ||
         !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }
 
-    final oldPixels = pixels!;
+    final oldPixels = owner.metrics.pixels;
     _applyScrollOffset(-1 * delta);
+    final newPixels = owner.metrics.pixels;
 
-    if (pixels != oldPixels) {
-      dispatchDragUpdateNotification(delta: pixels! - oldPixels);
+    if (newPixels != oldPixels) {
+      dispatchDragUpdateNotification(delta: newPixels - oldPixels);
     }
 
     return const DelegationResult.handled(null);
@@ -352,7 +351,7 @@ class _ContentUserScrollDrivenSheetActivity
   void onContentDragCancel(DelegatableScrollPosition position) {
     super.onContentDragCancel(position);
     if (identical(position, contentScrollPosition)) {
-      delegate.goBallistic(0);
+      owner.goBallistic(0);
     }
   }
 }
@@ -372,24 +371,24 @@ class _ContentBallisticScrollDrivenSheetActivity
     double velocity,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasDimensions ||
+    if (!owner.metrics.hasDimensions ||
         !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }
 
-    final oldPixels = pixels!;
+    final oldPixels = owner.metrics.pixels;
     final overscroll = _applyScrollOffset(delta);
 
-    if (pixels != oldPixels) {
+    if (owner.metrics.pixels != oldPixels) {
       dispatchUpdateNotification();
     }
 
-    final physics = delegate.config.physics;
+    final physics = owner.config.physics;
     if (((position.extentBefore.isApprox(0) && velocity < 0) ||
             (position.extentAfter.isApprox(0) && velocity > 0)) &&
         physics is ScrollableSheetPhysics &&
-        physics.shouldInterruptBallisticScroll(velocity, delegate.metrics)) {
-      delegate.goBallistic(0);
+        physics.shouldInterruptBallisticScroll(velocity, owner.metrics)) {
+      owner.goBallistic(0);
     }
 
     return DelegationResult.handled(overscroll);
@@ -398,7 +397,7 @@ class _ContentBallisticScrollDrivenSheetActivity
   @override
   void onWillContentBallisticScrollCancel(DelegatableScrollPosition position) {
     if (identical(position, contentScrollPosition)) {
-      delegate.goBallistic(0);
+      owner.goBallistic(0);
     }
   }
 }
@@ -421,7 +420,7 @@ class _DragInterruptibleBallisticSheetActivity extends BallisticSheetActivity
     DelegatableScrollPosition position,
   ) {
     _cancelSimulation();
-    delegate.beginActivity(
+    owner.beginActivity(
       _ContentUserScrollDrivenSheetActivity(
         contentScrollPosition: position,
       ),

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -15,9 +15,9 @@ class ScrollableSheetExtentConfig extends SheetExtentConfig {
     required this.initialExtent,
     required super.minExtent,
     required super.maxExtent,
-    required super.physics,
+    required ScrollableSheetPhysics physics,
     super.debugLabel,
-  });
+  }) : super(physics: physics);
 
   final Extent initialExtent;
 
@@ -50,6 +50,7 @@ class ScrollableSheetExtentDelegate with SheetExtentDelegate {
   }
 }
 
+// TODO: Move this to a separate file
 @internal
 class SheetContentScrollController extends ScrollController {
   SheetContentScrollController({

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -138,7 +138,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     }
 
     if (position.pixels.isApprox(position.minScrollExtent)) {
-      final simulation = delegate.physics
+      final simulation = delegate.config.physics
           .createBallisticSimulation(velocity, delegate.metrics);
       if (simulation != null) {
         delegate.goBallisticWith(simulation);
@@ -197,7 +197,8 @@ abstract class _SingleContentScrollDrivenSheetActivity
   final DelegatableScrollPosition contentScrollPosition;
 
   double _applyPhysicsToOffset(double offset) {
-    return delegate.physics.applyPhysicsToOffset(offset, delegate.metrics);
+    return delegate.config.physics
+        .applyPhysicsToOffset(offset, delegate.metrics);
   }
 
   double _applyScrollOffset(double offset) {
@@ -269,7 +270,8 @@ abstract class _SingleContentScrollDrivenSheetActivity
       notifyListeners();
     }
 
-    final overflow = delegate.physics.computeOverflow(delta, delegate.metrics);
+    final overflow =
+        delegate.config.physics.computeOverflow(delta, delegate.metrics);
     if (overflow.abs() > 0) {
       position.didOverscrollBy(overflow);
       dispatchOverflowNotification(overflow);
@@ -382,7 +384,7 @@ class _ContentBallisticScrollDrivenSheetActivity
       dispatchUpdateNotification();
     }
 
-    final physics = delegate.physics;
+    final physics = delegate.config.physics;
     if (((position.extentBefore.isApprox(0) && velocity < 0) ||
             (position.extentAfter.isApprox(0) && velocity > 0)) &&
         physics is ScrollableSheetPhysics &&

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -133,7 +133,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     bool shouldIgnorePointer,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.hasPixels) {
+    if (!delegate.metrics.hasPixels) {
       return const DelegationResult.notHandled();
     }
 
@@ -147,8 +147,9 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     }
 
     final scrolledDistance = position.pixels;
-    final draggedDistance = pixels! - delegate.minPixels!;
-    final draggableDistance = delegate.maxPixels! - delegate.minPixels!;
+    final draggedDistance = pixels! - delegate.metrics.minPixels;
+    final draggableDistance =
+        delegate.metrics.maxPixels - delegate.metrics.minPixels;
     final scrollableDistance =
         position.maxScrollExtent - position.minScrollExtent;
     final pixelsForScrollPhysics = scrolledDistance + draggedDistance;
@@ -203,7 +204,7 @@ abstract class _SingleContentScrollDrivenSheetActivity
     if (offset.isApprox(0)) return 0;
 
     final position = contentScrollPosition;
-    final maxPixels = delegate.maxPixels!;
+    final maxPixels = delegate.metrics.maxPixels;
     final oldPixels = pixels!;
     final oldScrollPixels = position.pixels;
     final minScrollPixels = position.minScrollExtent;
@@ -311,8 +312,9 @@ class _ContentIdleScrollDrivenSheetActivity
   void didChangeContentDimensions(Size? oldDimensions) {
     super.didChangeContentDimensions(oldDimensions);
     final config = delegate.config;
+    final metrics = delegate.metrics;
     if (pixels == null && config is ScrollableSheetExtentConfig) {
-      setPixels(config.initialExtent.resolve(delegate.contentDimensions!));
+      setPixels(config.initialExtent.resolve(metrics.contentDimensions));
     }
   }
 }
@@ -329,7 +331,8 @@ class _ContentUserScrollDrivenSheetActivity
     double delta,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.hasPixels || !identical(position, contentScrollPosition)) {
+    if (!delegate.metrics.hasPixels ||
+        !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }
 
@@ -367,7 +370,8 @@ class _ContentBallisticScrollDrivenSheetActivity
     double velocity,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.hasPixels || !identical(position, contentScrollPosition)) {
+    if (!delegate.metrics.hasPixels ||
+        !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -133,7 +133,7 @@ abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     bool shouldIgnorePointer,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasPixels) {
+    if (!delegate.metrics.hasDimensions) {
       return const DelegationResult.notHandled();
     }
 
@@ -331,7 +331,7 @@ class _ContentUserScrollDrivenSheetActivity
     double delta,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasPixels ||
+    if (!delegate.metrics.hasDimensions ||
         !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }
@@ -370,7 +370,7 @@ class _ContentBallisticScrollDrivenSheetActivity
     double velocity,
     DelegatableScrollPosition position,
   ) {
-    if (!delegate.metrics.hasPixels ||
+    if (!delegate.metrics.hasDimensions ||
         !identical(position, contentScrollPosition)) {
       return const DelegationResult.notHandled();
     }

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.4.2
+version: 0.5.0
 repository: https://github.com/fujidaiti/smooth_sheets
 
 environment:

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -19,7 +19,7 @@ const _referenceSheetMetrics = SheetMetrics(
   minPixels: 0,
   maxPixels: 600,
   pixels: 600,
-  contentDimensions: Size(360, 600),
+  contentSize: Size(360, 600),
   viewportDimensions: ViewportDimensions(
     width: 360,
     height: 700,

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -20,11 +20,8 @@ const _referenceSheetMetrics = SheetMetrics(
   maxPixels: 600,
   pixels: 600,
   contentSize: Size(360, 600),
-  viewportDimensions: ViewportDimensions(
-    width: 360,
-    height: 700,
-    insets: EdgeInsets.zero,
-  ),
+  viewportSize: Size(360, 700),
+  viewportInsets: EdgeInsets.zero,
 );
 
 final _positionAtTopEdge =

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -2,7 +2,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
-import 'package:smooth_sheets/src/foundation/sheet_status.dart';
 
 class _SheetPhysicsWithDefaultConfiguration extends SheetPhysics
     with SheetPhysicsMixin {
@@ -15,7 +14,6 @@ class _SheetPhysicsWithDefaultConfiguration extends SheetPhysics
 }
 
 const _referenceSheetMetrics = SheetMetrics(
-  status: SheetStatus.stable,
   minPixels: 0,
   maxPixels: 600,
   pixels: 600,

--- a/package/test/foundation/physics_test.dart
+++ b/package/test/foundation/physics_test.dart
@@ -14,7 +14,7 @@ class _SheetPhysicsWithDefaultConfiguration extends SheetPhysics
   }
 }
 
-const _referenceSheetMetrics = SheetMetricsSnapshot(
+const _referenceSheetMetrics = SheetMetrics(
   status: SheetStatus.stable,
   minPixels: 0,
   maxPixels: 600,


### PR DESCRIPTION
This PR has breaking changes. See `docs/migration-guide-0.5.x.md` for more details.

The summary is:
- Moved responsibility for creating SheetExtent to SheetController
- Reimplemented SheetExtent as ValueListenable<SheetMetrics>
- Changed SheetActivity to directly update SheetExtent instead of having its own `pixels`
- Refactored the core logic of NavigationSheet
- Bumped to 0.5.0