### PR TITLE
refactor(pkg): Hide SheetDismissible from public API

### DIFF
--- a/.cliffignore
+++ b/.cliffignore
@@ -1,0 +1,7 @@
+# Git-cliff ignores the following commits when generating CHANGELOG.
+# See https://git-cliff.org/docs/usage/skipping-commits for more details.
+
+# COMMIT: feat(pkg): Reintroduce SheetDismissible (#341)
+# REASON: SheetDismissible was excluded from the public API in the immediately following commit.
+#         It's fine to skip this commit since SheetDismissible was hidden before it was published.
+6b976a1c9b64d1b6ca6f996358a1636ae9c6b41b

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
 import 'drag.dart';
 import 'gesture_proxy.dart';
@@ -196,7 +196,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     return SheetViewport(
       padding: viewportPadding,
       child: switch (swipeDismissible) {
-        true => SheetDismissible(
+        true => _SheetDismissible(
             sensitivity: swipeDismissSensitivity,
             child: buildSheet(context),
           ),
@@ -259,28 +259,8 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
 ///
 /// Must be used as the content of a modal that implements
 /// [ModalSheetRouteMixin], and must be an ancestor of the sheet.
-///
-/// It is rarely used directly, as setting [ModalSheetRoute.swipeDismissible]
-/// to `true` implicitly wraps the sheet in a [SheetDismissible].
-/// However, it can be useful for conditionally enabling or disabling
-/// the swipe-to-dismiss gesture based on some logic.
-///
-/// ```dart
-/// ModalSheetRoute(
-///   swipeDismissible: false,
-///   builder: (context) {
-///     bool isDismissible = ...;
-///     Widget sheet = Sheet(...);
-///     return isDismissible ? SheetDismissible(child: sheet) : sheet;
-///   },
-/// );
-/// ```
-///
-/// The sensitivity of the swipe-to-dismiss gesture can be configured using
-/// the [sensitivity] property.
-class SheetDismissible extends StatefulWidget {
-  const SheetDismissible({
-    super.key,
+class _SheetDismissible extends StatefulWidget {
+  const _SheetDismissible({
     required this.child,
     this.sensitivity = const SwipeDismissSensitivity(),
   });
@@ -289,10 +269,10 @@ class SheetDismissible extends StatefulWidget {
   final Widget child;
 
   @override
-  State<SheetDismissible> createState() => _SheetDismissibleState();
+  State<_SheetDismissible> createState() => _SheetDismissibleState();
 }
 
-class _SheetDismissibleState extends State<SheetDismissible>
+class _SheetDismissibleState extends State<_SheetDismissible>
     with SheetGestureProxyMixin {
   late ModalSheetRouteMixin<dynamic> _route;
 

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -236,53 +236,6 @@ void main() {
         expect(find.byKey(const Key('sheet')), findsOneWidget);
       },
     );
-
-    testWidgets(
-      'existance of SheetDismissible should take precedence '
-      'over swipeDismissible flag',
-      (tester) async {
-        await tester.pumpWidget(
-          boilerplate(
-            swipeDismissible: false,
-            builder: (sheet) => SheetDismissible(
-              sensitivity: SwipeDismissSensitivity(minFlingVelocityRatio: 1),
-              child: sheet,
-            ),
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-
-        await tester.fling(
-          find.byKey(const Key('sheet')),
-          const Offset(0, 200),
-          1000,
-        );
-        await tester.pumpAndSettle();
-        expect(find.byKey(const Key('sheet')), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'Should warn if SheetDismissible is used with isSwipeDismissible=true',
-      (tester) async {
-        await tester.pumpWidget(
-          boilerplate(
-            swipeDismissible: true,
-            builder: (sheet) => SheetDismissible(
-              sensitivity: SwipeDismissSensitivity(minFlingVelocityRatio: 1),
-              child: sheet,
-            ),
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        final errors = await tester.pumpAndSettleAndCaptureErrors();
-        expect(errors.first.exception, isAssertionError);
-      },
-    );
   });
 
   // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/233
@@ -314,6 +267,22 @@ void main() {
         ),
       );
     });
+
+    testWidgets(
+      'existance of PopScope should take precedence over swipeDismissible flag',
+      (tester) async {
+        await tester.pumpWidget(testWidget);
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+        await tester.fling(
+          find.byKey(const Key('sheet')),
+          const Offset(0, 200),
+          2000,
+        );
+        await tester.pumpAndSettle();
+        expect(find.byId('sheet'), findsOneWidget);
+      },
+    );
 
     testWidgets(
       'PopScope.onPopInvoked should be called when tap on barrier',


### PR DESCRIPTION
## Problem / Issue

`SheetDismissible` was reintroduced in #339. However, while working on #170, we realized that the fix for #170 isn't compatible with exposing `SheetDismissible` as part of the public API. More details will be available in an upcoming PR.

## Solution

Since `SheetDismissible` hasn't been published yet, this PR simply makes it a private class. We're not removing it entirely, as it will be required to address other issues like #303. Instead, users are encouraged to use `PopScope.canPop` to control the dismissibility of a modal in the build method.