### PR TITLE
Fix: Momentum scrolling continues despite press and hold in list view

### DIFF
--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -12,6 +12,18 @@ import 'scrollable_sheet_extent.dart';
 import 'sheet_content_scroll_activity.dart';
 import 'sheet_content_scroll_position.dart';
 
+/// A [SheetActivity] that is associated with a [SheetContentScrollPosition].
+///
+/// This activity is responsible for both scrolling a scrollable content
+/// in the sheet and dragging the sheet itself.
+///
+/// [shouldIgnorePointer] and [SheetContentScrollPosition.shouldIgnorePointer]
+/// of the associated scroll position may be synchronized, but not always.
+/// For example, [BallisticScrollDrivenSheetActivity]'s [shouldIgnorePointer]
+/// is always `false` while the associated scroll position sets it to `true`
+/// in most cases to ensure that the pointer events, which potentially
+/// interrupt the ballistic scroll animation, are not stolen by clickable
+/// items in the scroll view.
 @internal
 abstract class ScrollableSheetActivity
     extends SheetActivity<ScrollableSheetExtent> {
@@ -196,7 +208,6 @@ class DragScrollDrivenSheetActivity extends ScrollableSheetActivity
       ..didDragEnd(details)
       ..goBallisticWithScrollPosition(
         velocity: -1 * details.velocityY,
-        shouldIgnorePointer: false,
         scrollPosition: scrollPosition,
       );
   }
@@ -215,13 +226,9 @@ class BallisticScrollDrivenSheetActivity extends ScrollableSheetActivity
     super.scrollPosition, {
     required this.simulation,
     required double initialPixels,
-    required this.shouldIgnorePointer,
   }) : _oldPixels = initialPixels;
 
   final Simulation simulation;
-
-  @override
-  final bool shouldIgnorePointer;
 
   double _oldPixels;
 
@@ -271,7 +278,6 @@ class BallisticScrollDrivenSheetActivity extends ScrollableSheetActivity
   void _end() {
     owner.goBallisticWithScrollPosition(
       velocity: 0,
-      shouldIgnorePointer: shouldIgnorePointer,
       scrollPosition: scrollPosition,
     );
   }

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -161,7 +161,6 @@ class ScrollableSheetExtent extends SheetExtent
   @override
   void goBallisticWithScrollPosition({
     required double velocity,
-    required bool shouldIgnorePointer,
     required SheetContentScrollPosition scrollPosition,
   }) {
     assert(metrics.hasDimensions);
@@ -196,13 +195,12 @@ class ScrollableSheetExtent extends SheetExtent
           scrollPosition,
           simulation: scrollSimulation,
           initialPixels: scrollPixelsForScrollPhysics,
-          shouldIgnorePointer: shouldIgnorePointer,
         ),
       );
       scrollPosition.beginActivity(
         SheetContentBallisticScrollActivity(
           delegate: scrollPosition,
-          shouldIgnorePointer: shouldIgnorePointer,
+          shouldIgnorePointer: scrollPosition.shouldIgnorePointer,
           getVelocity: () => activity.velocity,
         ),
       );

--- a/package/lib/src/scrollable/sheet_content_scroll_position.dart
+++ b/package/lib/src/scrollable/sheet_content_scroll_position.dart
@@ -32,7 +32,6 @@ abstract class SheetContentScrollPositionOwner {
 
   void goBallisticWithScrollPosition({
     required double velocity,
-    required bool shouldIgnorePointer,
     required SheetContentScrollPosition scrollPosition,
   });
 }
@@ -68,6 +67,10 @@ class SheetContentScrollPosition extends ScrollPositionWithSingleContext {
   /// being used from outside of this object.
   double _heldPreviousVelocity = 0.0;
   double get heldPreviousVelocity => _heldPreviousVelocity;
+
+  /// Whether the scroll view should prevent its contents from receiving
+  /// pointer events.
+  bool get shouldIgnorePointer => activity!.shouldIgnorePointer;
 
   /// Sets the user scroll direction.
   ///
@@ -123,7 +126,6 @@ class SheetContentScrollPosition extends ScrollPositionWithSingleContext {
     if (owner != null && owner.hasPrimaryScrollPosition && !calledByOwner) {
       owner.goBallisticWithScrollPosition(
         velocity: velocity,
-        shouldIgnorePointer: activity?.shouldIgnorePointer ?? true,
         scrollPosition: this,
       );
       return;

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -101,11 +101,7 @@ void main() {
             controller: controller,
             minExtent: const Extent.pixels(200),
             initialExtent: const Extent.pixels(200),
-            child: const Material(
-              child: _TestSheetContent(
-                height: 500,
-              ),
-            ),
+            child: const _TestSheetContent(height: 500),
           ),
         ),
       ),


### PR DESCRIPTION
## Fixes / Closes (optional)

Fixes #190.

## Description

This PR fixes an incorrect use of the `ScrollActivity.shouldIgnorePointer` flag that has caused the issue.

Previously, `DragScrollDrivenSheetActivity` used to start a `SheetContentBallisticScrollActivity` with `shouldIgnorePointer` set to `false` when a drag gesture ended. However, it should actually be `true` except in a special case. This is because setting `ScrollActivity.shouldIgnorePointer` to `true` means that clickable items in the scroll view cannot receive pointer events while performing that activity, and the scroll view may receive them instead. So if the flag is set to `false` during a ballistic scroll animation and there are any clickable items in the scroll view, the scroll view may not be able to receive the pointer events, resulting in the ballistic scroll animation not stopping in response to user gestures.

After this PR is merged, `SheetContentBallisticScrollActivity` will be started with the same value of `shouldIgnorePointer` as the previous `ScrollActivity`. Note that we can't use a hardcoded value of `true` here, as it may need to be `false` in a special case where the pointer device kind is `PointerDeviceKind.trackpad`.

## Summary (check all that apply)

- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
