### PR TITLE
Increase min SDK versions

### DIFF
--- a/cookbook/pubspec.yaml
+++ b/cookbook/pubspec.yaml
@@ -3,7 +3,7 @@ description: "A new Flutter project."
 publish_to: "none"
 
 environment:
-  sdk: ">=3.2.3 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   animations: ^2.0.10

--- a/docs/migration-guide-0.7.x.md
+++ b/docs/migration-guide-0.7.x.md
@@ -2,6 +2,13 @@
 
 Here is the summary of the breaking changes included in version 0.7.0.
 
-- `SheetDragStartDetails` no longer implements `DragStartDetails`
-- `SheetDragUpdateDetails` no longer implements `DragUpdateDetails`
-- `SheetDragEndDetails` no longer implements `DragEndDetails`
+## Changes in public APIs
+
+- `SheetDragStartDetails` no longer implements `DragStartDetails`.
+- `SheetDragUpdateDetails` no longer implements `DragUpdateDetails`.
+- `SheetDragEndDetails` no longer implements `DragEndDetails`.
+
+## miscellaneous
+
+- Now the package requires Dart SDK `>= 3.2.0` and Flutter SDK `3.16.0`.
+

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -7,8 +7,8 @@ screenshots:
     path: resources/smooth-sheets-thumbnail.png
 
 environment:
-  sdk: ">=3.0.6 <4.0.0"
-  flutter: ">=3.10.6"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   collection: ^1.17.1


### PR DESCRIPTION
Increased the minimum Dart SDK version to 3.2.0 and the Flutter SDK version to 3.16.0.