### PR TITLE
chore: Remove redundant workflow triggers on main branch

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -1,7 +1,5 @@
 name: Code Check
 on:
-  push:
-    branches: main
   pull_request:
 
 env:

--- a/.github/workflows/dry_publish.yaml
+++ b/.github/workflows/dry_publish.yaml
@@ -1,7 +1,5 @@
 name: Dry Publish
 on:
-  push:
-    branches: main
   pull_request:
     branches: main
 


### PR DESCRIPTION
## Problem / Issue

Closes #319.

Currently, the `code_check` and `dry_publish` workflows run validation on the `main` branch after every merge. However, due to branch protection rules, all changes to `main` must go through a pull request, and only PRs that pass validation can be merged. Therefore, running validation again on `main` after merging is redundant and consumes unnecessary resources.

## Solution

This PR removes the `on: push: branches: main` trigger from the following workflow files:
- `.github/workflows/code_check.yaml`
- `.github/workflows/dry_publish.yaml`

This ensures these workflows only run on pull requests, eliminating the redundant checks on the `main` branch after merging. 