### PR TITLE
Fix: Unable to build version 0.6.0 for Flutter versions < 3.22.0

### DIFF
--- a/docs/migration-guide-0.7.x.md
+++ b/docs/migration-guide-0.7.x.md
@@ -1,0 +1,7 @@
+# Migration guide to 0.7.x from 0.6.x
+
+Here is the summary of the breaking changes included in version 0.7.0.
+
+- `SheetDragStartDetails` no longer implements `DragStartDetails`
+- `SheetDragUpdateDetails` no longer implements `DragUpdateDetails`
+- `SheetDragEndDetails` no longer implements `DragEndDetails`

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0 May 30, 2024
+
+This version contains some breaking changes. See the [migration guide](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.7.x.md) for more details.
+
+- Fix: Unable to build with Flutter versions `< 3.22.0` (#141)
+
 ## 0.6.0 May 26, 2024
 
 This version contains some breaking changes. See the [migration guide](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.6.x.md) for more details.

--- a/package/lib/src/foundation/keyboard_dismissible.dart
+++ b/package/lib/src/foundation/keyboard_dismissible.dart
@@ -32,8 +32,8 @@ class SheetKeyboardDismissible extends StatelessWidget {
     Widget result = NotificationListener<SheetDragUpdateNotification>(
       onNotification: (notification) {
         final delta = switch (notification.dragDetails.axisDirection) {
-          VerticalDirection.up => notification.dragDetails.primaryDelta,
-          VerticalDirection.down => -1 * notification.dragDetails.primaryDelta,
+          VerticalDirection.up => notification.dragDetails.deltaY,
+          VerticalDirection.down => -1 * notification.dragDetails.deltaY,
         };
 
         if (primaryFocus?.hasFocus == true &&

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -196,7 +196,7 @@ class ScrollableSheetExtent extends SheetExtent<ScrollableSheetExtentConfig>
     scrollPosition.beginActivity(
       SheetContentDragScrollActivity(
         delegate: scrollPosition,
-        getLastDragDetails: () => currentDrag?.lastDetails,
+        getLastDragDetails: () => currentDrag?.lastRawDetails,
         getPointerDeviceKind: () => currentDrag?.pointerDeviceKind,
       ),
     );

--- a/package/lib/src/scrollable/sheet_content_scroll_activity.dart
+++ b/package/lib/src/scrollable/sheet_content_scroll_activity.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
-import '../foundation/sheet_drag.dart';
 import 'scrollable_sheet_activity.dart';
 import 'sheet_content_scroll_position.dart';
 
@@ -22,7 +21,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     required this.getPointerDeviceKind,
   }) : super(delegate);
 
-  final ValueGetter<SheetDragDetails?> getLastDragDetails;
+  final ValueGetter<dynamic> getLastDragDetails;
   final ValueGetter<PointerDeviceKind?> getPointerDeviceKind;
 
   @override
@@ -31,7 +30,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     BuildContext? context,
   ) {
     final lastDetails = getLastDragDetails();
-    if (lastDetails is SheetDragStartDetails) {
+    if (lastDetails is DragStartDetails) {
       ScrollStartNotification(
         metrics: metrics,
         context: context,
@@ -40,7 +39,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     } else {
       assert(() {
         throw FlutterError(
-          'Expected to have a $SheetDragStartDetails, but got $lastDetails.',
+          'Expected to have a $DragStartDetails, but got $lastDetails.',
         );
       }());
     }
@@ -53,7 +52,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     double scrollDelta,
   ) {
     final lastDetails = getLastDragDetails();
-    if (lastDetails is SheetDragUpdateDetails) {
+    if (lastDetails is DragUpdateDetails) {
       ScrollUpdateNotification(
         metrics: metrics,
         context: context,
@@ -63,7 +62,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     } else {
       assert(() {
         throw FlutterError(
-          'Expected to have a $SheetDragUpdateDetails, but got $lastDetails.',
+          'Expected to have a $DragUpdateDetails, but got $lastDetails.',
         );
       }());
     }
@@ -76,7 +75,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     double overscroll,
   ) {
     final lastDetails = getLastDragDetails();
-    if (lastDetails is SheetDragUpdateDetails) {
+    if (lastDetails is DragUpdateDetails) {
       OverscrollNotification(
         metrics: metrics,
         context: context,
@@ -86,7 +85,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     } else {
       assert(() {
         throw FlutterError(
-          'Expected to have a $SheetDragUpdateDetails, but got $lastDetails.',
+          'Expected to have a $DragUpdateDetails, but got $lastDetails.',
         );
       }());
     }
@@ -98,7 +97,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     BuildContext context,
   ) {
     final lastDetails = getLastDragDetails();
-    if (lastDetails is SheetDragEndDetails) {
+    if (lastDetails is DragEndDetails?) {
       ScrollEndNotification(
         metrics: metrics,
         context: context,
@@ -107,7 +106,7 @@ class SheetContentDragScrollActivity extends ScrollActivity {
     } else {
       assert(() {
         throw FlutterError(
-          'Expected to have a $SheetDragEndDetails, but got $lastDetails.',
+          'Expected to have a $DragEndDetails?, but got $lastDetails.',
         );
       }());
     }

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/fujidaiti/smooth_sheets
 screenshots:
   - description: Practical examples of smooth_sheets.


### PR DESCRIPTION
Fixes #144.

- `SheetDragDetails` subclasses no longer implement `Drag*Details`
- Bumped to 0.7.0
- Added a migration guide