### PR TITLE
Dispatch a notification when drag is canceled

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 MM DD, 2024
+
+- Dispatch a notification when drag is cancelled (#204)
+
 ## 0.8.2 Jul 11, 2024
 
 - Fix: Opening keyboard interrupts sheet animation (#189)

--- a/package/lib/src/foundation/foundation.dart
+++ b/package/lib/src/foundation/foundation.dart
@@ -18,6 +18,7 @@ export 'sheet_content_scaffold.dart'
 export 'sheet_controller.dart' show DefaultSheetController, SheetController;
 export 'sheet_drag.dart'
     show
+        SheetDragCancelDetails,
         SheetDragDetails,
         SheetDragEndDetails,
         SheetDragStartDetails,
@@ -26,6 +27,7 @@ export 'sheet_extent.dart'
     show Extent, FixedExtent, ProportionalExtent, SheetMetrics;
 export 'sheet_notification.dart'
     show
+        SheetDragCancelNotification,
         SheetDragEndNotification,
         SheetDragStartNotification,
         SheetDragUpdateNotification,

--- a/package/lib/src/foundation/sheet_activity.dart
+++ b/package/lib/src/foundation/sheet_activity.dart
@@ -281,6 +281,13 @@ class DragSheetActivity extends SheetActivity
       ..didDragEnd(details)
       ..goBallistic(details.velocityY);
   }
+
+  @override
+  void onDragCancel(SheetDragCancelDetails details) {
+    owner
+      ..didDragCancel()
+      ..goBallistic(0);
+  }
 }
 
 @internal

--- a/package/lib/src/foundation/sheet_extent.dart
+++ b/package/lib/src/foundation/sheet_extent.dart
@@ -542,6 +542,13 @@ abstract class SheetExtent extends ChangeNotifier
     ).dispatch(context.notificationContext);
   }
 
