### PR TITLE
Decrease required minimum pub points (tmp fix)

### DIFF
--- a/.github/workflows/dry_publish.yaml
+++ b/.github/workflows/dry_publish.yaml
@@ -32,7 +32,7 @@ jobs:
           report: ${{ steps.analysis.outputs.json_output }}
           min-convention-points: 30
           min-platform-points: 20
-          min-analysis-points: 50
+          min-analysis-points: 40
           min-dependency-points: 20
           supported-platforms: ios, android
 


### PR DESCRIPTION
## Fixes / Closes (optional)
<!-- List any issues or pull requests that this PR fixes or closes. Use the format: "Fixes #123" or "Closes #456". -->

None.

## Description
<!-- Provide a clear and concise description of what this PR does. Explain the problem it solves and the approach you've taken. -->

After the release of Flutter 3.24, pub.dev and `pana` have started to report the following warning:

```
40/50 points: code has no errors, warnings, lints, or formatting issues

INFO: 'onPopInvoked' is deprecated and shouldn't be used. Override onPopInvokedWithResult instead. This feature was deprecated after v3.22.0-12.0.pre.

lib/src/modal/modal_sheet.dart:395:13

    ╷
395 │       route.onPopInvoked(didPop);
    │             ^^^^^^^^^^^^
```

This decreases the package's pub points for the *Pass-static-analysis* section from 50 to 40, but the current CI requires it to always be 50, resulting in no PR passing the CI.

Although it is possible to fix this warning by following [the migration guide](https://docs.flutter.dev/release/breaking-changes/popscope-with-result), we are not doing this for now as it breaks backward compatibility. Instead, this PR works around this CI issue by decreasing the required pub points for that section to 40 until Flutter 3.24 is widely adopted in the community.

## Summary (check all that apply)
<!-- Mark the boxes that apply to this PR. Add details if necessary. -->
- [ ] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [x] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
