### PR TITLE
Trigger CI on pubspec.* changes

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -15,20 +15,22 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      dart-files: ${{ steps.filter.outputs.dart-files }}
+      flutter-files: ${{ steps.filter.outputs.flutter-files }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            dart-files:
+            flutter-files:
               - '**.dart'
+              - 'pubspec.yaml'
+              - 'pubspec.lock'
 
   # Static code analysis
   analysis:
     needs: changes
-    if: ${{ needs.changes.outputs.dart-files == 'true' }}
+    if: ${{ needs.changes.outputs.flutter-files == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,7 +51,7 @@ jobs:
   # Unit testing
   testing:
     needs: changes
-    if: ${{ needs.changes.outputs.dart-files == 'true' }}
+    if: ${{ needs.changes.outputs.flutter-files == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Currently, our CI pipeline only runs when `*.dart` files are modified. This PR extends the CI trigger to include changes to `pubspec.*` files, ensuring that dependency updates are also properly tested.

## Summary (check all that apply)

- [ ] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [x] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
