### PR TITLE
Fix: Opening keyboard interrupts sheet animation

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2 Jul 11, 2024
+
+- Fix: Opening keyboard interrupts sheet animation (#189)
+
 ## 0.8.1 Jun 23, 2024
 
 - Fix: Cupertino style modal transition not working with NavigationSheet (#182)

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -507,13 +507,11 @@ abstract class SheetExtent extends ChangeNotifier
     Duration duration = const Duration(milliseconds: 300),
   }) {
     assert(metrics.hasDimensions);
-    final destination = newExtent.resolve(metrics.contentSize);
-    if (metrics.pixels == destination) {
+    if (metrics.pixels == newExtent.resolve(metrics.contentSize)) {
       return Future.value();
     } else {
       final activity = AnimatedSheetActivity(
-        from: metrics.pixels,
-        to: destination,
+        destination: newExtent,
         duration: duration,
         curve: curve,
       );

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -88,6 +88,20 @@ class NavigationSheetExtent extends SheetExtent {
   }
 
   @override
+  Future<void> animateTo(
+    Extent newExtent, {
+    Curve curve = Curves.easeInOut,
+    Duration duration = const Duration(milliseconds: 300),
+  }) {
+    if (activity case ProxySheetActivity(:final route)) {
+      return route.scopeKey.currentExtent
+          .animateTo(newExtent, curve: curve, duration: duration);
+    } else {
+      return super.animateTo(newExtent, curve: curve, duration: duration);
+    }
+  }
+
+  @override
   void dispatchUpdateNotification() {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.8.1
+version: 0.8.2
 repository: https://github.com/fujidaiti/smooth_sheets
 screenshots:
   - description: Practical examples of smooth_sheets.

--- a/package/test/draggable/draggable_sheet_test.dart
+++ b/package/test/draggable/draggable_sheet_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 
+import '../src/keyboard_inset_simulation.dart';
 
 class _TestApp extends StatelessWidget {
   const _TestApp({
@@ -70,5 +71,61 @@ void main() {
 
     expect(controller.hasClient, isTrue,
         reason: 'The controller should have a client.');
+  });
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/14
+  testWidgets('Opening keyboard does not interrupt sheet animation',
+      (tester) async {
+    final controller = SheetController();
+    final sheetKey = GlobalKey();
+    final keyboardSimulationKey = GlobalKey<KeyboardInsetSimulationState>();
+
+    await tester.pumpWidget(
+      _TestApp(
+        useMaterial: true,
+        child: KeyboardInsetSimulation(
+          key: keyboardSimulationKey,
+          keyboardHeight: 200,
+          child: DraggableSheet(
+            key: sheetKey,
+            controller: controller,
+            minExtent: const Extent.pixels(200),
+            initialExtent: const Extent.pixels(200),
+            child: const Material(
+              child: _TestSheetContent(
+                height: 500,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.value.pixels, 200,
+        reason: 'The sheet should be at the initial extent.');
+    expect(controller.value.minPixels < controller.value.maxPixels, isTrue,
+        reason: 'The sheet should be draggable.');
+
+    // Start animating the sheet to the max extent.
+    unawaited(
+      controller.animateTo(
+        const Extent.proportional(1),
+        duration: const Duration(milliseconds: 250),
+      ),
+    );
+    // Then, show the keyboard while the sheet is animating.
+    unawaited(
+      keyboardSimulationKey.currentState!
+          .showKeyboard(const Duration(milliseconds: 250)),
+    );
+    await tester.pumpAndSettle();
+    expect(MediaQuery.viewInsetsOf(sheetKey.currentContext!).bottom, 200,
+        reason: 'The keyboard should be fully shown.');
+    expect(
+      controller.value.pixels,
+      controller.value.maxPixels,
+      reason: 'After the keyboard is fully shown, '
+          'the entire sheet should also be visible.',
+    );
   });
 }

--- a/package/test/draggable/draggable_sheet_test.dart
+++ b/package/test/draggable/draggable_sheet_test.dart
@@ -113,7 +113,7 @@ void main() {
         duration: const Duration(milliseconds: 250),
       ),
     );
-    // Then, show the keyboard while the sheet is animating.
+    // Then, show the keyboard while the animation is running.
     unawaited(
       keyboardSimulationKey.currentState!
           .showKeyboard(const Duration(milliseconds: 250)),

--- a/package/test/draggable/draggable_sheet_test.dart
+++ b/package/test/draggable/draggable_sheet_test.dart
@@ -1,34 +1,55 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 
-class _TestWidget extends StatelessWidget {
-  const _TestWidget({
-    this.contentKey,
-    this.contentHeight = 500,
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({
+    this.useMaterial = false,
+    required this.child,
   });
 
-  final Key? contentKey;
-  final double contentHeight;
+  final bool useMaterial;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    final content = Container(
-      key: contentKey,
-      color: Colors.white,
-      height: contentHeight,
-      width: double.infinity,
-    );
-
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(),
-        child: DraggableSheet(
-          child: content,
+    if (useMaterial) {
+      return MaterialApp(
+        home: child,
+      );
+    } else {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: child,
         ),
-      ),
+      );
+    }
+  }
+}
+
+class _TestSheetContent extends StatelessWidget {
+  const _TestSheetContent({
+    super.key,
+    this.height = 500,
+    this.child,
+  });
+
+  final double? height;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: double.infinity,
+      color: Colors.white,
+      child: child,
     );
   }
 }
@@ -39,7 +60,11 @@ void main() {
     await tester.pumpWidget(
       SheetControllerScope(
         controller: controller,
-        child: const _TestWidget(),
+        child: const _TestApp(
+          child: DraggableSheet(
+            child: _TestSheetContent(),
+          ),
+        ),
       ),
     );
 

--- a/package/test/navigation/navigation_sheet_test.dart
+++ b/package/test/navigation/navigation_sheet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
@@ -9,6 +11,8 @@ class _TestWidget extends StatelessWidget {
     required this.initialRoute,
     required this.routes,
     this.onTapBackgroundText,
+    this.sheetKey,
+    this.contentBuilder,
     this.sheetController,
     this.useMaterialApp = false,
   });
@@ -16,13 +20,16 @@ class _TestWidget extends StatelessWidget {
   final String initialRoute;
   final Map<String, ValueGetter<Route<dynamic>>> routes;
   final VoidCallback? onTapBackgroundText;
+  final Widget Function(BuildContext, Widget)? contentBuilder;
   final SheetController? sheetController;
   final NavigationSheetTransitionObserver sheetTransitionObserver;
+  final Key? sheetKey;
   final bool useMaterialApp;
 
   @override
   Widget build(BuildContext context) {
     final navigationSheet = NavigationSheet(
+      key: sheetKey,
       controller: sheetController,
       transitionObserver: sheetTransitionObserver,
       child: ColoredBox(
@@ -35,7 +42,7 @@ class _TestWidget extends StatelessWidget {
       ),
     );
 
-    final content = Stack(
+    Widget content = Stack(
       children: [
         TextButton(
           onPressed: onTapBackgroundText,
@@ -44,6 +51,10 @@ class _TestWidget extends StatelessWidget {
         navigationSheet,
       ],
     );
+
+    if (contentBuilder case final builder?) {
+      content = builder(context, content);
+    }
 
     return switch (useMaterialApp) {
       true => MaterialApp(home: content),
@@ -106,12 +117,14 @@ class _TestDraggablePageWidget extends StatelessWidget {
     required String label,
     required double height,
     String? nextRoute,
+    Extent initialExtent = const Extent.proportional(1),
     Extent minExtent = const Extent.proportional(1),
     Duration transitionDuration = const Duration(milliseconds: 300),
     SheetPhysics? physics,
   }) {
     return DraggableNavigationSheetRoute(
       physics: physics,
+      initialExtent: initialExtent,
       minExtent: minExtent,
       transitionDuration: transitionDuration,
       builder: (context) => _TestDraggablePageWidget(

--- a/package/test/navigation/navigation_sheet_test.dart
+++ b/package/test/navigation/navigation_sheet_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 
+import '../src/keyboard_inset_simulation.dart';
+
 class _TestWidget extends StatelessWidget {
   const _TestWidget(
     this.sheetTransitionObserver, {
@@ -349,6 +351,67 @@ void main() {
       expect(find.text('Option 1'), findsNothing);
       expect(find.text('Option 2'), findsOneWidget);
       expect(find.text('Option 3'), findsNothing);
+    },
+  );
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/14
+  testWidgets(
+    'Opening keyboard does not interrupts sheet animation',
+    (tester) async {
+      final controller = SheetController();
+      final sheetKey = GlobalKey();
+      final keyboardSimulationKey = GlobalKey<KeyboardInsetSimulationState>();
+
+      await tester.pumpWidget(
+        _TestWidget(
+          transitionObserver,
+          sheetController: controller,
+          sheetKey: sheetKey,
+          initialRoute: 'first',
+          routes: {
+            'first': () => _TestDraggablePageWidget.createRoute(
+                  label: 'First',
+                  height: 500,
+                  minExtent: const Extent.pixels(200),
+                  initialExtent: const Extent.pixels(200),
+                ),
+          },
+          contentBuilder: (context, child) {
+            return KeyboardInsetSimulation(
+              key: keyboardSimulationKey,
+              keyboardHeight: 200,
+              child: child,
+            );
+          },
+        ),
+      );
+
+      expect(controller.value.pixels, 200,
+          reason: 'The sheet should be at the initial extent.');
+      expect(controller.value.minPixels < controller.value.maxPixels, isTrue,
+          reason: 'The sheet should be draggable.');
+
+      // Start animating the sheet to the max extent.
+      unawaited(
+        controller.animateTo(
+          const Extent.proportional(1),
+          duration: const Duration(milliseconds: 250),
+        ),
+      );
+      // Then, show the keyboard while the sheet is animating.
+      unawaited(
+        keyboardSimulationKey.currentState!
+            .showKeyboard(const Duration(milliseconds: 250)),
+      );
+      await tester.pumpAndSettle();
+      expect(MediaQuery.viewInsetsOf(sheetKey.currentContext!).bottom, 200,
+          reason: 'The keyboard should be fully shown.');
+      expect(
+        controller.value.pixels,
+        controller.value.maxPixels,
+        reason: 'After the keyboard is fully shown, '
+            'the entire sheet should also be visible.',
+      );
     },
   );
 }

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -1,45 +1,63 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 
-class _TestWidget extends StatelessWidget {
-  const _TestWidget({
-    this.contentKey,
-    this.contentHeight,
-    this.scrollPhysics = const ClampingScrollPhysics(),
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({
+    this.useMaterial = false,
+    required this.child,
   });
 
-  final Key? contentKey;
-  final double? contentHeight;
-  final ScrollPhysics scrollPhysics;
+  final bool useMaterial;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    Widget content = Material(
-      color: Colors.white,
-      child: ListView(
-        key: contentKey,
-        physics: scrollPhysics,
-        children: List.generate(
-          30,
-          (index) => ListTile(
-            title: Text('Item $index'),
-          ),
+    if (useMaterial) {
+      return MaterialApp(
+        home: child,
+      );
+    } else {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: child,
         ),
-      ),
-    );
-
-    if (contentHeight case final height?) {
-      content = SizedBox(height: height, child: content);
+      );
     }
+  }
+}
 
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(),
-        child: ScrollableSheet(
-          child: content,
+class _TestSheetContent extends StatelessWidget {
+  const _TestSheetContent({
+    super.key,
+    this.height = 500,
+    // Disable the snapping effect by default in tests.
+    this.scrollPhysics = const ClampingScrollPhysics(),
+  });
+
+  final double? height;
+  final ScrollPhysics? scrollPhysics;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Material(
+        color: Colors.white,
+        child: ListView(
+          physics: scrollPhysics,
+          children: List.generate(
+            30,
+            (index) => ListTile(
+              title: Text('Item $index'),
+            ),
+          ),
         ),
       ),
     );
@@ -52,7 +70,11 @@ void main() {
     await tester.pumpWidget(
       SheetControllerScope(
         controller: controller,
-        child: const _TestWidget(),
+        child: const _TestApp(
+          child: ScrollableSheet(
+            child: _TestSheetContent(),
+          ),
+        ),
       ),
     );
 

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
 
+import '../src/keyboard_inset_simulation.dart';
 
 class _TestApp extends StatelessWidget {
   const _TestApp({
@@ -80,5 +81,61 @@ void main() {
 
     expect(controller.hasClient, isTrue,
         reason: 'The controller should have a client.');
+  });
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/14
+  testWidgets('Opening keyboard does not interrupt sheet animation',
+      (tester) async {
+    final controller = SheetController();
+    final sheetKey = GlobalKey();
+    final keyboardSimulationKey = GlobalKey<KeyboardInsetSimulationState>();
+
+    await tester.pumpWidget(
+      _TestApp(
+        useMaterial: true,
+        child: KeyboardInsetSimulation(
+          key: keyboardSimulationKey,
+          keyboardHeight: 200,
+          child: DraggableSheet(
+            key: sheetKey,
+            controller: controller,
+            minExtent: const Extent.pixels(200),
+            initialExtent: const Extent.pixels(200),
+            child: const Material(
+              child: _TestSheetContent(
+                height: 500,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.value.pixels, 200,
+        reason: 'The sheet should be at the initial extent.');
+    expect(controller.value.minPixels < controller.value.maxPixels, isTrue,
+        reason: 'The sheet should be draggable.');
+
+    // Start animating the sheet to the max extent.
+    unawaited(
+      controller.animateTo(
+        const Extent.proportional(1),
+        duration: const Duration(milliseconds: 250),
+      ),
+    );
+    // Then, show the keyboard while the sheet is animating.
+    unawaited(
+      keyboardSimulationKey.currentState!
+          .showKeyboard(const Duration(milliseconds: 250)),
+    );
+    await tester.pumpAndSettle();
+    expect(MediaQuery.viewInsetsOf(sheetKey.currentContext!).bottom, 200,
+        reason: 'The keyboard should be fully shown.');
+    expect(
+      controller.value.pixels,
+      controller.value.maxPixels,
+      reason: 'After the keyboard is fully shown, '
+          'the entire sheet should also be visible.',
+    );
   });
 }

--- a/package/test/src/keyboard_inset_simulation.dart
+++ b/package/test/src/keyboard_inset_simulation.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// A widget that simulates [MediaQueryData.viewInsets] as if the keyboard
-/// is shown for testing purposes.
+/// is shown.
 ///
 /// This exposes a [MediaQueryData] to its descendants, and if
 /// [KeyboardInsetSimulationState.showKeyboard] is called once,

--- a/package/test/src/keyboard_inset_simulation.dart
+++ b/package/test/src/keyboard_inset_simulation.dart
@@ -1,5 +1,12 @@
 import 'package:flutter/material.dart';
 
+/// A widget that simulates [MediaQueryData.viewInsets] as if the keyboard
+/// is shown for testing purposes.
+///
+/// This exposes a [MediaQueryData] to its descendants, and if
+/// [KeyboardInsetSimulationState.showKeyboard] is called once,
+/// it will gradually increase the `MediaQueryData.viewInsets.bottom`
+/// to the given [keyboardHeight] as if the on-screen keyboard is appearing.
 class KeyboardInsetSimulation extends StatefulWidget {
   const KeyboardInsetSimulation({
     super.key,

--- a/package/test/src/keyboard_inset_simulation.dart
+++ b/package/test/src/keyboard_inset_simulation.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class KeyboardInsetSimulation extends StatefulWidget {
+  const KeyboardInsetSimulation({
+    super.key,
+    required this.keyboardHeight,
+    required this.child,
+  });
+
+  final double keyboardHeight;
+  final Widget child;
+
+  @override
+  State<KeyboardInsetSimulation> createState() =>
+      KeyboardInsetSimulationState();
+}
+
+class KeyboardInsetSimulationState extends State<KeyboardInsetSimulation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  Future<void> showKeyboard(Duration duration) async {
+    assert(_controller.isDismissed);
+    return _controller.animateTo(widget.keyboardHeight, duration: duration);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      lowerBound: 0,
+      upperBound: widget.keyboardHeight,
+    )..addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(KeyboardInsetSimulation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    assert(widget.keyboardHeight == oldWidget.keyboardHeight);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inheritedMediaQuery = MediaQuery.of(context);
+    return MediaQuery(
+      data: inheritedMediaQuery.copyWith(
+        viewInsets: inheritedMediaQuery.viewInsets.copyWith(
+          bottom: _controller.value,
+        ),
+      ),
+      child: widget.child,
+    );
+  }
+}

--- a/package/test/src/keyboard_inset_simulation.dart
+++ b/package/test/src/keyboard_inset_simulation.dart
@@ -9,8 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 /// it will gradually increase the `MediaQueryData.viewInsets.bottom`
 /// to the given [keyboardHeight] as if the on-screen keyboard is appearing.
 ///
-/// We use this in tests to simulate the keyboard appearance instead of
-/// [WidgetTester.showKeyboard], as it does not change the `viewInsets` value.
+/// Although there is [WidgetTester.showKeyboard] method, we use this widget
+/// instead to simulate the keyboard appearance, as `showKeyboard` does not
+/// change the `viewInsets` value.
 class KeyboardInsetSimulation extends StatefulWidget {
   const KeyboardInsetSimulation({
     super.key,

--- a/package/test/src/keyboard_inset_simulation.dart
+++ b/package/test/src/keyboard_inset_simulation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /// A widget that simulates [MediaQueryData.viewInsets] as if the keyboard
 /// is shown.
@@ -7,6 +8,9 @@ import 'package:flutter/material.dart';
 /// [KeyboardInsetSimulationState.showKeyboard] is called once,
 /// it will gradually increase the `MediaQueryData.viewInsets.bottom`
 /// to the given [keyboardHeight] as if the on-screen keyboard is appearing.
+///
+/// We use this in tests to simulate the keyboard appearance instead of
+/// [WidgetTester.showKeyboard], as it does not change the `viewInsets` value.
 class KeyboardInsetSimulation extends StatefulWidget {
   const KeyboardInsetSimulation({
     super.key,


### PR DESCRIPTION
Fixes #14.

The sheet position adjustment strategy of `AnimatedSheetActivity`, which is used when either the sheet content size or the viewport size changes, was modified to:

1. append the delta of `MediaQueryData.viewInsets.bottom` (the keyboard height) to keep the visual sheet position unchanged, and
3. if the animation is still running, start a new linear animation to bring the sheet position to the recalculated final position in the remaining duration. We use a linear curve here because starting a curved animation in the middle of another curved animation tends to look jerky.