### PR TITLE
fix: Unstable route transition in PagedSheet when pop a route during snapping animation

### DIFF
--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -171,7 +171,6 @@ class _PagedSheetModel extends SheetModel<_PagedSheetModelConfig>
 
     beginActivity(
       _RouteTransitionSheetActivity(
-        originRouteOffset: targetOffsetResolver(currentEntry),
         destinationRouteOffset: targetOffsetResolver(nextEntry),
         animation: effectiveAnimation,
         animationCurve: effectiveCurve,
@@ -206,16 +205,15 @@ class _PagedSheetIdleActivity extends IdleSheetActivity<_PagedSheetModel> {
 
 class _RouteTransitionSheetActivity extends SheetActivity<_PagedSheetModel> {
   _RouteTransitionSheetActivity({
-    required this.originRouteOffset,
     required this.destinationRouteOffset,
     required this.animation,
     required this.animationCurve,
   });
 
-  final ValueGetter<double?> originRouteOffset;
   final ValueGetter<double?> destinationRouteOffset;
   final Animation<double> animation;
   final Curve animationCurve;
+  late final double _startPixelOffset;
   late final Animation<double> _effectiveAnimation;
 
   @override
@@ -224,6 +222,7 @@ class _RouteTransitionSheetActivity extends SheetActivity<_PagedSheetModel> {
   @override
   void init(_PagedSheetModel owner) {
     super.init(owner);
+    _startPixelOffset = owner.offset;
     owner.config = owner.config.copyWith(snapGrid: _kDefaultSnapGrid);
     _effectiveAnimation = animation.drive(
       CurveTween(curve: animationCurve),
@@ -238,11 +237,10 @@ class _RouteTransitionSheetActivity extends SheetActivity<_PagedSheetModel> {
 
   void _onAnimationTick() {
     final fraction = _effectiveAnimation.value;
-    final originOffset = originRouteOffset();
     final destOffset = destinationRouteOffset();
 
-    if (originOffset != null && destOffset != null) {
-      owner.offset = lerpDouble(originOffset, destOffset, fraction)!;
+    if (destOffset != null) {
+      owner.offset = lerpDouble(_startPixelOffset, destOffset, fraction)!;
     }
   }
 }

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1196,6 +1196,7 @@ void main() {
   });
 
   group('Regression test', () {
+    // https://github.com/fujidaiti/smooth_sheets/issues/309
     testWidgets(
       'Unstable route transition when pop a route during snapping animation',
       (tester) async {

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1194,6 +1194,83 @@ void main() {
       expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
     });
   });
+
+  group('Regression test', () {
+    testWidgets(
+      'Unstable route transition when pop a route during snapping animation',
+      (tester) async {
+        final controller = SheetController();
+        final navigatorKey = GlobalKey<NavigatorState>();
+        const sheetKey = Key('sheet');
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SheetViewport(
+              child: PagedSheet(
+                key: sheetKey,
+                controller: controller,
+                navigator: Navigator(
+                  key: navigatorKey,
+                  onGenerateRoute: (_) {
+                    return PagedSheetRoute(
+                      builder: (_) => _TestPage(
+                        key: Key('a'),
+                        height: 300,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        unawaited(
+          navigatorKey.currentState!.push(
+            PagedSheetRoute(
+              snapGrid: SheetSnapGrid(
+                minFlingSpeed: 50,
+                snaps: [SheetOffset(0.5), SheetOffset(1)],
+              ),
+              builder: (_) => _TestPage(
+                key: Key('b'),
+                height: 600,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(find.byId('b'), findsOneWidget);
+        expect(tester.getRect(find.byId('b')).top, 0);
+
+        final offsetHistory = <double>[];
+        controller.addListener(() {
+          offsetHistory.add(controller.value!);
+        });
+
+        await tester.fling(find.byId('b'), Offset(0, 100), 200);
+        await tester.pump(Duration(milliseconds: 500));
+        final sheetTopBeforePop = tester.getRect(find.byId('b')).top;
+        expect(
+          sheetTopBeforePop,
+          allOf(greaterThan(0), lessThan(300)),
+          reason: 'The sheet is in the middle of the snapping animation',
+        );
+
+        navigatorKey.currentState!.pop();
+        await tester.pump();
+        expect(
+          tester.getRect(find.byId('b')).top,
+          sheetTopBeforePop,
+          reason: 'The sheet position should be preserved',
+        );
+
+        await tester.pumpAndSettle();
+        expect(offsetHistory, isMonotonicallyDecreasing);
+      },
+    );
+  });
 }
 
 class _TestPage extends StatelessWidget {


### PR DESCRIPTION
## Problem / Issue

Fixes #309.

When a route within a `PagedSheet` is popped using `Navigator.pop()` while the sheet is undergoing a snapping animation (e.g., after a fling), the subsequent route transition animation starts from an incorrect offset. Instead of animating smoothly from the sheet's current position at the moment `pop()` is called, the animation uses an incorrect offset as its starting point, where the sheet was settled *before* the snapping animation began. This causes a visual jump or instability in the transition. This is particularly noticeable when popping a route during a fling-induced snap.

## Solution

This PR addresses the issue by modifying the `_RouteTransitionSheetActivity`, which handles the sheet offset animation during route transitions.

1.  **Capture Current Offset:** The activity now captures the sheet's exact pixel offset (`owner.offset`) at the moment the transition begins and stores it in a new field `_startPixelOffset`.
2.  **Animate from Captured Offset:** The animation logic (`_onAnimationTick`) has been updated to interpolate between the captured `_startPixelOffset` and the `destinationRouteOffset` of the next route.
3.  **Remove Redundant Parameter:** The `originRouteOffset` parameter, which previously contributed to the incorrect starting point calculation, has been removed as it's no longer needed.

This ensures that the transition animation always starts smoothly from the sheet's actual position when the transition is initiated, resolving the instability observed when popping during a snap animation. The accompanying test case, which specifically reproduces this scenario, now passes.