### PR TITLE
Ignore pointer

### DIFF
--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -53,6 +53,10 @@ abstract class SheetActivity<T extends SheetExtent> {
     _disposed = true;
   }
 
+  /// Whether the sheet should ignore pointer events while performing
+  /// this activity.
+  bool get shouldIgnorePointer => false;
+
   bool isCompatibleWith(SheetExtent newOwner) => newOwner is T;
 
   void didChangeContentSize(Size? oldSize) {}

--- a/package/lib/src/foundation/sheet_extent_scope.dart
+++ b/package/lib/src/foundation/sheet_extent_scope.dart
@@ -91,7 +91,7 @@ abstract class SheetExtentScope extends StatefulWidget {
   // TODO: Add 'useRoot' option.
   static E? maybeOf<E extends SheetExtent>(BuildContext context) {
     final inherited = context
-        .dependOnInheritedWidgetOfExactType<_InheritedSheetExtentScope>()
+        .dependOnInheritedWidgetOfExactType<InheritedSheetExtentScope>()
         ?.extent;
 
     return inherited is E ? inherited : null;
@@ -225,7 +225,7 @@ abstract class SheetExtentScopeState<E extends SheetExtent,
     assert(
       () {
         final parentScope = context
-            .dependOnInheritedWidgetOfExactType<_InheritedSheetExtentScope>();
+            .dependOnInheritedWidgetOfExactType<InheritedSheetExtentScope>();
         if (!widget.isPrimary ||
             parentScope == null ||
             !parentScope.isPrimary) {
@@ -245,7 +245,7 @@ abstract class SheetExtentScopeState<E extends SheetExtent,
 
   @override
   Widget build(BuildContext context) {
-    return _InheritedSheetExtentScope(
+    return InheritedSheetExtentScope(
       extent: _extent,
       isPrimary: widget.isPrimary,
       child: widget.child,
@@ -253,8 +253,10 @@ abstract class SheetExtentScopeState<E extends SheetExtent,
   }
 }
 
-class _InheritedSheetExtentScope extends InheritedWidget {
-  const _InheritedSheetExtentScope({
+@internal
+class InheritedSheetExtentScope extends InheritedWidget {
+  const InheritedSheetExtentScope({
+    super.key,
     required this.extent,
     required this.isPrimary,
     required super.child,
@@ -264,6 +266,6 @@ class _InheritedSheetExtentScope extends InheritedWidget {
   final bool isPrimary;
 
   @override
-  bool updateShouldNotify(_InheritedSheetExtentScope oldWidget) =>
+  bool updateShouldNotify(InheritedSheetExtentScope oldWidget) =>
       extent != oldWidget.extent || isPrimary != oldWidget.isPrimary;
 }

--- a/package/lib/src/foundation/sheet_viewport.dart
+++ b/package/lib/src/foundation/sheet_viewport.dart
@@ -111,6 +111,29 @@ class RenderSheetViewport extends RenderTransform {
     }
   }
 
+  // Mirrors `super._transform` as there is no public getter for it.
+  // This should be initialized before the first call to hitTest().
+  late Matrix4 _transform;
+
+  @override
+  set transform(Matrix4 value) {
+    super.transform = value;
+    _transform = value;
+  }
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (_extent.activity.shouldIgnorePointer) {
+      final invTransform = Matrix4.tryInvert(
+        PointerEvent.removePerspectiveTransform(_transform),
+      );
+      return invTransform != null &&
+          size.contains(MatrixUtils.transformPoint(invTransform, position));
+    }
+
+    return super.hitTest(result, position: position);
+  }
+
   @override
   void dispose() {
     _extent.removeListener(_invalidateTranslationValue);

--- a/package/lib/src/navigation/navigation_sheet_activity.dart
+++ b/package/lib/src/navigation/navigation_sheet_activity.dart
@@ -29,7 +29,7 @@ class TransitionSheetActivity extends NavigationSheetActivity {
 
   @override
   SheetStatus get status => SheetStatus.animating;
-  
+
   @override
   bool get shouldIgnorePointer => true;
 

--- a/package/lib/src/navigation/navigation_sheet_activity.dart
+++ b/package/lib/src/navigation/navigation_sheet_activity.dart
@@ -29,6 +29,9 @@ class TransitionSheetActivity extends NavigationSheetActivity {
 
   @override
   SheetStatus get status => SheetStatus.animating;
+  
+  @override
+  bool get shouldIgnorePointer => true;
 
   @override
   void init(NavigationSheetExtent owner) {

--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -210,6 +210,8 @@ class BallisticScrollDrivenSheetActivity extends ScrollableSheetActivity
   }) : _oldPixels = initialPixels;
 
   final Simulation simulation;
+
+  @override
   final bool shouldIgnorePointer;
 
   double _oldPixels;

--- a/package/test/flutter_test_config.dart
+++ b/package/test/flutter_test_config.dart
@@ -1,0 +1,8 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  WidgetController.hitTestWarningShouldBeFatal = true;
+  await testMain();
+}

--- a/package/test/foundation/sheet_viewport_test.dart
+++ b/package/test/foundation/sheet_viewport_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
+import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/foundation/sheet_extent_scope.dart';
+import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
+import 'package:smooth_sheets/src/foundation/sheet_status.dart';
+import 'package:smooth_sheets/src/foundation/sheet_viewport.dart';
+
+class _FakeNotificationContext extends Fake implements BuildContext {
+  @override
+  void dispatchNotification(Notification notification) {/* no-op */}
+}
+
+class _FakeSheetContext extends Fake implements SheetContext {
+  @override
+  final notificationContext = _FakeNotificationContext();
+}
+
+class _FakeSheetActivity extends SheetActivity {
+  _FakeSheetActivity({
+    this.shouldIgnorePointer = false,
+    this.status = SheetStatus.stable,
+  });
+
+  @override
+  final bool shouldIgnorePointer;
+
+  @override
+  final SheetStatus status;
+}
+
+class _FakeSheetExtent extends SheetExtent {
+  _FakeSheetExtent({
+    super.minExtent = const Extent.proportional(0.5),
+    super.maxExtent = const Extent.proportional(1),
+    super.physics = const ClampingSheetPhysics(),
+    this.createIdleActivity,
+  }) : super(context: _FakeSheetContext());
+
+  final ValueGetter<SheetActivity>? createIdleActivity;
+
+  @override
+  void applyNewContentSize(Size contentSize) {
+    super.applyNewContentSize(contentSize);
+    if (metrics.maybePixels == null) {
+      setPixels(maxExtent.resolve(metrics.contentSize));
+    }
+  }
+
+  @override
+  void goIdle() {
+    if (createIdleActivity case final builder?) {
+      beginActivity(builder());
+    } else {
+      super.goIdle();
+    }
+  }
+}
+
+class _TestWidget extends StatelessWidget {
+  const _TestWidget({
+    required this.extent,
+    this.background,
+    this.sheetContent,
+  });
+
+  final SheetExtent extent;
+  final Widget? sheetContent;
+  final Widget? background;
+
+  @override
+  Widget build(BuildContext context) {
+    final sheet = InheritedSheetExtentScope(
+      isPrimary: true,
+      extent: extent,
+      child: SheetViewport(
+        child: SheetContentViewport(
+          child: sheetContent ??
+              Container(
+                color: Colors.white,
+                width: double.infinity,
+                height: 500,
+              ),
+        ),
+      ),
+    );
+
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(),
+        child: switch (background) {
+          null => sheet,
+          final background => Stack(
+              children: [background, sheet],
+            )
+        },
+      ),
+    );
+  }
+}
+
+void main() {
+  group('Ignore pointer test:', () {
+    ({
+      SheetExtent extent,
+      Widget testWidget,
+      ValueGetter<bool> didTapForeground,
+      ValueGetter<bool> didTapBackgroundTop,
+      ValueGetter<bool> didTapBackgroundBottom,
+    }) boilerplate({
+      required bool shouldIgnorePointer,
+    }) {
+      var didTapForeground = false;
+      var didTapBackgroundTop = false;
+      var didTapBackgroundBottom = false;
+
+      final extent = _FakeSheetExtent(
+        createIdleActivity: () => _FakeSheetActivity(
+          shouldIgnorePointer: shouldIgnorePointer,
+        ),
+      );
+
+      final testWidget = _TestWidget(
+        extent: extent,
+        background: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            TextButton(
+              onPressed: () => didTapBackgroundTop = true,
+              child: const Text('Background top'),
+            ),
+            TextButton(
+              onPressed: () => didTapBackgroundBottom = true,
+              child: const Text('Background bottom'),
+            ),
+          ],
+        ),
+        sheetContent: Container(
+          alignment: Alignment.center,
+          color: Colors.white,
+          width: double.infinity,
+          height: 500,
+          child: TextButton(
+            onPressed: () => didTapForeground = true,
+            child: const Text('Foreground'),
+          ),
+        ),
+      );
+
+      return (
+        extent: extent,
+        testWidget: testWidget,
+        didTapForeground: () => didTapForeground,
+        didTapBackgroundTop: () => didTapBackgroundTop,
+        didTapBackgroundBottom: () => didTapBackgroundBottom,
+      );
+    }
+
+    testWidgets(
+      'pointer events on a sheet should be ignored if activity says to do so',
+      (tester) async {
+        final env = boilerplate(shouldIgnorePointer: true);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Foreground'), warnIfMissed: false);
+        expect(env.didTapForeground(), isFalse);
+      },
+    );
+
+    testWidgets(
+      'content in a sheet should receive pointer events if activity allows',
+      (tester) async {
+        final env = boilerplate(shouldIgnorePointer: false);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Foreground'), warnIfMissed: false);
+        expect(env.didTapForeground(), isTrue);
+      },
+    );
+
+    testWidgets(
+      'content obscured by a sheet should never receive pointer events',
+      (tester) async {
+        final env = boilerplate(shouldIgnorePointer: true);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Background bottom'), warnIfMissed: false);
+        expect(env.didTapBackgroundBottom(), isFalse);
+      },
+    );
+
+    testWidgets(
+      'content not obscured by a sheet should always receive pointer events',
+      (tester) async {
+        final env = boilerplate(shouldIgnorePointer: true);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Background top'), warnIfMissed: false);
+        expect(env.didTapBackgroundTop(), isTrue);
+      },
+    );
+  });
+}

--- a/package/test/navigation/navigation_sheet_test.dart
+++ b/package/test/navigation/navigation_sheet_test.dart
@@ -536,7 +536,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       // Press and hold the list view in the second page
       // until the transition animation is finished.
-      // TODO: Change warnIfMissed to true and verify that the long press gesture fails.
+      // TODO: Change warnIfMissed to 'true' and verify that the long press gesture fails.
       await tester.press(find.byKey(const Key('Second')), warnIfMissed: false);
       await tester.pumpAndSettle();
       // Ensure that the transition is completed without any exceptions.

--- a/package/test/navigation/navigation_sheet_test.dart
+++ b/package/test/navigation/navigation_sheet_test.dart
@@ -536,7 +536,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       // Press and hold the list view in the second page
       // until the transition animation is finished.
-      await tester.press(find.byKey(const Key('Second')));
+      // TODO: Change warnIfMissed to true and verify that the long press gesture fails.
+      await tester.press(find.byKey(const Key('Second')), warnIfMissed: false);
       await tester.pumpAndSettle();
       // Ensure that the transition is completed without any exceptions.
       expect(find.text('First').hitTestable(), findsNothing);

--- a/package/test/navigation/navigation_sheet_test.dart
+++ b/package/test/navigation/navigation_sheet_test.dart
@@ -148,6 +148,88 @@ class _TestDraggablePageWidget extends StatelessWidget {
   }
 }
 
+class _TestScrollablePageWidget extends StatelessWidget {
+  const _TestScrollablePageWidget({
+    super.key,
+    required this.height,
+    required this.label,
+    required this.itemCount,
+    this.onTapItem,
+    this.onTapNext,
+    this.onTapBack,
+  });
+
+  final double? height;
+  final String label;
+  final int itemCount;
+  final void Function(int index)? onTapItem;
+  final VoidCallback? onTapNext;
+  final VoidCallback? onTapBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: SizedBox(
+        width: double.infinity,
+        height: height,
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(onPressed: onTapBack, child: const Text('Back')),
+                Text(label),
+                TextButton(onPressed: onTapNext, child: const Text('Next')),
+              ],
+            ),
+            Expanded(
+              child: ListView(
+                children: List.generate(
+                  itemCount,
+                  (index) => ListTile(
+                    title: Text('List Item $index'),
+                    onTap: onTapItem != null ? () => onTapItem!(index) : null,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static Route<dynamic> createRoute({
+    required String label,
+    double? height,
+    int itemCount = 30,
+    String? nextRoute,
+    Extent initialExtent = const Extent.proportional(1),
+    Extent minExtent = const Extent.proportional(1),
+    Duration transitionDuration = const Duration(milliseconds: 300),
+    SheetPhysics? physics,
+    void Function(int index)? onTapItem,
+  }) {
+    return ScrollableNavigationSheetRoute(
+      physics: physics,
+      initialExtent: initialExtent,
+      minExtent: minExtent,
+      transitionDuration: transitionDuration,
+      builder: (context) => _TestScrollablePageWidget(
+        key: ValueKey(label),
+        height: height,
+        label: label,
+        itemCount: itemCount,
+        onTapItem: onTapItem,
+        onTapBack: () => Navigator.pop(context),
+        onTapNext: nextRoute != null
+            ? () => Navigator.pushNamed(context, nextRoute)
+            : null,
+      ),
+    );
+  }
+}
+
 void main() {
   late NavigationSheetTransitionObserver transitionObserver;
 
@@ -249,7 +331,7 @@ void main() {
       // during a route transition.
       await tester.tap(find.text('Next'));
       // Forwards the transition animation by half.
-      await tester.pumpAndSettle(const Duration(milliseconds: 150));
+      await tester.pump(const Duration(milliseconds: 150));
       expect(lastBoundaryValues, equals((300, 300)));
       // Wait for the transition to finish.
       await tester.pumpAndSettle();
@@ -418,6 +500,47 @@ void main() {
         reason: 'After the keyboard is fully shown, '
             'the entire sheet should also be visible.',
       );
+    },
+  );
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/166
+  testWidgets(
+    'Drag gestures should be ignored during a page transition',
+    (tester) async {
+      await tester.pumpWidget(
+        _TestWidget(
+          transitionObserver,
+          initialRoute: 'first',
+          routes: {
+            'first': () => _TestDraggablePageWidget.createRoute(
+                  label: 'First',
+                  nextRoute: 'second',
+                  height: 500,
+                ),
+            'second': () => _TestScrollablePageWidget.createRoute(
+                  label: 'Second',
+                  height: double.infinity,
+                  // Intentionally slow down the transition animation.
+                  transitionDuration: const Duration(milliseconds: 600),
+                ),
+          },
+        ),
+      );
+
+      expect(find.text('First').hitTestable(), findsOneWidget);
+      expect(find.text('Second'), findsNothing);
+
+      // Go to the second page.
+      await tester.tap(find.text('Next'));
+      // Forwards the transition animation by half.
+      await tester.pump(const Duration(milliseconds: 300));
+      // Press and hold the list view in the second page
+      // until the transition animation is finished.
+      await tester.press(find.byKey(const Key('Second')));
+      await tester.pumpAndSettle();
+      // Ensure that the transition is completed without any exceptions.
+      expect(find.text('First').hitTestable(), findsNothing);
+      expect(find.text('Second').hitTestable(), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
## Fixes / Closes (optional)
<!-- List any issues or pull requests that this PR fixes or closes. Use the format: "Fixes #123" or "Closes #456". -->

Fixes #166.

## Description
<!-- Provide a clear and concise description of what this PR does. Explain the problem it solves and the approach you've taken. -->

This PR introduces `SheetActivity.shouldIgnorePointer`, a flag that indicates whether the sheet should prevent its content from receiving the pointer events. `TransitionSheetActivity` for `NavigationSheet` sets this flag to `true` to avoid potential issues that caused by user gestures during the unstable state of route transitions.

## Summary (check all that apply)
<!-- Mark the boxes that apply to this PR. Add details if necessary. -->
- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
