### PR TITLE
Fix: Modal sheet jerks when swipe to dismiss

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -195,7 +195,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.4"
+    version: "0.10.0"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,6 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
-  go_router: ^14.3.0
+  go_router: ^14.2.3
   mockito: ^5.4.4
   pedantic_mono: ^1.23.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,5 +24,6 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
+  go_router: ^14.3.0
   mockito: ^5.4.4
   pedantic_mono: ^1.23.0

--- a/test/modal/modal_sheet_test.dart
+++ b/test/modal/modal_sheet_test.dart
@@ -2,36 +2,51 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 
+class _Boilerplate extends StatelessWidget {
+  const _Boilerplate({
+    required this.modalRoute,
+    this.navigatorKey,
+  });
+
+  final ModalSheetRoute<dynamic> modalRoute;
+  final GlobalKey<NavigatorState>? navigatorKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      navigatorKey: navigatorKey,
+      home: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(context, modalRoute);
+                },
+                child: const Text('Open modal'),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
 void main() {
   group('Swipe-to-dismiss action test', () {
     Widget boilerplate(SwipeDismissSensitivity sensitivity) {
-      return MaterialApp(
-        home: Builder(
+      return _Boilerplate(
+        modalRoute: ModalSheetRoute<dynamic>(
+          swipeDismissible: true,
+          swipeDismissSensitivity: sensitivity,
           builder: (context) {
-            return Scaffold(
-              body: Center(
-                child: ElevatedButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      ModalSheetRoute<dynamic>(
-                        swipeDismissible: true,
-                        swipeDismissSensitivity: sensitivity,
-                        builder: (context) {
-                          return DraggableSheet(
-                            child: Container(
-                              key: const Key('sheet'),
-                              color: Colors.white,
-                              width: double.infinity,
-                              height: 600,
-                            ),
-                          );
-                        },
-                      ),
-                    );
-                  },
-                  child: const Text('Open modal'),
-                ),
+            return DraggableSheet(
+              child: Container(
+                key: const Key('sheet'),
+                color: Colors.white,
+                width: double.infinity,
+                height: 600,
               ),
             );
           },
@@ -155,37 +170,21 @@ void main() {
 
     setUp(() {
       isOnPopInvokedCalled = false;
-      testWidget = MaterialApp(
-        home: Builder(
+      testWidget = _Boilerplate(
+        modalRoute: ModalSheetRoute(
+          swipeDismissible: true,
           builder: (context) {
-            return Scaffold(
-              body: Center(
-                child: ElevatedButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      ModalSheetRoute<dynamic>(
-                        swipeDismissible: true,
-                        builder: (context) {
-                          return DraggableSheet(
-                            child: PopScope(
-                              canPop: false,
-                              onPopInvoked: (didPop) {
-                                isOnPopInvokedCalled = true;
-                              },
-                              child: Container(
-                                key: const Key('sheet'),
-                                color: Colors.white,
-                                width: double.infinity,
-                                height: 200,
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-                    );
-                  },
-                  child: const Text('Open modal'),
+            return DraggableSheet(
+              child: PopScope(
+                canPop: false,
+                onPopInvoked: (didPop) {
+                  isOnPopInvokedCalled = true;
+                },
+                child: Container(
+                  key: const Key('sheet'),
+                  color: Colors.white,
+                  width: double.infinity,
+                  height: 200,
                 ),
               ),
             );
@@ -254,22 +253,9 @@ void main() {
 
       final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(
-        MaterialApp(
+        _Boilerplate(
+          modalRoute: route,
           navigatorKey: navigatorKey,
-          home: Builder(
-            builder: (context) {
-              return Scaffold(
-                body: Center(
-                  child: ElevatedButton(
-                    onPressed: () {
-                      Navigator.push(context, route);
-                    },
-                    child: const Text('Open modal'),
-                  ),
-                ),
-              );
-            },
-          ),
         ),
       );
 

--- a/test/modal/modal_sheet_test.dart
+++ b/test/modal/modal_sheet_test.dart
@@ -5,16 +5,13 @@ import 'package:smooth_sheets/smooth_sheets.dart';
 class _Boilerplate extends StatelessWidget {
   const _Boilerplate({
     required this.modalRoute,
-    this.navigatorKey,
   });
 
   final ModalSheetRoute<dynamic> modalRoute;
-  final GlobalKey<NavigatorState>? navigatorKey;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      navigatorKey: navigatorKey,
       home: Builder(
         builder: (context) {
           return Scaffold(
@@ -223,11 +220,11 @@ void main() {
   });
 
   // Regression tests for https://github.com/fujidaiti/smooth_sheets/issues/250
-  group('userGestureInProgress and transition curve consistency test', () {
+  // TODO: Add test cases using Navigator 2.0.
+  group('Transition animation status and animation curve consistency test', () {
     ({
       Widget testWidget,
       ModalSheetRoute<dynamic> modalRoute,
-      GlobalKey<NavigatorState> navigatorKey,
       ValueGetter<bool> popInvoked,
     }) boilerplate() {
       var popInvoked = false;
@@ -255,16 +252,9 @@ void main() {
         },
       );
 
-      final navigatorKey = GlobalKey<NavigatorState>();
-      final testWidget = _Boilerplate(
-        modalRoute: modalRoute,
-        navigatorKey: navigatorKey,
-      );
-
       return (
-        testWidget: testWidget,
+        testWidget: _Boilerplate(modalRoute: modalRoute),
         modalRoute: modalRoute,
-        navigatorKey: navigatorKey,
         popInvoked: () => popInvoked,
       );
     }
@@ -275,38 +265,42 @@ void main() {
 
       await tester.tap(find.text('Open modal'));
       await tester.pumpAndSettle();
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isFalse);
+      expect(env.modalRoute.animation!.isCompleted, isTrue);
       expect(env.modalRoute.effectiveCurve, Curves.easeInOut);
 
       // Start dragging.
       final gesture = await tester.press(find.byKey(const Key('sheet')));
       await gesture.moveBy(const Offset(0, 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await gesture.moveBy(const Offset(0, 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       // End dragging and then a pop animation starts.
       await gesture.moveBy(const Offset(0, 100));
       await gesture.up();
       expect(env.popInvoked(), isTrue);
-      expect(env.modalRoute.animation!.status, AnimationStatus.reverse);
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await tester.pump(const Duration(milliseconds: 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await tester.pump(const Duration(milliseconds: 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       // Ensure that the pop animation is completed.
       await tester.pumpAndSettle();
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isTrue);
       expect(env.modalRoute.effectiveCurve, Curves.easeInOut);
     });
 
@@ -316,17 +310,19 @@ void main() {
 
       await tester.tap(find.text('Open modal'));
       await tester.pumpAndSettle();
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isFalse);
+      expect(env.modalRoute.animation!.isCompleted, isTrue);
       expect(env.modalRoute.effectiveCurve, Curves.easeInOut);
 
       // Start dragging.
       final gesture = await tester.press(find.byKey(const Key('sheet')));
       await gesture.moveBy(const Offset(0, 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await gesture.moveBy(const Offset(0, 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       // Release the drag, triggering the modal
@@ -334,20 +330,23 @@ void main() {
       await gesture.up();
       expect(env.popInvoked(), isFalse);
       expect(env.modalRoute.animation!.status, AnimationStatus.forward);
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await tester.pump(const Duration(milliseconds: 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       await tester.pump(const Duration(milliseconds: 50));
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+      expect(env.modalRoute.animation!.isCompleted, isFalse);
+      expect(env.modalRoute.animation!.isDismissed, isFalse);
       expect(env.modalRoute.effectiveCurve, Curves.linear);
 
       // Ensure that the pop animation is completed.
       await tester.pumpAndSettle();
-      expect(env.navigatorKey.currentState!.userGestureInProgress, isFalse);
+      expect(env.modalRoute.animation!.isCompleted, isTrue);
       expect(env.modalRoute.effectiveCurve, Curves.easeInOut);
     });
   });


### PR DESCRIPTION
## Related issues (optional)

Fixes #250.

## Description

This PR modifies `_SwipeDismissibleController` to ensure that the transition animation curve remains linear during the animation triggered by a swipe-to-dismiss gesture. This is crucial to prevent the sheet from jerking when the user swipes it down, as reported in #250. See the comments in the `_handleDragEnd` method for a more detailed explanation.

## Summary (check all that apply)

- [x] Modified / added code
- [x] Modified / added tests
- [ ] Modified / added examples
- [x] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
