### PR TITLE
Analyze and test with both lowest and highest supported Flutter SDK versions in CI

### DIFF
--- a/.github/actions/setup_flutter/action.yaml
+++ b/.github/actions/setup_flutter/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: "The working directory where the Flutter project is located."
     required: false
     default: "."
+  version:
+    description: "The version of Flutter to install."
+    required: false
+    default: "3.x"
 
 runs:
   using: "composite"
@@ -14,7 +18,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         channel: stable
-        flutter-version: 3.x
+        flutter-version: ${{ inputs.version }}
         cache: true
 
     - name: Flutter version

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -36,6 +36,10 @@ jobs:
           sdk_constraint=$(cat pubspec.yaml | yq .environment.flutter)
           lowest=$(echo "$sdk_constraint" | grep -oP '(?<=\>=)[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           highest=$(echo "$sdk_constraint" | grep -oP '(?<=\<)[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # If no upper bound is specified, default to 3.x
+          if [ -z "$highest" ]; then
+            highest="3.x"
+          fi
           echo "lowest=$lowest" >> "$GITHUB_OUTPUT"
           echo "highest=$highest" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -9,7 +9,6 @@ env:
   PATTERN_CHECKER: ${{github.workspace}}/scripts/pattern_checker.sh
 
 jobs:
-  # Change detection
   setup:
     runs-on: ubuntu-latest
     permissions:
@@ -46,17 +45,23 @@ jobs:
           echo "lowest-flutter-version=${{ steps.flutter-version-constraint.outputs.lowest }}"
           echo "highest-flutter-version=${{ steps.flutter-version-constraint.outputs.highest }}"
 
-  # Static code analysis
   analysis:
     needs: setup
     if: ${{ needs.setup.outputs.flutter-file-changed == 'true' }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter-version:
+          - ${{ needs.setup.outputs.lowest-flutter-version }}
+          - ${{ needs.setup.outputs.highest-flutter-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Flutter
         uses: ./.github/actions/setup_flutter
+        with:
+          version: ${{ matrix.flutter-version }}
 
       - name: Format
         run: dart format . -o none --set-exit-if-changed
@@ -67,7 +72,6 @@ jobs:
       - name: Disallowed patterns check
         run: bash ${{ env.PATTERN_CHECKER }} "*.dart" "--" "debugPrint"
 
-  # Unit testing
   testing:
     needs: setup
     if: ${{ needs.setup.outputs.flutter-file-changed == 'true' }}
@@ -76,12 +80,19 @@ jobs:
       contents: read
       actions: read
       checks: write
+    strategy:
+      matrix:
+        flutter-version:
+          - ${{ needs.setup.outputs.lowest-flutter-version }}
+          - ${{ needs.setup.outputs.highest-flutter-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Flutter
         uses: ./.github/actions/setup_flutter
+        with:
+          version: ${{ matrix.flutter-version }}
 
       - name: Run unit tests
         run: flutter test --file-reporter="json:${{ env.FLUTTER_TEST_REPORT }}"
@@ -91,7 +102,7 @@ jobs:
         # PRs from forks have no write permissions.
         if: github.event.pull_request.head.repo.fork == false && (success() || failure())
         with:
-          name: Test Report
+          name: Test Report (with Flutter ${{ matrix.flutter-version }})
           path: ${{ env.FLUTTER_TEST_REPORT }}
           reporter: flutter-json
 

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -16,9 +16,13 @@ jobs:
       pull-requests: read
     outputs:
       flutter-file-changed: ${{ steps.filter.outputs.flutter-file-changed }}
+      lowest-flutter-version: ${{ steps.flutter-version-constraint.outputs.lowest }}
+      highest-flutter-version: ${{ steps.flutter-version-constraint.outputs.highest }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+
+      - name: Filter changed files
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -26,6 +30,21 @@ jobs:
               - '**.dart'
               - 'pubspec.yaml'
               - 'pubspec.lock'
+
+      - name: Get Flutter SDK version constraint
+        id: flutter-version-constraint
+        run: |
+          sdk_constraint=$(cat pubspec.yaml | yq .environment.flutter)
+          lowest=$(echo "$sdk_constraint" | grep -oP '(?<=\>=)[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          highest=$(echo "$sdk_constraint" | grep -oP '(?<=\<)[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          echo "lowest=$lowest" >> "$GITHUB_OUTPUT"
+          echo "highest=$highest" >> "$GITHUB_OUTPUT"
+
+      - name: Print output values
+        run: |
+          echo "flutter-file-changed=${{ steps.filter.outputs.flutter-file-changed }}"
+          echo "lowest-flutter-version=${{ steps.flutter-version-constraint.outputs.lowest }}"
+          echo "highest-flutter-version=${{ steps.flutter-version-constraint.outputs.highest }}"
 
   # Static code analysis
   analysis:

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -10,27 +10,27 @@ env:
 
 jobs:
   # Change detection
-  changes:
+  setup:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
-      flutter-files: ${{ steps.filter.outputs.flutter-files }}
+      flutter-file-changed: ${{ steps.filter.outputs.flutter-file-changed }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            flutter-files:
+            flutter-file-changed:
               - '**.dart'
               - 'pubspec.yaml'
               - 'pubspec.lock'
 
   # Static code analysis
   analysis:
-    needs: changes
-    if: ${{ needs.changes.outputs.flutter-files == 'true' }}
+    needs: setup
+    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,8 +50,8 @@ jobs:
 
   # Unit testing
   testing:
-    needs: changes
-    if: ${{ needs.changes.outputs.flutter-files == 'true' }}
+    needs: setup
+    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Related issues (optional)

Closes #229.

## Description

The workflow file was updated to run unit tests and static analysis for both the lowest and highest supported Flutter SDK versions. This approach helps detect potential compatibility issues across the entire supported SDK range. For example, issue #144 stemmed from accidentally using newly added APIs in Flutter 3.22 that don't exist in lower versions, while issue #233 arose due to a breaking change introduced in Flutter 3.24.


## Summary (check all that apply)

- [ ] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [x] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
