### PR TITLE
Prefer composition style for SheetKeyboardDismissible

### DIFF
--- a/cookbook/lib/showcase/safari/bookmark.dart
+++ b/cookbook/lib/showcase/safari/bookmark.dart
@@ -27,32 +27,34 @@ class EditBookmarkSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DraggableSheet(
-      keyboardDismissBehavior: const SheetKeyboardDismissBehavior.onDragDown(),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(16),
-        child: SheetContentScaffold(
-          backgroundColor: CupertinoColors.systemGroupedBackground,
-          appBar: CupertinoAppBar(
-            title: const Text('Add Bookmark'),
-            leading: CupertinoButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Cancel'),
+    return SheetKeyboardDismissible(
+      dismissBehavior: const SheetKeyboardDismissBehavior.onDragDown(),
+      child: DraggableSheet(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(16),
+          child: SheetContentScaffold(
+            backgroundColor: CupertinoColors.systemGroupedBackground,
+            appBar: CupertinoAppBar(
+              title: const Text('Add Bookmark'),
+              leading: CupertinoButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              trailing: CupertinoButton(
+                onPressed: () =>
+                    Navigator.popUntil(context, (route) => route.isFirst),
+                child: const Text('Save'),
+              ),
             ),
-            trailing: CupertinoButton(
-              onPressed: () =>
-                  Navigator.popUntil(context, (route) => route.isFirst),
-              child: const Text('Save'),
-            ),
-          ),
-          body: SizedBox.expand(
-            child: CupertinoListSection.insetGrouped(
-              children: [
-                _BookmarkEditor(
-                  pageUrl: pageUrl,
-                  faviconUrl: faviconUrl,
-                ),
-              ],
+            body: SizedBox.expand(
+              child: CupertinoListSection.insetGrouped(
+                children: [
+                  _BookmarkEditor(
+                    pageUrl: pageUrl,
+                    faviconUrl: faviconUrl,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/cookbook/lib/showcase/todo_list/todo_editor.dart
+++ b/cookbook/lib/showcase/todo_list/todo_editor.dart
@@ -144,21 +144,22 @@ class _TodoEditorState extends State<TodoEditor> {
       child: PopScope(
         canPop: false,
         onPopInvoked: onPopInvoked,
-        child: ScrollableSheet(
-          keyboardDismissBehavior:
-              const SheetKeyboardDismissBehavior.onDragDown(
+        child: SheetKeyboardDismissible(
+          dismissBehavior: const SheetKeyboardDismissBehavior.onDragDown(
             isContentScrollAware: true,
           ),
-          child: Container(
-            clipBehavior: Clip.antiAlias,
-            decoration: sheetShape,
-            child: SheetContentScaffold(
-              resizeBehavior: const ResizeScaffoldBehavior.avoidBottomInset(
-                // Make the bottom bar visible when the keyboard is open.
-                maintainBottomBar: true,
+          child: ScrollableSheet(
+            child: Container(
+              clipBehavior: Clip.antiAlias,
+              decoration: sheetShape,
+              child: SheetContentScaffold(
+                resizeBehavior: const ResizeScaffoldBehavior.avoidBottomInset(
+                  // Make the bottom bar visible when the keyboard is open.
+                  maintainBottomBar: true,
+                ),
+                body: body,
+                bottomBar: bottomBar,
               ),
-              body: body,
-              bottomBar: bottomBar,
             ),
           ),
         ),

--- a/cookbook/lib/tutorial/keyboard_dismiss_behavior.dart
+++ b/cookbook/lib/tutorial/keyboard_dismiss_behavior.dart
@@ -28,10 +28,6 @@ enum _KeyboardDismissBehaviorKind {
   onDragUp(
     'onDragUp',
     'Dismisses the keyboard only when the user drags the sheet upwards.',
-  ),
-  none(
-    'Null',
-    'Does not automatically dismiss the keyboard.',
   );
 
   final String name;
@@ -49,7 +45,7 @@ class _ExampleHome extends StatefulWidget {
 
 class _ExampleHomeState extends State<_ExampleHome> {
   _KeyboardDismissBehaviorKind selectedBehavior =
-      _KeyboardDismissBehaviorKind.none;
+      _KeyboardDismissBehaviorKind.onDrag;
   bool isContentScrollAware = false;
   bool isFullScreen = false;
 
@@ -122,7 +118,6 @@ class _ExampleHomeState extends State<_ExampleHome> {
   void showExampleSheet(BuildContext context) {
     // This object determines when the sheet should dismisses the on-screen keyboard.
     final keyboardDismissBehavior = switch (selectedBehavior) {
-      _KeyboardDismissBehaviorKind.none => null,
       _KeyboardDismissBehaviorKind.onDrag =>
         SheetKeyboardDismissBehavior.onDrag(
             isContentScrollAware: isContentScrollAware),
@@ -173,25 +168,27 @@ class _ExampleSheet extends StatelessWidget {
 
     return SafeArea(
       bottom: false,
-      child: ScrollableSheet(
-        keyboardDismissBehavior: keyboardDismissBehavior,
-        child: SheetContentScaffold(
-          appBar: AppBar(),
-          body: body,
-          bottomBar: StickyBottomBarVisibility(
-            child: BottomAppBar(
-              child: Row(
-                children: [
-                  IconButton(
-                    onPressed: () {},
-                    icon: const Icon(Icons.menu),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    onPressed: () {},
-                    icon: const Icon(Icons.more_vert),
-                  ),
-                ],
+      child: SheetKeyboardDismissible(
+        dismissBehavior: keyboardDismissBehavior,
+        child: ScrollableSheet(
+          child: SheetContentScaffold(
+            appBar: AppBar(),
+            body: body,
+            bottomBar: StickyBottomBarVisibility(
+              child: BottomAppBar(
+                child: Row(
+                  children: [
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(Icons.menu),
+                    ),
+                    const Spacer(),
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(Icons.more_vert),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/docs/migration-guide-0.9.x.md
+++ b/docs/migration-guide-0.9.x.md
@@ -1,0 +1,41 @@
+# Migration guide to 0.9.x from 0.8.x
+
+## keyboardDismissBehavior is now a widget instead of a property
+
+`*Sheet.keyboardDismissBehavior` is now removed and replaced with `SheetKeyboardDismissible` widget. You can retain existing behavior by wrapping a sheet with `SheetKeyboardDismissible` and setting the same `KeyboardDismissBehavior` object to its `dismissBehavior` property.
+
+### Removed APIs
+
+- `ScrollableSheet.keyboardDismissBehavior`
+- `DraggableSheet.keyboardDismissBehavior`
+- `NavigationSheet.keyboardDismissBehavior`
+
+### Before
+
+```dart
+DraggableSheet(
+  keyboardDismissBehavior: const KeyboardDismissBehavior.onDrag(),
+  child: Container(
+    color: Colors.white,
+    width: double.infinity,
+    height: 500,
+  )
+);
+```
+
+### After
+
+Wrap a sheet with `SheetKeyboardDismissible` widget (the same applies to `ScrollableSheet` and `NavigationSheet`).
+
+```dart
+SheetKeyboardDismissible(
+  dismissBehavior: const KeyboardDismissBehavior.onDrag(),
+  child: DraggableSheet(
+    child: Container(
+      color: Colors.white,
+      width: double.infinity,
+      height: 500,
+    ),
+  ),
+);
+```

--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../foundation/keyboard_dismissible.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
@@ -32,7 +31,6 @@ class DraggableSheet extends StatelessWidget {
   const DraggableSheet({
     super.key,
     this.hitTestBehavior = HitTestBehavior.translucent,
-    this.keyboardDismissBehavior,
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
@@ -40,9 +38,6 @@ class DraggableSheet extends StatelessWidget {
     required this.child,
     this.controller,
   });
-
-  /// The strategy to dismiss the on-screen keyboard when the sheet is dragged.
-  final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
 
   final Extent initialExtent;
 
@@ -70,12 +65,10 @@ class DraggableSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
     final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
-    final keyboardDismissBehavior =
-        this.keyboardDismissBehavior ?? theme?.keyboardDismissBehavior;
     final gestureTamper = TamperSheetGesture.maybeOf(context);
     final controller = this.controller ?? SheetControllerScope.maybeOf(context);
 
-    Widget result = DraggableSheetExtentScope(
+    return DraggableSheetExtentScope(
       controller: controller,
       initialExtent: initialExtent,
       minExtent: minExtent,
@@ -92,14 +85,5 @@ class DraggableSheet extends StatelessWidget {
         ),
       ),
     );
-
-    if (keyboardDismissBehavior != null) {
-      result = SheetKeyboardDismissible(
-        dismissBehavior: keyboardDismissBehavior,
-        child: result,
-      );
-    }
-
-    return result;
   }
 }

--- a/package/lib/src/foundation/keyboard_dismissible.dart
+++ b/package/lib/src/foundation/keyboard_dismissible.dart
@@ -1,18 +1,31 @@
 import 'package:flutter/widgets.dart';
-import '../draggable/draggable_sheet.dart';
+
 import 'sheet_notification.dart';
+import 'sheet_theme.dart';
 
 /// A widget that dismisses the on-screen keyboard when the user
 /// drags the sheet below this widget.
 ///
-/// It is rarely used directly since the sheets internally have this widget
-/// and expose a slot for a [SheetKeyboardDismissBehavior], which is directly
-/// passed to this widget.
+/// The following snippet is an example of a sheet in which the on-screen
+/// keyboard is dismissed when the user drags the sheet downwards:
+///
+/// ```dart
+/// return SheetKeyboardDismissible(
+///   dismissBehavior: const SheetKeyboardDismissBehavior.onDragDown(),
+///   child: DraggableSheet(
+///     child: Container(
+///       color: Colors.white,
+///       width: double.infinity,
+///       height: 500,
+///     ),
+///   ),
+/// );
+/// ```
 ///
 /// See also:
-/// - [DraggableSheet.keyboardDismissBehavior], which is the slot for
-///   a custom [SheetKeyboardDismissBehavior].
-class SheetKeyboardDismissible extends StatelessWidget {
+/// - [SheetKeyboardDismissBehavior], which determines when the on-screen
+/// keyboard should be dismissed.
+class SheetKeyboardDismissible extends StatefulWidget {
   /// Creates a widget that dismisses the on-screen keyboard when the user
   /// drags the sheet below this widget.
   const SheetKeyboardDismissible({
@@ -22,10 +35,26 @@ class SheetKeyboardDismissible extends StatelessWidget {
   });
 
   /// Determines when the on-screen keyboard should be dismissed.
-  final SheetKeyboardDismissBehavior dismissBehavior;
+  ///
+  /// If null, [SheetThemeData.keyboardDismissBehavior] obtained by
+  /// [SheetTheme.maybeOf] will be used. If that is also null,
+  /// [DragSheetKeyboardDismissBehavior] with `isContentScrollAware` set to
+  /// `false` will be used as a fallback.
+  final SheetKeyboardDismissBehavior? dismissBehavior;
 
   /// The widget below this widget in the tree.
   final Widget child;
+
+  @override
+  State<SheetKeyboardDismissible> createState() =>
+      _SheetKeyboardDismissibleState();
+}
+
+class _SheetKeyboardDismissibleState extends State<SheetKeyboardDismissible> {
+  SheetKeyboardDismissBehavior get _dismissBehavior =>
+      widget.dismissBehavior ??
+      SheetTheme.maybeOf(context)?.keyboardDismissBehavior ??
+      const DragSheetKeyboardDismissBehavior();
 
   @override
   Widget build(BuildContext context) {
@@ -37,22 +66,22 @@ class SheetKeyboardDismissible extends StatelessWidget {
         };
 
         if (primaryFocus?.hasFocus == true &&
-            dismissBehavior.shouldDismissKeyboard(delta)) {
+            _dismissBehavior.shouldDismissKeyboard(delta)) {
           primaryFocus!.unfocus();
         }
         return false;
       },
-      child: child,
+      child: widget.child,
     );
 
-    if (dismissBehavior.isContentScrollAware) {
+    if (_dismissBehavior.isContentScrollAware) {
       result = NotificationListener<ScrollUpdateNotification>(
         onNotification: (notification) {
           final dragDelta = notification.dragDetails?.delta.dy;
           if (notification.depth == 0 &&
               dragDelta != null &&
               primaryFocus?.hasFocus == true &&
-              dismissBehavior.shouldDismissKeyboard(-1 * dragDelta)) {
+              _dismissBehavior.shouldDismissKeyboard(-1 * dragDelta)) {
             primaryFocus!.unfocus();
           }
           return false;

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../foundation/keyboard_dismissible.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent_scope.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
-import '../foundation/sheet_theme.dart';
 import '../foundation/sheet_viewport.dart';
 import '../internal/transition_observer.dart';
 import 'navigation_sheet_extent.dart';
@@ -18,7 +16,6 @@ class NavigationSheet extends StatefulWidget with TransitionAwareWidgetMixin {
   const NavigationSheet({
     super.key,
     required this.transitionObserver,
-    this.keyboardDismissBehavior,
     this.controller,
     required this.child,
   });
@@ -26,7 +23,6 @@ class NavigationSheet extends StatefulWidget with TransitionAwareWidgetMixin {
   @override
   final NavigationSheetTransitionObserver transitionObserver;
 
-  final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
   final SheetController? controller;
   final Widget child;
 
@@ -47,14 +43,11 @@ class _NavigationSheetState extends State<NavigationSheet>
 
   @override
   Widget build(BuildContext context) {
-    final theme = SheetTheme.maybeOf(context);
-    final keyboardDismissBehavior =
-        widget.keyboardDismissBehavior ?? theme?.keyboardDismissBehavior;
     final gestureTamper = TamperSheetGesture.maybeOf(context);
     final controller =
         widget.controller ?? SheetControllerScope.maybeOf(context);
 
-    Widget result = NavigationSheetExtentScope(
+    return NavigationSheetExtentScope(
       key: _scopeKey,
       controller: controller,
       gestureTamperer: gestureTamper,
@@ -63,14 +56,5 @@ class _NavigationSheetState extends State<NavigationSheet>
         child: SheetContentViewport(child: widget.child),
       ),
     );
-
-    if (keyboardDismissBehavior != null) {
-      result = SheetKeyboardDismissible(
-        dismissBehavior: keyboardDismissBehavior,
-        child: result,
-      );
-    }
-
-    return result;
   }
 }

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
-import '../foundation/keyboard_dismissible.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
@@ -16,7 +15,6 @@ import 'sheet_scrollable.dart';
 class ScrollableSheet extends StatelessWidget {
   const ScrollableSheet({
     super.key,
-    this.keyboardDismissBehavior,
     this.initialExtent = const Extent.proportional(1),
     this.minExtent = const Extent.proportional(1),
     this.maxExtent = const Extent.proportional(1),
@@ -24,9 +22,6 @@ class ScrollableSheet extends StatelessWidget {
     this.controller,
     required this.child,
   });
-
-  /// The strategy to dismiss the on-screen keyboard when the sheet is dragged.
-  final SheetKeyboardDismissBehavior? keyboardDismissBehavior;
 
   /// {@macro ScrollableSheetExtent.initialExtent}
   final Extent initialExtent;
@@ -50,12 +45,10 @@ class ScrollableSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
     final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
-    final keyboardDismissBehavior =
-        this.keyboardDismissBehavior ?? theme?.keyboardDismissBehavior;
     final gestureTamper = TamperSheetGesture.maybeOf(context);
     final controller = this.controller ?? SheetControllerScope.maybeOf(context);
 
-    Widget result = ScrollableSheetExtentScope(
+    return ScrollableSheetExtentScope(
       controller: controller,
       initialExtent: initialExtent,
       minExtent: minExtent,
@@ -69,15 +62,6 @@ class ScrollableSheet extends StatelessWidget {
         ),
       ),
     );
-
-    if (keyboardDismissBehavior != null) {
-      result = SheetKeyboardDismissible(
-        dismissBehavior: keyboardDismissBehavior,
-        child: result,
-      );
-    }
-
-    return result;
   }
 }
 

--- a/package/test/draggable/draggable_sheet_test.dart
+++ b/package/test/draggable/draggable_sheet_test.dart
@@ -128,4 +128,68 @@ void main() {
           'the entire sheet should also be visible.',
     );
   });
+
+  group('SheetKeyboardDismissible', () {
+    late FocusNode focusNode;
+    late ScrollController scrollController;
+    late Widget testWidget;
+
+    setUp(() {
+      focusNode = FocusNode();
+      scrollController = ScrollController();
+      testWidget = _TestApp(
+        useMaterial: true,
+        child: SheetKeyboardDismissible(
+          dismissBehavior: const SheetKeyboardDismissBehavior.onDrag(
+            isContentScrollAware: true,
+          ),
+          child: DraggableSheet(
+            child: Material(
+              child: TextField(
+                focusNode: focusNode,
+                scrollController: scrollController,
+                maxLines: 2,
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    tearDown(() {
+      focusNode.dispose();
+      scrollController.dispose();
+    });
+
+    testWidgets('should dismiss the keyboard when dragging', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      final textField = find.byType(TextField);
+      await tester.showKeyboard(textField);
+      expect(focusNode.hasFocus, isTrue,
+          reason: 'The keyboard should be shown.');
+
+      await tester.drag(textField, const Offset(0, -40));
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isFalse,
+          reason: 'Downward dragging should dismiss the keyboard.');
+    });
+
+    testWidgets('should dismiss the keyboard when scrolling', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      final textField = find.byType(TextField);
+      await tester.enterText(textField, 'Hello, world! ' * 100);
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isTrue,
+          reason: 'The keyboard should be shown.');
+      expect(scrollController.position.extentBefore, greaterThan(0),
+          reason: 'The text field should be able to scroll downwards.');
+
+      await tester.drag(textField, const Offset(0, 40));
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isFalse,
+          reason: 'Downward dragging should dismiss the keyboard.');
+    });
+  });
 }

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -96,7 +96,7 @@ void main() {
         child: KeyboardInsetSimulation(
           key: keyboardSimulationKey,
           keyboardHeight: 200,
-          child: DraggableSheet(
+          child: ScrollableSheet(
             key: sheetKey,
             controller: controller,
             minExtent: const Extent.pixels(200),

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -138,4 +138,71 @@ void main() {
           'the entire sheet should also be visible.',
     );
   });
+
+  group('SheetKeyboardDismissible', () {
+    late FocusNode focusNode;
+    late Widget testWidget;
+
+    setUp(() {
+      focusNode = FocusNode();
+      testWidget = _TestApp(
+        useMaterial: true,
+        child: SheetKeyboardDismissible(
+          dismissBehavior: const SheetKeyboardDismissBehavior.onDrag(
+            isContentScrollAware: true,
+          ),
+          child: ScrollableSheet(
+            child: Material(
+              child: Column(
+                children: [
+                  TextField(focusNode: focusNode),
+                  Expanded(
+                    child: ListView(
+                      children: List.generate(
+                        30,
+                        (index) => ListTile(
+                          title: Text('Item $index'),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    tearDown(() {
+      focusNode.dispose();
+    });
+
+    testWidgets('should dismiss the keyboard when dragging', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      await tester.showKeyboard(find.byType(TextField));
+      expect(focusNode.hasFocus, isTrue,
+          reason: 'The keyboard should be shown.');
+
+      await tester.drag(find.byType(ListView), const Offset(0, 40));
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isFalse,
+          reason: 'Downward dragging should dismiss the keyboard.');
+    });
+
+    testWidgets('should dismiss the keyboard when scrolling', (tester) async {
+      await tester.pumpWidget(testWidget);
+
+      final textField = find.byType(TextField).first;
+      await tester.showKeyboard(textField);
+      expect(focusNode.hasFocus, isTrue,
+          reason: 'The keyboard should be shown.');
+
+      await tester.drag(find.byType(ListView), const Offset(0, -40));
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isFalse,
+          reason: 'Upward scrolling should dismiss the keyboard.');
+    });
+  });
 }


### PR DESCRIPTION
## Fixes / Closes (optional)

None.

## Description

This PR prepares for the upcoming `SheetActivity.ignorePointer` API. In these changes, the implementation of `SheetContext` will be moved from `SheetExtentScopeState` to the State classes of each sheet widget. As a result, the `SheetKeyboardDismissible` widget will need to be an ancestor of a sheet. This is because `SheetContext.notificationContext` will be at the sheet widget itself (currently it is at `SheetExtentScope`, which is a descendant of the sheet). Consequently, the `SheetKeyboardDismissible` internally inserted into the sheet subtree won't be able to catch `SheetNotification`s, resulting in the keyboard dismissing behavior not working.

## Summary (check all that apply)

- [x] Modified / added code
- [x] Modified / added tests
- [x] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [x] Contains breaking changes
  - [x] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
