### PR TITLE
Transfer activity from old extent to new extent in takeOver()

### DIFF
--- a/package/lib/src/draggable/draggable_sheet_extent.dart
+++ b/package/lib/src/draggable/draggable_sheet_extent.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
@@ -68,5 +69,10 @@ class _IdleDraggableSheetActivity extends IdleSheetActivity {
     if (metrics.maybePixels == null && config is DraggableSheetExtentConfig) {
       owner.setPixels(config.initialExtent.resolve(metrics.contentSize));
     }
+  }
+
+  @override
+  bool isCompatibleWith(SheetExtent newOwner) {
+    return newOwner is DraggableSheetExtent;
   }
 }

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -37,6 +37,11 @@ abstract class SheetActivity {
     _mounted = true;
   }
 
+  @mustCallSuper
+  void updateOwner(SheetExtent owner) {
+    _owner = owner;
+  }
+
   void dispose() {
     _mounted = false;
   }
@@ -126,7 +131,7 @@ abstract class SheetActivity {
     }
   }
 
-  void takeOver(SheetActivity other) {}
+  bool isCompatibleWith(SheetExtent newOwner) => true;
 
   void didChangeContentSize(Size? oldSize) {}
 

--- a/package/lib/src/foundation/activities.dart
+++ b/package/lib/src/foundation/activities.dart
@@ -17,7 +17,7 @@ abstract class SheetActivity {
   SheetExtent get owner {
     assert(
       _owner != null,
-      '$SheetActivity must be initialized with initWith().',
+      '$SheetActivity must be initialized with init().',
     );
     return _owner!;
   }
@@ -30,7 +30,7 @@ abstract class SheetActivity {
   void init(SheetExtent owner) {
     assert(
       _owner == null,
-      'initWith() must be called only once.',
+      'init() must be called only once.',
     );
 
     _owner = owner;

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -138,12 +138,24 @@ class SheetExtent extends ChangeNotifier
 
   @mustCallSuper
   void takeOver(SheetExtent other) {
+    if (other.activity.isCompatibleWith(this)) {
+      activity.dispose();
+      _activity = other.activity;
+      // This is necessary to prevent the activity from being disposed of
+      // when `other` extent is disposed of.
+      other._activity = null;
+      activity.updateOwner(this);
+    } else {
+      goIdle();
+    }
+    if (other.metrics.maybePixels case final pixels?) {
+      correctPixels(pixels);
+    }
     applyNewViewportDimensions(
       other.metrics.viewportSize,
       other.metrics.viewportInsets,
     );
     applyNewContentSize(other.metrics.contentSize);
-    activity.takeOver(other.activity);
   }
 
   @mustCallSuper
@@ -283,11 +295,7 @@ class SheetExtent extends ChangeNotifier
     // Update the current activity before initialization.
     _activity = activity;
     activity.init(this);
-
-    if (oldActivity != null) {
-      activity.takeOver(oldActivity);
-      oldActivity.dispose();
-    }
+    oldActivity?.dispose();
   }
 
   void goIdle() {
@@ -322,7 +330,7 @@ class SheetExtent extends ChangeNotifier
 
   @override
   void dispose() {
-    activity.dispose();
+    _activity?.dispose();
     super.dispose();
   }
 

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -149,6 +149,7 @@ class _NavigationSheetExtent extends SheetExtent {
       // Prevent the scope keys in `other._localExtentScopeKeyRegistry` from
       // being discarded when `other` is disposed.
       other._localExtentScopeKeyRegistry.clear();
+      assert(_debugAssertActivityTypeConsistency());
     }
   }
 
@@ -203,6 +204,8 @@ class _NavigationSheetExtent extends SheetExtent {
       case _:
         goIdle();
     }
+
+    assert(_debugAssertActivityTypeConsistency());
   }
 
   @override
@@ -213,6 +216,24 @@ class _NavigationSheetExtent extends SheetExtent {
       case _:
         super.goIdle();
     }
+  }
+
+  bool _debugAssertActivityTypeConsistency() {
+    assert(
+      () {
+        switch ((_lastReportedTransition, activity)) {
+          case (NoTransition(), _ProxySheetActivity()):
+          case (ForwardTransition(), _TransitionSheetActivity()):
+          case (BackwardTransition(), _TransitionSheetActivity()):
+          case (UserGestureTransition(), _TransitionSheetActivity()):
+          case (null, _):
+            return true;
+          case _:
+            return false;
+        }
+      }(),
+    );
+    return true;
   }
 }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -81,10 +81,10 @@ class SheetContentScrollController extends ScrollController {
     super.debugLabel,
     super.initialScrollOffset,
     super.keepScrollOffset,
-    required this.extent,
+    required this.getDelegate,
   });
 
-  final SheetExtent extent;
+  final ValueGetter<ScrollPositionDelegate?> getDelegate;
 
   @override
   ScrollPosition createScrollPosition(
@@ -93,10 +93,7 @@ class SheetContentScrollController extends ScrollController {
     ScrollPosition? oldPosition,
   ) {
     return DelegatableScrollPosition(
-      getDelegate: () => switch (extent.activity) {
-        final ScrollPositionDelegate delegate => delegate,
-        _ => null,
-      },
+      getDelegate: getDelegate,
       initialPixels: initialScrollOffset,
       keepScrollOffset: keepScrollOffset,
       debugLabel: debugLabel,
@@ -114,6 +111,11 @@ class SheetContentScrollController extends ScrollController {
 /// of the scrollable content within the sheet.
 abstract class _ContentScrollDrivenSheetActivity extends SheetActivity
     with ScrollPositionDelegate {
+  @override
+  bool isCompatibleWith(SheetExtent newOwner) {
+    return newOwner is ScrollableSheetExtent;
+  }
+
   @mustCallSuper
   @override
   void onContentDragStart(


### PR DESCRIPTION
`SheetExtent.takeOver` was changed to transfer the current activity from the old extent to the new extent instead of disposing of it, so that the internal state of the activity is maintained before and after changing its owner.