### PR TITLE
Don't write test report if workflow is triggered by a fork

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -78,7 +78,8 @@ jobs:
 
       - name: Write test report
         uses: dorny/test-reporter@v1
-        if: success() || failure()
+        # PRs from forks have no write permissions.
+        if: github.event.pull_request.head.repo.fork == false && (success() || failure())
         with:
           name: Test Report
           path: ${{ env.FLUTTER_TEST_REPORT }}


### PR DESCRIPTION
## Related issues (optional)

None.

## Description

According to [dorny/test-reporter](https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories):

> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. 

As a workaround, this PR modifies the workflow to generate a test report only when triggered by the original repository.

## Summary (check all that apply)

- [ ] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [x] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
