### PR TITLE
Refactor notification dispatch mechanism

### DIFF
--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -267,6 +267,12 @@ class DragSheetActivity extends SheetActivity
         ..setPixels(owner.metrics.pixels + physicsAppliedDelta)
         ..didDragUpdateMetrics(details);
     }
+
+    final overflow =
+        owner.physics.computeOverflow(details.deltaY, owner.metrics);
+    if (overflow != 0) {
+      owner.didOverflowBy(overflow);
+    }
   }
 
   @override

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -90,7 +90,7 @@ abstract class SheetActivity<T extends SheetExtent> {
         final correction = min(0.0, metrics.maxViewPixels - metrics.viewPixels);
         owner
           ..setPixels(oldPixels + correction)
-          ..dispatchUpdateNotification();
+          ..didUpdateMetrics();
 
       case < 0:
         // Appends the delta of the bottom inset (typically the keyboard height)
@@ -100,7 +100,7 @@ abstract class SheetActivity<T extends SheetExtent> {
             oldPixels - deltaInsetBottom,
             owner.metrics.maxPixels,
           ))
-          ..dispatchUpdateNotification();
+          ..didUpdateMetrics();
     }
 
     owner.settle();
@@ -184,7 +184,7 @@ class AnimatedSheetActivity extends SheetActivity
     final deltaInsetBottom = newInsets.bottom - oldInsets.bottom;
     owner
       ..setPixels(owner.metrics.pixels - deltaInsetBottom)
-      ..dispatchUpdateNotification();
+      ..didUpdateMetrics();
 
     // 2. If the animation is still running, we start a new linear animation
     // to bring the sheet position to the recalculated final position in the
@@ -265,14 +265,14 @@ class DragSheetActivity extends SheetActivity
     if (physicsAppliedDelta != 0) {
       owner
         ..setPixels(owner.metrics.pixels + physicsAppliedDelta)
-        ..dispatchDragUpdateNotification(details: details);
+        ..didDragUpdateMetrics(details: details);
     }
   }
 
   @override
   void applyUserDragEnd(SheetDragEndDetails details) {
     owner
-      ..dispatchDragEndNotification(details: details)
+      ..didDragEnd(details: details)
       ..goBallistic(details.velocityY);
   }
 }
@@ -311,7 +311,7 @@ mixin ControlledSheetActivityMixin<T extends SheetExtent> on SheetActivity<T> {
       final oldPixels = owner.metrics.pixels;
       owner
         ..setPixels(oldPixels + controller.value - _lastAnimatedValue)
-        ..dispatchUpdateNotification();
+        ..didUpdateMetrics();
       _lastAnimatedValue = controller.value;
     }
   }
@@ -346,7 +346,7 @@ mixin UserControlledSheetActivityMixin<T extends SheetExtent>
     // to keep the visual sheet position unchanged.
     owner
       ..setPixels(owner.metrics.pixels - deltaInsetBottom)
-      ..dispatchUpdateNotification();
+      ..didUpdateMetrics();
     // We don't call `goSettling` here because the user is still
     // manually controlling the sheet position.
   }

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -265,14 +265,14 @@ class DragSheetActivity extends SheetActivity
     if (physicsAppliedDelta != 0) {
       owner
         ..setPixels(owner.metrics.pixels + physicsAppliedDelta)
-        ..didDragUpdateMetrics(details: details);
+        ..didDragUpdateMetrics(details);
     }
   }
 
   @override
   void applyUserDragEnd(SheetDragEndDetails details) {
     owner
-      ..didDragEnd(details: details)
+      ..didDragEnd(details)
       ..goBallistic(details.velocityY);
   }
 }

