### PR TITLE
Update cupertino.dart to fix page route

### DIFF
--- a/lib/src/modal/cupertino.dart
+++ b/lib/src/modal/cupertino.dart
@@ -343,7 +343,7 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
   });
 
   late final SheetController _sheetController;
-  PageRoute<dynamic>? _previousRoute;
+  Route<dynamic>? _previousRoute;
 
   @override
   void install() {
@@ -366,7 +366,7 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
   @override
   void didChangePrevious(Route<dynamic>? previousRoute) {
     super.didChangePrevious(previousRoute);
-    _previousRoute = previousRoute as PageRoute?;
+    _previousRoute = previousRoute as Route?;
   }
 
   void _invalidateTransitionProgress() {


### PR DESCRIPTION
## Description

Previous route is hardcoded as a `PageRoute` but the previous route may not always be a `PageRoute`.  What about `ModalRoute`, `Popuproute` etc?

Before the fix, if the previous route was not a page route then you get a fatal error leading to unresponsive app. 

This is more generally addressing the previous route as a `Route` including all the various inherited types of routes

There is no breaking change that I can see

## Summary (check all that apply)

- [X ] Modified / added code
- [ ] Modified / added tests
- [ ] Modified / added examples
- [ ] Modified / added others (pubspec.yaml, workflows, etc...)
- [ ] Updated README
- [ ] Contains breaking changes
  - [ ] Created / updated migration guide
- [ ] Incremented version number
  - [ ] Updated CHANGELOG
