### PR TITLE
Fix: Sometimes touch is ignored when scrollable sheet reaches edge

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1 Jul 30, 2024
+
+- Fix: Sometimes touch is ignored when scrollable sheet reaches edge (#209)
+
 ## 0.9.0 Jul 24, 2024
 
 This version contains some breaking changes. See the [migration guide](https://github.com/fujidaiti/smooth_sheets/blob/main/docs/migration-guide-0.9.x.md) for more details.

--- a/package/lib/src/foundation/sheet_context.dart
+++ b/package/lib/src/foundation/sheet_context.dart
@@ -8,6 +8,7 @@ import 'sheet_extent.dart';
 abstract class SheetContext {
   TickerProvider get vsync;
   BuildContext? get notificationContext;
+  double get devicePixelRatio;
 }
 
 @internal
@@ -20,4 +21,8 @@ mixin SheetContextStateMixin<T extends StatefulWidget>
 
   @override
   BuildContext? get notificationContext => mounted ? context : null;
+
+  @override
+  double get devicePixelRatio =>
+      MediaQuery.maybeDevicePixelRatioOf(context) ?? 1.0;
 }

--- a/package/lib/src/internal/double_utils.dart
+++ b/package/lib/src/internal/double_utils.dart
@@ -1,31 +1,12 @@
 import 'dart:math';
 
-import 'package:flutter/physics.dart';
-
 extension DoubleUtils on double {
-  bool isApprox(double value) =>
-      nearEqual(this, value, Tolerance.defaultTolerance.distance);
-
-  bool isLessThan(double value) => this < value && !isApprox(value);
-
-  bool isGreaterThan(double value) => this > value && !isApprox(value);
-
-  bool isLessThanOrApprox(double value) => isLessThan(value) || isApprox(value);
-
-  bool isGreaterThanOrApprox(double value) =>
-      isGreaterThan(value) || isApprox(value);
-
-  bool isOutOfBounds(double min, double max) =>
-      isLessThan(min) || isGreaterThan(max);
-
-  bool isInBounds(double min, double max) => !isOutOfBounds(min, max);
-
   double clampAbs(double norm) => min(max(-norm, this), norm);
 
   double nearest(double a, double b) =>
       (a - this).abs() < (b - this).abs() ? a : b;
-}
 
-double inverseLerp(double min, double max, double value) {
-  return min == max ? 1.0 : (value - min) / (max - min);
+  double inverseLerp(double min, double max) {
+    return min == max ? 1.0 : (this - min) / (max - min);
+  }
 }

--- a/package/lib/src/internal/float_comp.dart
+++ b/package/lib/src/internal/float_comp.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+/// Caches [FloatComp] instances for different epsilon values to avoid
+/// object creations for every comparison. Although these instances may never
+/// be released, the memory overhead is negligible as the device pixel ratio
+/// rarely changes during the app's lifetime.
+final _instanceForEpsilon = <double, FloatComp>{};
+
+// TODO: Reimplement this class as an extension type of [double] to avoid object creation.
+/// A comparator for floating-point numbers in a certain precision.
+///
+/// [FloatComp.distance] and [FloatComp.velocity] determine the [epsilon] based
+/// on the given device pixel ratio, which is the number of physical pixels per
+/// logical pixel.
+@internal
+class FloatComp {
+  /// Creates a [FloatComp] with the given [epsilon].
+  factory FloatComp({required double epsilon}) {
+    return _instanceForEpsilon[epsilon] ??= FloatComp._(epsilon);
+  }
+
+  /// Creates a [FloatComp] for comparing distances.
+  ///
+  /// The [devicePixelRatio] is the number of physical pixels per logical
+  /// pixel. This is typically obtained by [MediaQuery.devicePixelRatioOf].
+  factory FloatComp.distance(double devicePixelRatio) {
+    return FloatComp(epsilon: 1e-3 / devicePixelRatio);
+  }
+
+  /// Creates a [FloatComp] for comparing velocities.
+  ///
+  /// The [devicePixelRatio] is the number of physical pixels per logical
+  /// pixel. This is typically obtained by [MediaQuery.devicePixelRatioOf].
+  factory FloatComp.velocity(double devicePixelRatio) {
+    return FloatComp(epsilon: 1e-4 / devicePixelRatio);
+  }
+
+  const FloatComp._(this.epsilon);
+
+  /// The maximum difference between two floating-point numbers to consider
+  /// them approximately equal.
+  final double epsilon;
+
+  /// Returns `true` if [a] is approximately equal to [b].
+  bool isApprox(double a, double b) => nearEqual(a, b, epsilon);
+
+  /// Returns `true` if [a] is not approximately equal to [b].
+  bool isNotApprox(double a, double b) => !isApprox(a, b);
+
+  /// Returns `true` if [a] is less than [b] and not approximately equal to [b].
+  bool isLessThan(double a, double b) => a < b && !isApprox(a, b);
+
+  /// Returns `true` if [a] is greater than [b] and not approximately
+  /// equal to [b].
+  bool isGreaterThan(double a, double b) => a > b && !isApprox(a, b);
+
+  /// Returns `true` if [a] is less than [b] or approximately equal to [b].
+  bool isLessThanOrApprox(double a, double b) =>
+      isLessThan(a, b) || isApprox(a, b);
+
+  /// Returns `true` if [a] is greater than [b] or approximately equal to [b].
+  bool isGreaterThanOrApprox(double a, double b) =>
+      isGreaterThan(a, b) || isApprox(a, b);
+
+  /// Returns `true` if [a] is less than [min] or greater than [max].
+  bool isOutOfBounds(double a, double min, double max) =>
+      isLessThan(a, min) || isGreaterThan(a, max);
+
+  /// Returns `true` if [a] is in the range `[min, max]`, inclusive.
+  bool isInBounds(double a, double min, double max) =>
+      !isOutOfBounds(a, min, max);
+
+  /// Returns [b] if [a] is approximately equal to [b], otherwise [a].
+  double roundToIfApprox(double a, double b) => isApprox(a, b) ? b : a;
+}

--- a/package/lib/src/modal/cupertino.dart
+++ b/package/lib/src/modal/cupertino.dart
@@ -376,11 +376,10 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
         if (metrics.hasDimensions) {
           _cupertinoTransitionControllerOf[_previousRoute]?.value = min(
             controller!.value,
-            inverseLerp(
+            metrics.viewPixels.inverseLerp(
               // TODO: Make this configurable.
               metrics.viewportSize.height / 2,
               metrics.viewportSize.height,
-              metrics.viewPixels,
             ),
           );
         }

--- a/package/lib/src/modal/modal_sheet.dart
+++ b/package/lib/src/modal/modal_sheet.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../foundation/sheet_drag.dart';
 import '../foundation/sheet_gesture_tamperer.dart';
-import '../internal/double_utils.dart';
+import '../internal/float_comp.dart';
 
 const _minFlingVelocityToDismiss = 1.0;
 const _minDragDistanceToDismiss = 100.0; // Logical pixels.
@@ -262,7 +262,8 @@ class _SwipeDismissibleController with SheetGestureTamperer {
       // Dominantly use the full pixels if it is in the middle of a transition.
       effectiveDragDelta = dragDelta;
     } else if (dragDelta < 0 &&
-        !dragDelta.isApprox(minPDC) &&
+        FloatComp.distance(MediaQuery.devicePixelRatioOf(_context))
+            .isNotApprox(dragDelta, minPDC) &&
         MediaQuery.viewInsetsOf(_context).bottom == 0) {
       // If the drag is downwards and the sheet may not consume the full pixels,
       // then use the remaining pixels as the effective drag delta.
@@ -344,7 +345,8 @@ class _SwipeDismissibleController with SheetGestureTamperer {
     } else if (effectiveVelocity < 0) {
       // Flings down.
       invokePop = effectiveVelocity.abs() > _minFlingVelocityToDismiss;
-    } else if (effectiveVelocity.isApprox(0)) {
+    } else if (FloatComp.velocity(MediaQuery.devicePixelRatioOf(_context))
+        .isApprox(effectiveVelocity, 0)) {
       assert(draggedDistance >= 0);
       // Dragged down enough to dismiss.
       invokePop = draggedDistance > _minDragDistanceToDismiss;

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.9.0
+version: 0.9.1
 repository: https://github.com/fujidaiti/smooth_sheets
 screenshots:
   - description: Practical examples of smooth_sheets.

--- a/package/test/foundation/sheet_viewport_test.dart
+++ b/package/test/foundation/sheet_viewport_test.dart
@@ -16,6 +16,9 @@ class _FakeNotificationContext extends Fake implements BuildContext {
 class _FakeSheetContext extends Fake implements SheetContext {
   @override
   final notificationContext = _FakeNotificationContext();
+
+  @override
+  double get devicePixelRatio => 3.0;
 }
 
 class _FakeSheetActivity extends SheetActivity {

--- a/package/test/scrollable/scrollable_sheet_test.dart
+++ b/package/test/scrollable/scrollable_sheet_test.dart
@@ -3,7 +3,11 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
+import 'package:smooth_sheets/src/foundation/sheet_activity.dart';
 import 'package:smooth_sheets/src/foundation/sheet_controller.dart';
+import 'package:smooth_sheets/src/foundation/sheet_extent_scope.dart';
+import 'package:smooth_sheets/src/scrollable/scrollable_sheet_extent.dart';
+import 'package:smooth_sheets/src/scrollable/sheet_content_scroll_position.dart';
 
 import '../src/keyboard_inset_simulation.dart';
 
@@ -265,5 +269,48 @@ void main() {
       expect(focusNode.hasFocus, isFalse,
           reason: 'Upward scrolling should dismiss the keyboard.');
     });
+  });
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/207
+  testWidgets('Infinite ballistic scroll activity test', (tester) async {
+    late ScrollController scrollController;
+    late ScrollableSheetExtent sheetExtent;
+
+    await tester.pumpWidget(
+      ScrollableSheet(
+        child: Builder(
+          builder: (context) {
+            scrollController = PrimaryScrollController.of(context);
+            sheetExtent = SheetExtentScope.of(context);
+            return SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Container(
+                color: Colors.white,
+                width: double.infinity,
+                height: 1200,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    scrollController.jumpTo(600.0);
+    await tester.pumpAndSettle();
+    expect(scrollController.position.extentAfter, 0,
+        reason: 'Ensure that the scroll view cannot be scrolled anymore');
+
+    // Start a ballistic animation from a position extremely close to,
+    // but not equal, to the current position.
+    scrollController.position.correctPixels(600.000000001);
+    sheetExtent.goBallisticWithScrollPosition(
+      velocity: 0,
+      scrollPosition: scrollController.position as SheetContentScrollPosition,
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.position.pixels, 600.0);
+    expect(sheetExtent.activity, isA<IdleSheetActivity>(),
+        reason: 'Should not enter an infinite recursion '
+            'of BallisticScrollDrivenSheetActivity');
   });
 }


### PR DESCRIPTION
## Fixes / Closes (optional)
<!-- List any issues or pull requests that this PR fixes or closes. Use the format: "Fixes #123" or "Closes #456". -->

Fixes #207.

## Description
<!-- Provide a clear and concise description of what this PR does. Explain the problem it solves and the approach you've taken. -->

This PR improves floating-point value comparisons throughout the codebase to address an existing issue and prevent potential problems related to floating-point precision errors. For example, #207 was caused by infinite recursion of `SheetContentScrollPositionOwner.goBallisticWithScrollPosition` calls, triggered by `ScrollMetrics.outOfRange` always being true in `ScrollPhysics.createBallisticSimulation` due to such a floating-point precision error.

## Summary (check all that apply)
<!-- Mark the boxes that apply to this PR. Add details if necessary. -->
- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [x] Incremented version number
  - [x] Updated CHANGELOG