--- a/package/lib/src/foundation/sheet_drag.dart
+++ b/package/lib/src/foundation/sheet_drag.dart
@@ -217,8 +217,8 @@ class SheetDragEndDetails extends SheetDragDetails {
 @internal
 abstract class SheetDragControllerTarget {
   VerticalDirection get dragAxisDirection;
-  void applyUserDragUpdate(Offset offset);
-  void applyUserDragEnd(Velocity velocity);
+  void applyUserDragUpdate(SheetDragUpdateDetails details);
+  void applyUserDragEnd(SheetDragEndDetails details);
 
   /// Returns the minimum number of pixels that the sheet being dragged
   /// will potentially consume for the given drag delta.
@@ -318,7 +318,7 @@ class SheetDragController implements Drag, ScrollActivityDelegate {
     }
 
     _lastDetails = details;
-    _target!.applyUserDragEnd(details.velocity);
+    _target!.applyUserDragEnd(details);
   }
 
   /// Called by the [ScrollDragController] in [Drag.update].
@@ -349,7 +349,7 @@ class SheetDragController implements Drag, ScrollActivityDelegate {
     }
 
     _lastDetails = details;
-    _target!.applyUserDragUpdate(details.delta);
+    _target!.applyUserDragUpdate(details);
   }
 
   @override

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -458,7 +458,7 @@ abstract class SheetExtent extends ChangeNotifier
       motionStartDistanceThreshold: physics.dragStartDistanceMotionThreshold,
     );
     beginActivity(dragActivity);
-    didDragStart(details: startDetails);
+    didDragStart(startDetails);
     return drag;
   }
 
@@ -521,7 +521,7 @@ abstract class SheetExtent extends ChangeNotifier
     }
   }
 
