### PR TITLE
Re-export NavigationSheetRoute unintentionally omitted in v0.5.0

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 May 4, 2024
+
+- Re-export `NavigationSheetRoute` that is unintentionally omitted in v0.5.0 (#110)
+
 ## 0.5.0 May 4, 2024
 
 This version contains some breaking changes. See the [migration guide](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.5.x.md) for more details.

--- a/package/lib/smooth_sheets.dart
+++ b/package/lib/smooth_sheets.dart
@@ -18,6 +18,7 @@ export 'src/foundation/sheet_extent.dart';
 export 'src/foundation/theme.dart';
 export 'src/modal/cupertino.dart';
 export 'src/modal/modal_sheet.dart';
+export 'src/navigation/navigation_route.dart';
 export 'src/navigation/navigation_routes.dart';
 export 'src/navigation/navigation_sheet.dart';
 export 'src/scrollable/scrollable_sheet.dart'

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/fujidaiti/smooth_sheets
 
 environment:


### PR DESCRIPTION
Fixes #110.