### PR TITLE
Do not put sheets in scaffolds

### DIFF
--- a/cookbook/lib/tutorial/declarative_navigation_sheet.dart
+++ b/cookbook/lib/tutorial/declarative_navigation_sheet.dart
@@ -128,13 +128,11 @@ class _ExampleHome extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Stack(
-        children: [
-          const Placeholder(),
-          _ExampleSheet(nestedNavigator: nestedNavigator),
-        ],
-      ),
+    return Stack(
+      children: [
+        const Scaffold(),
+        _ExampleSheet(nestedNavigator: nestedNavigator),
+      ],
     );
   }
 }

--- a/cookbook/lib/tutorial/draggable_sheet.dart
+++ b/cookbook/lib/tutorial/draggable_sheet.dart
@@ -11,15 +11,13 @@ class _BasicDraggableSheetExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(
-        // Typically, you would use a Stack to place the sheet
-        // on top of another widget.
-        body: Stack(
-          children: [
-            Placeholder(),
-            _MySheet(),
-          ],
-        ),
+      // Typically, you would use a Stack to place the sheet
+      // on top of another widget.
+      home: Stack(
+        children: [
+          Scaffold(),
+          _MySheet(),
+        ],
       ),
     );
   }

--- a/cookbook/lib/tutorial/imperative_navigation_sheet.dart
+++ b/cookbook/lib/tutorial/imperative_navigation_sheet.dart
@@ -11,13 +11,11 @@ class _ImperativeNavigationSheetExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(
-        body: Stack(
-          children: [
-            Placeholder(),
-            _ExampleSheet(),
-          ],
-        ),
+      home: Stack(
+        children: [
+          Scaffold(),
+          _ExampleSheet(),
+        ],
       ),
     );
   }

--- a/cookbook/lib/tutorial/scrollable_sheet.dart
+++ b/cookbook/lib/tutorial/scrollable_sheet.dart
@@ -11,15 +11,13 @@ class _BasicScrollableSheetExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(
-        // Typically, you would use a Stack to place the sheet
-        // on top of another widget.
-        body: Stack(
-          children: [
-            Placeholder(),
-            _MySheet(),
-          ],
-        ),
+      // Typically, you would use a Stack to place the sheet
+      // on top of another widget.
+      home: Stack(
+        children: [
+          Scaffold(),
+          _MySheet(),
+        ],
       ),
     );
   }

--- a/cookbook/lib/tutorial/sheet_content_scaffold.dart
+++ b/cookbook/lib/tutorial/sheet_content_scaffold.dart
@@ -11,14 +11,11 @@ class _SheetContentScaffoldExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: Stack(
-          children: [
-            Placeholder(),
-            _ExampleSheet(),
-          ],
-        ),
+      home: Stack(
+        children: [
+          Scaffold(),
+          _ExampleSheet(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Edited tutorial code to **not** put a sheet in a scaffold widget, to prevent the readers from being misled into putting a sheet in a scaffold, which can cause problems like #66.