### PR TITLE
chore: Add PR title lint workflow

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,32 @@
+name: "PR Title Lint"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  lint_pr_title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title against Conventional Commits format
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          types: |
+            fix
+            feat
+            docs
+            refactor
+            style
+            test
+            chore
+            revert
+          requireScope: false
+


### PR DESCRIPTION
Closes #317.

This PR introduces a GitHub Actions workflow that validates PR titles against Conventional Commits using [amannn/action-semantic-pull-request@v5](https://github.com/amannn/action-semantic-pull-request).