### PR TITLE
Make SheetDraggable Public to Allow More Granular Drag Control

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -8,6 +8,7 @@ export 'src/controller.dart' hide SheetControllerScope;
 export 'src/cupertino.dart';
 export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
+export 'src/draggable.dart';
 export 'src/keyboard_dismissible.dart';
 export 'src/modal.dart';
 export 'src/model.dart'

--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 
 import 'model.dart';
 import 'model_owner.dart';
@@ -12,7 +11,6 @@ import 'sheet.dart';
 /// Typically, this widget is used when placing non-scrollable widget(s)
 /// in a [Sheet], since it only works with scrollable widgets,
 /// so you can't drag the sheet by touching a non-scrollable area.
-@internal
 class SheetDraggable extends StatefulWidget {
   /// Creates a drag-handle for a sheet.
   ///


### PR DESCRIPTION
## Problem / Issue

When using certain widgets like WebViews, the drag gesture used for sheet scrolling can override the internal scrolling of these widgets. This makes it impossible to scroll inside a WebView when drag gestures are active globally.

To better manage this behavior, it is important to localize drag gestures—for example, limiting them to the app bar only. To achieve this, the SheetDraggable widget should be exported so it can be used more modularly and integrated precisely where needed.
