### PR TITLE
Allow routes other than NavigationSheetRoute to be used in NavigationSheet

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.3 Jun 9, 2024
+
+- Fix: DropdownButton doesn't work in NavigationSheet (#139)
+
 ## 0.7.2 Jun 9, 2024
 
 - Fix: Attaching SheetController to NavigationSheet causes "Null check operator used on a null value" (#151)

--- a/package/analysis_options.yaml
+++ b/package/analysis_options.yaml
@@ -12,3 +12,4 @@ linter:
     cascade_invocations: false
     join_return_with_assignment: false
     prefer_relative_imports: true
+    unnecessary_parenthesis: false

--- a/package/lib/src/internal/transition_observer.dart
+++ b/package/lib/src/internal/transition_observer.dart
@@ -165,17 +165,6 @@ class NoTransition extends Transition {
   NoTransition({required this.currentRoute});
 
   final ModalRoute<dynamic> currentRoute;
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other is NoTransition &&
-            runtimeType == other.runtimeType &&
-            currentRoute == other.currentRoute);
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, currentRoute);
 }
 
 class ForwardTransition extends Transition {
@@ -188,24 +177,6 @@ class ForwardTransition extends Transition {
   final ModalRoute<dynamic> originRoute;
   final ModalRoute<dynamic> destinationRoute;
   final Animation<double> animation;
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other is ForwardTransition &&
-            runtimeType == other.runtimeType &&
-            originRoute == other.originRoute &&
-            destinationRoute == other.destinationRoute &&
-            animation == other.animation);
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        originRoute,
-        destinationRoute,
-        animation,
-      );
 }
 
 class BackwardTransition extends Transition {
@@ -218,24 +189,6 @@ class BackwardTransition extends Transition {
   final ModalRoute<dynamic> originRoute;
   final ModalRoute<dynamic> destinationRoute;
   final Animation<double> animation;
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other is BackwardTransition &&
-            runtimeType == other.runtimeType &&
-            originRoute == other.originRoute &&
-            destinationRoute == other.destinationRoute &&
-            animation == other.animation);
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        originRoute,
-        destinationRoute,
-        animation,
-      );
 }
 
 class UserGestureTransition extends Transition {
@@ -248,22 +201,4 @@ class UserGestureTransition extends Transition {
   final ModalRoute<dynamic> currentRoute;
   final ModalRoute<dynamic> previousRoute;
   final Animation<double> animation;
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other is UserGestureTransition &&
-            runtimeType == other.runtimeType &&
-            currentRoute == other.currentRoute &&
-            previousRoute == other.previousRoute &&
-            animation == other.animation);
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        currentRoute,
-        previousRoute,
-        animation,
-      );
 }

--- a/package/lib/src/internal/transition_observer.dart
+++ b/package/lib/src/internal/transition_observer.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 class TransitionObserver extends NavigatorObserver {
@@ -165,6 +166,10 @@ class NoTransition extends Transition {
   NoTransition({required this.currentRoute});
 
   final ModalRoute<dynamic> currentRoute;
+
+  @override
+  String toString() =>
+      '$NoTransition${(currentRoute: describeIdentity(currentRoute))}';
 }
 
 class ForwardTransition extends Transition {
@@ -177,6 +182,12 @@ class ForwardTransition extends Transition {
   final ModalRoute<dynamic> originRoute;
   final ModalRoute<dynamic> destinationRoute;
   final Animation<double> animation;
+
+  @override
+  String toString() => '$ForwardTransition${(
+        originRoute: describeIdentity(originRoute),
+        destinationRoute: describeIdentity(destinationRoute),
+      )}';
 }
 
 class BackwardTransition extends Transition {
@@ -189,6 +200,12 @@ class BackwardTransition extends Transition {
   final ModalRoute<dynamic> originRoute;
   final ModalRoute<dynamic> destinationRoute;
   final Animation<double> animation;
+
+  @override
+  String toString() => '$BackwardTransition${(
+        originRoute: describeIdentity(originRoute),
+        destinationRoute: describeIdentity(destinationRoute),
+      )}';
 }
 
 class UserGestureTransition extends Transition {
@@ -201,4 +218,10 @@ class UserGestureTransition extends Transition {
   final ModalRoute<dynamic> currentRoute;
   final ModalRoute<dynamic> previousRoute;
   final Animation<double> animation;
+
+  @override
+  String toString() => '$UserGestureTransition${(
+        currentRoute: describeIdentity(currentRoute),
+        previousRoute: describeIdentity(previousRoute),
+      )}';
 }

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -67,7 +67,7 @@ abstract class NavigationSheetRoute<T, E extends SheetExtent>
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
     return previousRoute is NavigationSheetRoute;
   }
