### PR TITLE
Refactor: Lift sheet context up

### DIFF
--- a/package/lib/src/draggable/draggable_sheet.dart
+++ b/package/lib/src/draggable/draggable_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
@@ -15,7 +16,7 @@ import 'sheet_draggable.dart';
 ///
 /// Note that this widget does not work with scrollable widgets.
 /// Instead, use [ScrollableSheet] for this usecase.
-class DraggableSheet extends StatelessWidget {
+class DraggableSheet extends StatefulWidget {
   /// Creates a sheet that can be dragged.
   ///
   /// The maximum height will be equal to the [child]'s height.
@@ -62,25 +63,33 @@ class DraggableSheet extends StatelessWidget {
   final HitTestBehavior hitTestBehavior;
 
   @override
+  State<DraggableSheet> createState() => _DraggableSheetState();
+}
+
+class _DraggableSheetState extends State<DraggableSheet>
+    with TickerProviderStateMixin, SheetContextStateMixin<DraggableSheet> {
+  @override
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
-    final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
+    final physics = widget.physics ?? theme?.physics ?? kDefaultSheetPhysics;
     final gestureTamper = TamperSheetGesture.maybeOf(context);
-    final controller = this.controller ?? SheetControllerScope.maybeOf(context);
+    final controller =
+        widget.controller ?? SheetControllerScope.maybeOf(context);
 
     return DraggableSheetExtentScope(
+      context: this,
       controller: controller,
-      initialExtent: initialExtent,
-      minExtent: minExtent,
-      maxExtent: maxExtent,
+      initialExtent: widget.initialExtent,
+      minExtent: widget.minExtent,
+      maxExtent: widget.maxExtent,
       physics: physics,
       gestureTamperer: gestureTamper,
       debugLabel: kDebugMode ? 'DraggableSheet' : null,
       child: SheetViewport(
         child: SheetContentViewport(
           child: SheetDraggable(
-            behavior: hitTestBehavior,
-            child: child,
+            behavior: widget.hitTestBehavior,
+            child: widget.child,
           ),
         ),
       ),

--- a/package/lib/src/draggable/draggable_sheet_extent_scope.dart
+++ b/package/lib/src/draggable/draggable_sheet_extent_scope.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_extent_scope.dart';
 import 'draggable_sheet_extent.dart';
@@ -10,6 +11,7 @@ class DraggableSheetExtentScope extends SheetExtentScope {
     super.key,
     super.controller,
     super.isPrimary,
+    required super.context,
     required this.initialExtent,
     required super.minExtent,
     required super.maxExtent,

--- a/package/lib/src/foundation/sheet_context.dart
+++ b/package/lib/src/foundation/sheet_context.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+import 'sheet_extent.dart';
+
+/// An interface that provides a set of dependencies required by [SheetExtent].
+@internal
+abstract class SheetContext {
+  TickerProvider get vsync;
+  BuildContext? get notificationContext;
+}
+
+@internal
+@optionalTypeArgs
+mixin SheetContextStateMixin<T extends StatefulWidget>
+    on State<T>, TickerProviderStateMixin<T>
+    implements SheetContext {
+  @override
+  TickerProvider get vsync => this;
+
+  @override
+  BuildContext? get notificationContext => mounted ? context : null;
+}

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 
 import '../internal/double_utils.dart';
 import 'sheet_activity.dart';
+import 'sheet_context.dart';
 import 'sheet_controller.dart';
 import 'sheet_drag.dart';
 import 'sheet_extent_scope.dart';
@@ -743,13 +744,4 @@ class SheetMetrics {
         viewportSize: maybeViewportSize,
         viewportInsets: maybeViewportInsets,
       ).toString();
-}
-
-/// An interface that provides the necessary context to a [SheetExtent].
-///
-/// Typically, [State]s that host a [SheetExtent] will implement this interface.
-@internal
-abstract class SheetContext {
-  TickerProvider get vsync;
-  BuildContext? get notificationContext;
 }

--- a/package/lib/src/navigation/navigation_routes.dart
+++ b/package/lib/src/navigation/navigation_routes.dart
@@ -37,9 +37,10 @@ class _ScrollableNavigationSheetRouteContent extends StatelessWidget {
     final gestureTamper = TamperSheetGesture.maybeOf(context);
 
     return NavigationSheetRouteContent(
-      scopeBuilder: (key, child) {
+      scopeBuilder: (context, key, child) {
         return ScrollableSheetExtentScope(
           key: key,
+          context: context,
           isPrimary: false,
           initialExtent: initialExtent,
           minExtent: minExtent,
@@ -78,9 +79,10 @@ class _DraggableNavigationSheetRouteContent extends StatelessWidget {
     final gestureTamper = TamperSheetGesture.maybeOf(context);
 
     return NavigationSheetRouteContent(
-      scopeBuilder: (key, child) {
+      scopeBuilder: (context, key, child) {
         return DraggableSheetExtentScope(
           key: key,
+          context: context,
           isPrimary: false,
           initialExtent: initialExtent,
           minExtent: minExtent,

--- a/package/lib/src/navigation/navigation_sheet.dart
+++ b/package/lib/src/navigation/navigation_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent_scope.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
@@ -31,7 +32,10 @@ class NavigationSheet extends StatefulWidget with TransitionAwareWidgetMixin {
 }
 
 class _NavigationSheetState extends State<NavigationSheet>
-    with TransitionAwareStateMixin {
+    with
+        TransitionAwareStateMixin,
+        TickerProviderStateMixin,
+        SheetContextStateMixin {
   final _scopeKey = SheetExtentScopeKey<NavigationSheetExtent>(
     debugLabel: kDebugMode ? 'NavigationSheet' : null,
   );
@@ -49,6 +53,7 @@ class _NavigationSheetState extends State<NavigationSheet>
 
     return NavigationSheetExtentScope(
       key: _scopeKey,
+      context: this,
       controller: controller,
       gestureTamperer: gestureTamper,
       debugLabel: kDebugMode ? 'NavigationSheet' : null,

--- a/package/lib/src/navigation/navigation_sheet_extent_scope.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent_scope.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_extent_scope.dart';
 import '../foundation/sheet_physics.dart';
@@ -11,6 +12,7 @@ class NavigationSheetExtentScope extends SheetExtentScope {
     super.key,
     super.controller,
     super.gestureTamperer,
+    required super.context,
     this.debugLabel,
     required super.child,
   }) : super(

--- a/package/lib/src/scrollable/scrollable_sheet.dart
+++ b/package/lib/src/scrollable/scrollable_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_controller.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
@@ -12,7 +13,7 @@ import '../foundation/sheet_viewport.dart';
 import 'scrollable_sheet_extent_scope.dart';
 import 'sheet_scrollable.dart';
 
-class ScrollableSheet extends StatelessWidget {
+class ScrollableSheet extends StatefulWidget {
   const ScrollableSheet({
     super.key,
     this.initialExtent = const Extent.proportional(1),
@@ -42,23 +43,31 @@ class ScrollableSheet extends StatelessWidget {
   final Widget child;
 
   @override
+  State<ScrollableSheet> createState() => _ScrollableSheetState();
+}
+
+class _ScrollableSheetState extends State<ScrollableSheet>
+    with TickerProviderStateMixin, SheetContextStateMixin {
+  @override
   Widget build(BuildContext context) {
     final theme = SheetTheme.maybeOf(context);
-    final physics = this.physics ?? theme?.physics ?? kDefaultSheetPhysics;
+    final physics = widget.physics ?? theme?.physics ?? kDefaultSheetPhysics;
     final gestureTamper = TamperSheetGesture.maybeOf(context);
-    final controller = this.controller ?? SheetControllerScope.maybeOf(context);
+    final controller =
+        widget.controller ?? SheetControllerScope.maybeOf(context);
 
     return ScrollableSheetExtentScope(
+      context: this,
       controller: controller,
-      initialExtent: initialExtent,
-      minExtent: minExtent,
-      maxExtent: maxExtent,
+      initialExtent: widget.initialExtent,
+      minExtent: widget.minExtent,
+      maxExtent: widget.maxExtent,
       physics: physics,
       gestureTamperer: gestureTamper,
       debugLabel: kDebugMode ? 'ScrollableSheet' : null,
       child: SheetViewport(
         child: SheetContentViewport(
-          child: ScrollableSheetContent(child: child),
+          child: ScrollableSheetContent(child: widget.child),
         ),
       ),
     );

--- a/package/lib/src/scrollable/scrollable_sheet_extent_scope.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent_scope.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../foundation/sheet_context.dart';
 import '../foundation/sheet_extent.dart';
 import '../foundation/sheet_extent_scope.dart';
 import 'scrollable_sheet_extent.dart';
@@ -10,6 +11,7 @@ class ScrollableSheetExtentScope extends SheetExtentScope {
     super.key,
     super.controller,
     super.isPrimary,
+    required super.context,
     required this.initialExtent,
     required super.minExtent,
     required super.maxExtent,

--- a/package/test/foundation/sheet_viewport_test.dart
+++ b/package/test/foundation/sheet_viewport_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
+import 'package:smooth_sheets/src/foundation/sheet_context.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
 import 'package:smooth_sheets/src/foundation/sheet_extent_scope.dart';
 import 'package:smooth_sheets/src/foundation/sheet_physics.dart';


### PR DESCRIPTION
## Fixes / Closes (optional)
<!-- List any issues or pull requests that this PR fixes or closes. Use the format: "Fixes #123" or "Closes #456". -->

None.

## Description
<!-- Provide a clear and concise description of what this PR does. Explain the problem it solves and the approach you've taken. -->

`SheetExtentScopeState` no longer implements `SheetContext`. Instead, these implementations have been moved to `SheetContextStateMixin`, which is mixed in by all the `*SheetState` classes.

## Summary (check all that apply)
<!-- Mark the boxes that apply to this PR. Add details if necessary. -->
- [x] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