+  void didDragCancel() {
+    assert(metrics.hasDimensions);
+    SheetDragCancelNotification(
+      metrics: metrics,
+    ).dispatch(context.notificationContext);
+  }
+
   void didOverflowBy(double overflow) {
     assert(metrics.hasDimensions);
     SheetOverflowNotification(

--- a/package/lib/src/foundation/sheet_gesture_tamperer.dart
+++ b/package/lib/src/foundation/sheet_gesture_tamperer.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'sheet_drag.dart';
 
 // TODO: Expose this as a public API.
+// TODO: Rename to SheetGestureProxy.
 @internal
 class TamperSheetGesture extends StatefulWidget {
   const TamperSheetGesture({
@@ -54,6 +55,7 @@ class _TamperSheetGestureState extends State<TamperSheetGesture> {
   }
 }
 
+// TODO: Rename to SheetGestureProxyScope.
 class _TamperSheetGestureScope extends InheritedWidget {
   const _TamperSheetGestureScope({
     required this.tamperer,
@@ -68,6 +70,7 @@ class _TamperSheetGestureScope extends InheritedWidget {
 }
 
 // TODO: Expose this as a public API.
+// TODO: Rename to SheetGestureProxyMixin.
 @internal
 mixin SheetGestureTamperer {
   SheetGestureTamperer? _parent;
@@ -79,12 +82,14 @@ mixin SheetGestureTamperer {
 
   @useResult
   @mustCallSuper
+  // TODO: Rename to onDragStart.
   SheetDragStartDetails tamperWithDragStart(SheetDragStartDetails details) {
     return _parent?.tamperWithDragStart(details) ?? details;
   }
 
   @useResult
   @mustCallSuper
+  // TODO: Rename to onDragUpdate.
   SheetDragUpdateDetails tamperWithDragUpdate(
     SheetDragUpdateDetails details,
     Offset minPotentialDeltaConsumption,
@@ -100,7 +105,13 @@ mixin SheetGestureTamperer {
 
   @useResult
   @mustCallSuper
+  // TODO: Rename to onDragEnd.
   SheetDragEndDetails tamperWithDragEnd(SheetDragEndDetails details) {
     return _parent?.tamperWithDragEnd(details) ?? details;
+  }
+
+  @mustCallSuper
+  void onDragCancel(SheetDragCancelDetails details) {
+    _parent?.onDragCancel(details);
   }
 }

--- a/package/lib/src/foundation/sheet_notification.dart
+++ b/package/lib/src/foundation/sheet_notification.dart
@@ -8,7 +8,7 @@ import 'sheet_status.dart';
 /// A [Notification] that is dispatched when the sheet extent changes.
 ///
 /// Sheet widgets notify their ancestors about changes to their extent.
-/// There are 5 types of notifications:
+/// There are 6 types of notifications:
 /// - [SheetOverflowNotification], which is dispatched when the user tries
 ///   to drag the sheet beyond its draggable bounds but the sheet has not
 ///   changed its extent because its [SheetPhysics] does not allow it to be.
@@ -20,6 +20,8 @@ import 'sheet_status.dart';
 ///   dragging the sheet.
 /// - [SheetDragEndNotification], which is dispatched when the user stops
 ///   dragging the sheet.
+/// - [SheetDragCancelNotification], which is dispatched when the user
+///  or the system cancels a drag gesture in the sheet.
 ///
 /// See also:
 /// - [NotificationListener], which can be used to listen for notifications
@@ -114,6 +116,16 @@ class SheetDragEndNotification extends SheetNotification {
     super.debugFillDescription(description);
     description.add('dragDetails: $dragDetails');
   }
+}
+
+/// A [SheetNotification] that is dispatched when the user
+/// or the system cancels a drag gesture in the sheet.
+class SheetDragCancelNotification extends SheetNotification {
+  /// Create a notification that is dispatched when a drag gesture
+  /// in the sheet is canceled.
+  const SheetDragCancelNotification({
+    required super.metrics,
+  }) : super(status: SheetStatus.dragging);
 }
 
 /// A [SheetNotification] that is dispatched when the user tries

--- a/package/lib/src/scrollable/scrollable_sheet_activity.dart
+++ b/package/lib/src/scrollable/scrollable_sheet_activity.dart
@@ -211,6 +211,16 @@ class DragScrollDrivenSheetActivity extends ScrollableSheetActivity
         scrollPosition: scrollPosition,
       );
   }
+
+  @override
+  void onDragCancel(SheetDragCancelDetails details) {
+    owner
+      ..didDragCancel()
+      ..goBallisticWithScrollPosition(
+        velocity: 0,
+        scrollPosition: scrollPosition,
+      );
+  }
 }
 
 /// A [SheetActivity] that animates either a scrollable content of

--- a/package/test/foundation/sheet_notification_test.dart
+++ b/package/test/foundation/sheet_notification_test.dart
@@ -303,4 +303,60 @@ void main() {
               'no notification should be dispatched.');
     },
   );
+
+  /*
+  TODO: Uncomment this once https://github.com/flutter/flutter/issues/152163 is fixed.
+  testWidgets(
+    'Canceling drag gesture should dispatch a drag cancel notification',
+    (tester) async {
+      final reportedNotifications = <SheetNotification>[];
+      const targetKey = Key('target');
+
+      await tester.pumpWidget(
+        NotificationListener<SheetNotification>(
+          onNotification: (notification) {
+            reportedNotifications.add(notification);
+            return false;
+          },
+          child: DraggableSheet(
+            minExtent: const Extent.pixels(0),
+            // Disable the snapping effect
+            physics: const ClampingSheetPhysics(),
+            child: Container(
+              key: targetKey,
+              color: Colors.white,
+              width: double.infinity,
+              height: 500,
+            ),
+          ),
+        ),
+      );
+
+      final gesturePointer = await tester.press(find.byKey(targetKey));
+      await gesturePointer.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(
+        reportedNotifications,
+        equals([
+          isA<SheetDragStartNotification>(),
+          isA<SheetDragUpdateNotification>(),
+        ]),
+      );
+
+      reportedNotifications.clear();
+      await gesturePointer.cancel();
+      await tester.pump();
+      expect(
+        reportedNotifications.single,
+        isA<SheetDragCancelNotification>(),
+      );
+
+      reportedNotifications.clear();
+      await tester.pumpAndSettle();
+      expect(reportedNotifications, isEmpty,
+          reason: 'Once the drag is canceled, '
+              'no notification should be dispatched.');
+    },
+  );
+  */
 }


### PR DESCRIPTION
## Fixes / Closes (optional)
<!-- List any issues or pull requests that this PR fixes or closes. Use the format: "Fixes #123" or "Closes #456". -->

None.

## Description
<!-- Provide a clear and concise description of what this PR does. Explain the problem it solves and the approach you've taken. -->

In this PR, the following new features have been added:
- `SheetDragCancelNotification`, which is dispatched when a drag is canceled.
- `SheetDragCancelDetails`, which represents the final state of `SheetDragController.details` when the tracked drag gesture is canceled.

## Summary (check all that apply)
<!-- Mark the boxes that apply to this PR. Add details if necessary. -->
- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [x] Updated CHANGELOG