-  
+
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     return nextRoute is NavigationSheetRoute;

--- a/package/lib/src/navigation/navigation_route.dart
+++ b/package/lib/src/navigation/navigation_route.dart
@@ -64,6 +64,16 @@ abstract class NavigationSheetRoute<T, E extends SheetExtent>
   RouteTransitionsBuilder? get transitionsBuilder;
 
   @override
+  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
+    return previousRoute is NavigationSheetRoute;
+  }
+  
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is NavigationSheetRoute;
+  }
+
+  @override
   Widget buildTransitions(
     BuildContext context,
     Animation<double> animation,

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -150,14 +150,43 @@ class NavigationSheetExtent extends SheetExtent {
     assert(
       () {
         switch ((_lastReportedTransition, activity)) {
-          case (NoTransition(), ProxySheetActivity()):
-          case (ForwardTransition(), TransitionSheetActivity()):
-          case (BackwardTransition(), TransitionSheetActivity()):
-          case (UserGestureTransition(), TransitionSheetActivity()):
-          case (null, _):
+          // Allowed patterns.
+          case (
+              NoTransition(currentRoute: NavigationSheetRoute()),
+              ProxySheetActivity(),
+            ):
+          case (
+              ForwardTransition(
+                originRoute: NavigationSheetRoute(),
+                destinationRoute: NavigationSheetRoute(),
+              ),
+              TransitionSheetActivity(),
+            ):
+          case (
+              BackwardTransition(
+                originRoute: NavigationSheetRoute(),
+                destinationRoute: NavigationSheetRoute(),
+              ),
+              TransitionSheetActivity(),
+            ):
+          case (
+              UserGestureTransition(
+                currentRoute: NavigationSheetRoute(),
+                previousRoute: NavigationSheetRoute(),
+              ),
+              TransitionSheetActivity(),
+            ):
+          case (_, final activity) when activity is! NavigationSheetActivity:
             return true;
-          case _:
-            return false;
+
+          // Other patterns are not allowed.
+          case (final transition, final activity):
+            throw FlutterError(
+              'There is an inconsistency between the current transition state '
+              'and the current activity type.\n'
+              '  Transition: $transition\n'
+              '  Activity: ${describeIdentity(activity)}\n',
+            );
         }
       }(),
     );

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -183,9 +183,9 @@ class NavigationSheetExtent extends SheetExtent {
           case (final transition, final activity):
             throw FlutterError(
               'There is an inconsistency between the current transition state '
-              'and the current activity type.\n'
+              'and the current sheet activity type.\n'
               '  Transition: $transition\n'
-              '  Activity: ${describeIdentity(activity)}\n',
+              '  Activity: ${describeIdentity(activity)}',
             );
         }
       }(),

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.7.2
+version: 0.7.3
 repository: https://github.com/fujidaiti/smooth_sheets
 screenshots:
   - description: Practical examples of smooth_sheets.


### PR DESCRIPTION
Fixes #139.

Essentially the issue was fixed by the changes in #164, so this PR just adds some missing pieces to fully support non-`NavigationSheetRoute`s in `NavigationSheet`.

- Relaxed assertion to allow routes other than `NavigationSheetRoute`.
- Removed equals and hashCode to reduce unnecessary complexity in code.
- Implemented `canTransitionFrom` and `canTransitionTo` of `NavigationSheetRoute`.
- Added a regression test of #139.
- Disabled `unneecssary_parenthesis` rule.
- Bumped the version to 0.7.3.