-  void didDragStart({required SheetDragStartDetails details}) {
+  void didDragStart(SheetDragStartDetails details) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragStartNotification(
@@ -531,7 +531,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void didDragEnd({required SheetDragEndDetails details}) {
+  void didDragEnd(SheetDragEndDetails details) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragEndNotification(
@@ -541,7 +541,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void didDragUpdateMetrics({required SheetDragUpdateDetails details}) {
+  void didDragUpdateMetrics(SheetDragUpdateDetails details) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragUpdateNotification(
@@ -551,7 +551,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void didOverflow({required double overflow}) {
+  void didOverflowBy(double overflow) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetOverflowNotification(

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -458,7 +458,7 @@ abstract class SheetExtent extends ChangeNotifier
       motionStartDistanceThreshold: physics.dragStartDistanceMotionThreshold,
     );
     beginActivity(dragActivity);
-    dispatchDragStartNotification(details: startDetails);
+    didDragStart(details: startDetails);
     return drag;
   }
 
@@ -510,7 +510,7 @@ abstract class SheetExtent extends ChangeNotifier
     }
   }
 
-  void dispatchUpdateNotification() {
+  void didUpdateMetrics() {
     if (metrics.hasDimensions) {
       _dispatchNotification(
         SheetUpdateNotification(
@@ -521,9 +521,7 @@ abstract class SheetExtent extends ChangeNotifier
     }
   }
 
-  void dispatchDragStartNotification({
-    required SheetDragStartDetails details,
-  }) {
+  void didDragStart({required SheetDragStartDetails details}) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragStartNotification(
@@ -533,9 +531,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void dispatchDragEndNotification({
-    required SheetDragEndDetails details,
-  }) {
+  void didDragEnd({required SheetDragEndDetails details}) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragEndNotification(
@@ -545,9 +541,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void dispatchDragUpdateNotification({
-    required SheetDragUpdateDetails details,
-  }) {
+  void didDragUpdateMetrics({required SheetDragUpdateDetails details}) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetDragUpdateNotification(
@@ -557,9 +551,7 @@ abstract class SheetExtent extends ChangeNotifier
     );
   }
 
-  void dispatchOverflowNotification({
-    required double overflow,
-  }) {
+  void didOverflow({required double overflow}) {
     assert(metrics.hasDimensions);
     _dispatchNotification(
       SheetOverflowNotification(

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../internal/double_utils.dart';
 import 'sheet_activity.dart';
+import 'sheet_controller.dart';
 import 'sheet_drag.dart';
 import 'sheet_extent_scope.dart';
 import 'sheet_gesture_tamperer.dart';

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -512,69 +511,44 @@ abstract class SheetExtent extends ChangeNotifier
 
   void didUpdateMetrics() {
     if (metrics.hasDimensions) {
-      _dispatchNotification(
-        SheetUpdateNotification(
-          metrics: metrics,
-          status: status,
-        ),
-      );
+      SheetUpdateNotification(
+        metrics: metrics,
+        status: status,
+      ).dispatch(context.notificationContext);
     }
   }
 
   void didDragStart(SheetDragStartDetails details) {
     assert(metrics.hasDimensions);
-    _dispatchNotification(
-      SheetDragStartNotification(
-        metrics: metrics,
-        dragDetails: details,
-      ),
-    );
+    SheetDragStartNotification(
+      metrics: metrics,
+      dragDetails: details,
+    ).dispatch(context.notificationContext);
   }
 
   void didDragEnd(SheetDragEndDetails details) {
     assert(metrics.hasDimensions);
-    _dispatchNotification(
-      SheetDragEndNotification(
-        metrics: metrics,
-        dragDetails: details,
-      ),
-    );
+    SheetDragEndNotification(
+      metrics: metrics,
+      dragDetails: details,
+    ).dispatch(context.notificationContext);
   }
 
   void didDragUpdateMetrics(SheetDragUpdateDetails details) {
     assert(metrics.hasDimensions);
-    _dispatchNotification(
-      SheetDragUpdateNotification(
-        metrics: metrics,
-        dragDetails: details,
-      ),
-    );
+    SheetDragUpdateNotification(
+      metrics: metrics,
+      dragDetails: details,
+    ).dispatch(context.notificationContext);
   }
 
   void didOverflowBy(double overflow) {
     assert(metrics.hasDimensions);
-    _dispatchNotification(
-      SheetOverflowNotification(
-        metrics: metrics,
-        status: status,
-        overflow: overflow,
-      ),
-    );
-  }
-
-  void _dispatchNotification(SheetNotification notification) {
-    // Avoid dispatching a notification in the middle of a build.
-    switch (SchedulerBinding.instance.schedulerPhase) {
-      case SchedulerPhase.postFrameCallbacks:
-        notification.dispatch(context.notificationContext);
-      case SchedulerPhase.idle:
-      case SchedulerPhase.midFrameMicrotasks:
-      case SchedulerPhase.persistentCallbacks:
-      case SchedulerPhase.transientCallbacks:
-        SchedulerBinding.instance.addPostFrameCallback((_) {
-          notification.dispatch(context.notificationContext);
-        });
-    }
+    SheetOverflowNotification(
+      metrics: metrics,
+      status: status,
+      overflow: overflow,
+    ).dispatch(context.notificationContext);
   }
 
   String _debugMessage(String message) {

--- a/package/lib/src/foundation/sheet_physics.dart
+++ b/package/lib/src/foundation/sheet_physics.dart
@@ -64,6 +64,7 @@ abstract class SheetPhysics {
 
   double computeOverflow(double offset, SheetMetrics metrics);
 
+  // TODO: Change to return a tuple of (physicsAppliedOffset, overflow) to avoid recomputation of the overflow.
   double applyPhysicsToOffset(double offset, SheetMetrics metrics);
 
   Simulation? createBallisticSimulation(double velocity, SheetMetrics metrics);
@@ -92,6 +93,7 @@ mixin SheetPhysicsMixin on SheetPhysics {
 
   @override
   double applyPhysicsToOffset(double offset, SheetMetrics metrics) {
+    // TODO: Use computeOverflow() to calculate the overflowed pixels.
     if (parent case final parent?) {
       return parent.applyPhysicsToOffset(offset, metrics);
     } else if (offset > 0 && metrics.pixels < metrics.maxPixels) {

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -103,50 +103,50 @@ class NavigationSheetExtent extends SheetExtent {
   }
 
   @override
-  void dispatchUpdateNotification() {
+  void didUpdateMetrics() {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchUpdateNotification();
+      super.didUpdateMetrics();
     }
   }
 
   @override
-  void dispatchDragStartNotification({
+  void didDragStart({
     required SheetDragStartDetails details,
   }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragStartNotification(details: details);
+      super.didDragStart(details: details);
     }
   }
 
   @override
-  void dispatchDragEndNotification({
+  void didDragEnd({
     required SheetDragEndDetails details,
   }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragEndNotification(details: details);
+      super.didDragEnd(details: details);
     }
   }
 
   @override
-  void dispatchDragUpdateNotification({
+  void didDragUpdateMetrics({
     required SheetDragUpdateDetails details,
   }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragUpdateNotification(details: details);
+      super.didDragUpdateMetrics(details: details);
     }
   }
 
   @override
-  void dispatchOverflowNotification({
+  void didOverflow({
     required double overflow,
   }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchOverflowNotification(overflow: overflow);
+      super.didOverflow(overflow: overflow);
     }
   }
 

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -111,42 +111,34 @@ class NavigationSheetExtent extends SheetExtent {
   }
 
   @override
-  void didDragStart({
-    required SheetDragStartDetails details,
-  }) {
+  void didDragStart(SheetDragStartDetails details) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.didDragStart(details: details);
+      super.didDragStart(details);
     }
   }
 
   @override
-  void didDragEnd({
-    required SheetDragEndDetails details,
-  }) {
+  void didDragEnd(SheetDragEndDetails details) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.didDragEnd(details: details);
+      super.didDragEnd(details);
     }
   }
 
   @override
-  void didDragUpdateMetrics({
-    required SheetDragUpdateDetails details,
-  }) {
+  void didDragUpdateMetrics(SheetDragUpdateDetails details) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.didDragUpdateMetrics(details: details);
+      super.didDragUpdateMetrics(details);
     }
   }
 
   @override
-  void didOverflow({
-    required double overflow,
-  }) {
+  void didOverflowBy(double overflow) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.didOverflow(overflow: overflow);
+      super.didOverflowBy(overflow);
     }
   }
 

--- a/package/lib/src/navigation/navigation_sheet_extent.dart
+++ b/package/lib/src/navigation/navigation_sheet_extent.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
+import '../foundation/sheet_drag.dart';
 import '../foundation/sheet_extent.dart';
 import '../internal/transition_observer.dart';
 import 'navigation_route.dart';
@@ -110,34 +111,42 @@ class NavigationSheetExtent extends SheetExtent {
   }
 
   @override
-  void dispatchDragStartNotification() {
+  void dispatchDragStartNotification({
+    required SheetDragStartDetails details,
+  }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragStartNotification();
+      super.dispatchDragStartNotification(details: details);
     }
   }
 
   @override
-  void dispatchDragEndNotification() {
+  void dispatchDragEndNotification({
+    required SheetDragEndDetails details,
+  }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragEndNotification();
+      super.dispatchDragEndNotification(details: details);
     }
   }
 
   @override
-  void dispatchDragUpdateNotification() {
+  void dispatchDragUpdateNotification({
+    required SheetDragUpdateDetails details,
+  }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchDragUpdateNotification();
+      super.dispatchDragUpdateNotification(details: details);
     }
   }
 
   @override
-  void dispatchOverflowNotification(double overflow) {
+  void dispatchOverflowNotification({
+    required double overflow,
+  }) {
     // Do not dispatch a notifications if a local extent is active.
     if (activity is! NavigationSheetActivity) {
-      super.dispatchOverflowNotification(overflow);
+      super.dispatchOverflowNotification(overflow: overflow);
     }
   }
 

--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -183,17 +183,17 @@ class DragScrollDrivenSheetActivity extends ScrollableSheetActivity
     final oldPixels = owner.metrics.pixels;
     final overflow = _applyScrollOffset(-1 * details.deltaY);
     if (owner.metrics.pixels != oldPixels) {
-      owner.dispatchDragUpdateNotification(details: details);
+      owner.didDragUpdateMetrics(details: details);
     }
     if (overflow > 0) {
-      owner.dispatchOverflowNotification(overflow: overflow);
+      owner.didOverflow(overflow: overflow);
     }
   }
 
   @override
   void applyUserDragEnd(SheetDragEndDetails details) {
     owner
-      ..dispatchDragEndNotification(details: details)
+      ..didDragEnd(details: details)
       ..goBallisticWithScrollPosition(
         velocity: -1 * details.velocityY,
         shouldIgnorePointer: false,
@@ -241,11 +241,11 @@ class BallisticScrollDrivenSheetActivity extends ScrollableSheetActivity
     _oldPixels = controller.value;
     final overflow = _applyScrollOffset(delta);
     if (owner.metrics.pixels != _oldPixels) {
-      owner.dispatchUpdateNotification();
+      owner.didUpdateMetrics();
     }
     if (!overflow.isApprox(0)) {
       owner
-        ..dispatchOverflowNotification(overflow: overflow)
+        ..didOverflow(overflow: overflow)
         ..goIdleWithScrollPosition();
       return;
     }

--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -183,17 +183,17 @@ class DragScrollDrivenSheetActivity extends ScrollableSheetActivity
     final oldPixels = owner.metrics.pixels;
     final overflow = _applyScrollOffset(-1 * details.deltaY);
     if (owner.metrics.pixels != oldPixels) {
-      owner.didDragUpdateMetrics(details: details);
+      owner.didDragUpdateMetrics(details);
     }
     if (overflow > 0) {
-      owner.didOverflow(overflow: overflow);
+      owner.didOverflowBy(overflow);
     }
   }
 
   @override
   void applyUserDragEnd(SheetDragEndDetails details) {
     owner
-      ..didDragEnd(details: details)
+      ..didDragEnd(details)
       ..goBallisticWithScrollPosition(
         velocity: -1 * details.velocityY,
         shouldIgnorePointer: false,
@@ -245,7 +245,7 @@ class BallisticScrollDrivenSheetActivity extends ScrollableSheetActivity
     }
     if (!overflow.isApprox(0)) {
       owner
-        ..didOverflow(overflow: overflow)
+        ..didOverflowBy(overflow)
         ..goIdleWithScrollPosition();
       return;
     }

--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -111,7 +111,7 @@ abstract class ScrollableSheetActivity
     final overflow = owner.physics.computeOverflow(delta, owner.metrics);
     if (overflow.abs() > 0) {
       position.didOverscrollBy(overflow);
-      owner.dispatchOverflowNotification(overflow);
+      owner.dispatchOverflowNotification(overflow: overflow);
       return overflow;
     }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -154,7 +154,7 @@ class ScrollableSheetExtent extends SheetExtent
       ),
     );
     beginActivity(dragActivity);
-    didDragStart(details: startDetails);
+    didDragStart(startDetails);
     return drag;
   }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -154,6 +154,7 @@ class ScrollableSheetExtent extends SheetExtent
       ),
     );
     beginActivity(dragActivity);
+    dispatchDragStartNotification(details: startDetails);
     return drag;
   }
 

--- a/package/lib/src/scrollable/scrollable_sheet_extent.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_extent.dart
@@ -154,7 +154,7 @@ class ScrollableSheetExtent extends SheetExtent
       ),
     );
     beginActivity(dragActivity);
-    dispatchDragStartNotification(details: startDetails);
+    didDragStart(details: startDetails);
     return drag;
   }
 

--- a/package/test/foundation/sheet_notification_test.dart
+++ b/package/test/foundation/sheet_notification_test.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_sheets/src/draggable/draggable_sheet.dart';
+import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
+import 'package:smooth_sheets/src/foundation/sheet_extent.dart';
+import 'package:smooth_sheets/src/foundation/sheet_notification.dart';
+import 'package:smooth_sheets/src/foundation/sheet_physics.dart';
+import 'package:smooth_sheets/src/foundation/sheet_status.dart';
+
+void main() {
+  testWidgets(
+    'Drag gesture should dispatch drag start/update/end notifications in sequence',
+    (tester) async {
+      final reportedNotifications = <SheetNotification>[];
+      const targetKey = Key('target');
+
+      await tester.pumpWidget(
+        NotificationListener<SheetNotification>(
+          onNotification: (notification) {
+            reportedNotifications.add(notification);
+            return false;
+          },
+          child: DraggableSheet(
+            minExtent: const Extent.pixels(0),
+            // Disable the snapping effect
+            physics: const ClampingSheetPhysics(),
+            child: Container(
+              key: targetKey,
+              color: Colors.white,
+              width: double.infinity,
+              height: 500,
+            ),
+          ),
+        ),
+      );
+
+      final gesturePointer = await tester.press(find.byKey(targetKey));
+      await gesturePointer.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(reportedNotifications, hasLength(2));
+      expect(
+        reportedNotifications[0],
+        isA<SheetDragStartNotification>()
+            .having((e) => e.metrics.maybePixels, 'pixels', 500)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having((e) => e.dragDetails.kind, 'kind', PointerDeviceKind.touch)
+            .having(
+              (e) => e.dragDetails.localPosition,
+              'localPosition',
+              const Offset(400, 250),
+            )
+            .having(
+              (e) => e.dragDetails.globalPosition,
+              'globalPosition',
+              const Offset(400, 350),
+            ),
+      );
+      expect(
+        reportedNotifications[1],
+        isA<SheetDragUpdateNotification>()
+            .having((e) => e.metrics.maybePixels, 'pixels', 480)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having(
+              (e) => e.dragDetails.axisDirection,
+              'axisDirection',
+              VerticalDirection.up,
+            )
+            .having(
+              (e) => e.dragDetails.localPosition,
+              'localPosition',
+              const Offset(400, 270),
+            )
+            .having(
+              (e) => e.dragDetails.globalPosition,
+              'globalPosition',
+              const Offset(400, 370),
+            ),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(
+        reportedNotifications.single,
+        isA<SheetDragUpdateNotification>()
+            .having((e) => e.metrics.maybePixels, 'pixels', 460)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having(
+              (e) => e.dragDetails.axisDirection,
+              'axisDirection',
+              VerticalDirection.up,
+            )
+            .having(
+              (e) => e.dragDetails.localPosition,
+              'localPosition',
+              const Offset(400, 290),
+            )
+            .having(
+              (e) => e.dragDetails.globalPosition,
+              'globalPosition',
+              const Offset(400, 390),
+            ),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.moveBy(const Offset(0, -20));
+      await tester.pump();
+      expect(
+        reportedNotifications.single,
+        isA<SheetDragUpdateNotification>()
+            .having((e) => e.metrics.maybePixels, 'pixels', 480)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having(
+              (e) => e.dragDetails.axisDirection,
+              'axisDirection',
+              VerticalDirection.up,
+            )
+            .having(
+              (e) => e.dragDetails.localPosition,
+              'localPosition',
+              const Offset(400, 270),
+            )
+            .having(
+              (e) => e.dragDetails.globalPosition,
+              'globalPosition',
+              const Offset(400, 370),
+            ),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.up();
+      await tester.pump();
+      expect(
+        reportedNotifications.single,
+        isA<SheetDragEndNotification>()
+            .having((e) => e.metrics.maybePixels, 'pixels', 480)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having((e) => e.dragDetails.velocity, 'velocity', Velocity.zero)
+            .having(
+              (e) => e.dragDetails.axisDirection,
+              'axisDirection',
+              VerticalDirection.up,
+            ),
+      );
+
+      reportedNotifications.clear();
+      await tester.pumpAndSettle();
+      expect(reportedNotifications, isEmpty,
+          reason: 'Once the drag is ended, '
+              'no notification should be dispatched.');
+    },
+  );
+
+  testWidgets(
+    'Sheet animation should dispatch metrics update notifications',
+    (tester) async {
+      final reportedNotifications = <SheetNotification>[];
+      final controller = SheetController();
+
+      await tester.pumpWidget(
+        NotificationListener<SheetNotification>(
+          onNotification: (notification) {
+            reportedNotifications.add(notification);
+            return false;
+          },
+          child: DraggableSheet(
+            controller: controller,
+            minExtent: const Extent.pixels(0),
+            // Disable the snapping effect
+            physics: const ClampingSheetPhysics(),
+            child: Container(
+              color: Colors.white,
+              width: double.infinity,
+              height: 600,
+            ),
+          ),
+        ),
+      );
+
+      unawaited(
+        controller.animateTo(
+          const Extent.pixels(0),
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.linear,
+        ),
+      );
+      await tester.pump(Duration.zero);
+      expect(
+        reportedNotifications.single,
+        isA<SheetUpdateNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', moreOrLessEquals(600))
+            .having((e) => e.status, 'status', SheetStatus.animating),
+      );
+
+      reportedNotifications.clear();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        reportedNotifications.single,
+        isA<SheetUpdateNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', moreOrLessEquals(400))
+            .having((e) => e.status, 'status', SheetStatus.animating),
+      );
+
+      reportedNotifications.clear();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        reportedNotifications.single,
+        isA<SheetUpdateNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', moreOrLessEquals(200))
+            .having((e) => e.status, 'status', SheetStatus.animating),
+      );
+
+      reportedNotifications.clear();
+      await tester.pump(const Duration(seconds: 100));
+      expect(
+        reportedNotifications.single,
+        isA<SheetUpdateNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', moreOrLessEquals(0))
+            .having((e) => e.status, 'status', SheetStatus.animating),
+      );
+
+      reportedNotifications.clear();
+      await tester.pumpAndSettle();
+      expect(reportedNotifications, isEmpty,
+          reason: 'Once the animation is finished, '
+              'no notification should be dispatched.');
+    },
+  );
+
+  testWidgets(
+    'Over-darg gesture should dispatch both darg and overflow notifications',
+    (tester) async {
+      final reportedNotifications = <SheetNotification>[];
+      const targetKey = Key('target');
+
+      await tester.pumpWidget(
+        NotificationListener<SheetNotification>(
+          onNotification: (notification) {
+            reportedNotifications.add(notification);
+            return false;
+          },
+          child: DraggableSheet(
+            // Make sure the sheet can't be dragged
+            minExtent: const Extent.proportional(1),
+            maxExtent: const Extent.proportional(1),
+            // Disable the snapping effect
+            physics: const ClampingSheetPhysics(),
+            child: Container(
+              key: targetKey,
+              color: Colors.white,
+              width: double.infinity,
+              height: 500,
+            ),
+          ),
+        ),
+      );
+
+      final gesturePointer = await tester.press(find.byKey(targetKey));
+      await gesturePointer.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(reportedNotifications, hasLength(2));
+      expect(
+        reportedNotifications[0],
+        isA<SheetDragStartNotification>().having(
+          (e) => e.dragDetails.axisDirection,
+          'axisDirection',
+          // Since the y-axis is upward and we are performing a downward drag,
+          // the sign of the overflowed delta should be negative.
+          VerticalDirection.up,
+        ),
+      );
+      expect(
+        reportedNotifications[1],
+        isA<SheetOverflowNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', 500)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having((e) => e.overflow, 'overflow', -20),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(
+        reportedNotifications.single,
+        isA<SheetOverflowNotification>()
+            .having((e) => e.metrics.pixels, 'pixels', 500)
+            .having((e) => e.status, 'status', SheetStatus.dragging)
+            .having((e) => e.overflow, 'overflow', -20),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.up();
+      await tester.pump();
+      expect(reportedNotifications.single, isA<SheetDragEndNotification>());
+
+      reportedNotifications.clear();
+      await tester.pumpAndSettle();
+      expect(reportedNotifications, isEmpty,
+          reason: 'Once the drag is ended, '
+              'no notification should be dispatched.');
+    },
+  );
+}


### PR DESCRIPTION
## Fixes / Closes (optional)

Fixes #179.

## Description

Moved the notification dispatch logic from `SheetExtent.beginActivity()` to the individual `SheetActivity` classes, as they have a better understanding of what kind of notification should be dispatched and when. This refactoring will implicitly fix #179, as the assertions that caused the errors reported in the issue have also been removed in this PR.

## Summary (check all that apply)

- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
