### PR TITLE
Fix: bottom bar is hidden despite `BottomBarVisibility.always(ignoreBottomInset: true)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.2 Apr 17, 2025
+
+- Fix: bottom bar is hidden despite `BottomBarVisibility.always(ignoreBottomInset: true)` [#312](https://github.com/fujidaiti/smooth_sheets/issues/312)
+
 ## 0.11.1 Apr 14, 2025
 
 - Fix: PagedSheetRoute's initialOffset is ignored when using auto_route: Sheet displays full screen on startup [#308](https://github.com/fujidaiti/smooth_sheets/issues/308)

--- a/lib/src/content_scaffold.dart
+++ b/lib/src/content_scaffold.dart
@@ -683,8 +683,10 @@ abstract class _RenderBottomBarVisibility extends RenderTransform {
     if (bottomBarSize != null && _model.hasMetrics) {
       // This translation ensures that the bar is fully visible even when
       // the sheet's content is partially or fully outside of the viewport.
-      final baseDeltaY =
-          (_model.viewportSize.height - _model.contentRect.bottom).clamp(
+      final baseDeltaY = (_model.viewportSize.height -
+              _model.contentBaseline -
+              _model.contentRect.bottom)
+          .clamp(
         // Prevent the bar from being moved up
         // when the content is fully outside of the viewport.
         bottomBarSize.height - _model.contentSize.height,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smooth_sheets
 description: Sheet widgets with smooth motion and great flexibility. Also supports nested navigation in both imperative and declarative ways.
-version: 0.11.1
+version: 0.11.2
 repository: https://github.com/fujidaiti/smooth_sheets
 screenshots:
   - description: Practical examples of smooth_sheets.

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -999,6 +999,16 @@ void main() {
           Rect.fromLTWH(0, 500, 800, 50),
           reason: 'The keyboard height should not affect the layout of the bar',
         );
+
+        env.getModel().offset = 500;
+        await tester.pump();
+        expect(env.getModel().visibleContentRect!.height, 500);
+        expect(
+          env.getLocalBottomBarRect(tester),
+          Rect.fromLTWH(0, 400, 800, 50),
+          reason: 'The bar should be visible even if '
+              'the scaffold is partially outside of the viewport',
+        );
       },
     );
 
@@ -1152,6 +1162,24 @@ void main() {
           env.getLocalBottomBarRect(tester),
           Rect.fromLTWH(0, 500, 800, 50),
           reason: 'The keyboard height should not affect the layout of the bar',
+        );
+
+        env.getModel().offset = 500;
+        await tester.pump();
+        expect(env.getModel().visibleContentRect!.height, 500);
+        expect(
+          env.getLocalBottomBarRect(tester),
+          Rect.fromLTWH(0, 400, 800, 50),
+          reason: 'The bar should be visible even if '
+              'the scaffold is partially outside of the viewport',
+        );
+
+        visibilityNotifier.value = 0.0;
+        await tester.pump();
+        expect(
+          env.getLocalBottomBarRect(tester),
+          Rect.fromLTWH(0, 450, 800, 50),
+          reason: 'The bar should be fully hidden',
         );
       },
     );
@@ -1320,6 +1348,15 @@ void main() {
           env.getLocalBottomBarRect(tester),
           Rect.fromLTWH(0, 500, 800, 50),
           reason: 'The keyboard height should not affect the layout of the bar',
+        );
+
+        env.getModel().offset = 500;
+        await tester.pumpAndSettle();
+        expect(env.getModel().visibleContentRect!.height, 500);
+        expect(
+          env.getLocalBottomBarRect(tester),
+          Rect.fromLTWH(0, 450, 800, 50),
+          reason: 'The bar should be fully hidden',
         );
       },
     );


### PR DESCRIPTION
## Problem / Issue

Fixes #312.

When using `SheetContentScaffold` with `BottomBarVisibility.always(ignoreBottomInset: true)`, the bottom bar was incorrectly hidden by the on-screen keyboard or when the sheet was scrolled partially offscreen.

## Solution

This PR corrects the vertical offset calculation for the bottom bar within the `_RenderBottomBarVisibility` render object.

The root cause was that the calculation for `baseDeltaY` (the vertical translation applied to the bottom bar) did not correctly account for the `MediaQueryData.viewInsets.bottom` (keyboard height) when `ignoreBottomInset: true`. This prevented the bottom bar from translating upwards along with the sheet body as intended, causing it to be obscured by the keyboard or hidden when the sheet was partially scrolled.
