### PR TITLE
fix(pkg): changing swipeDismissible dynamically causes a layout error

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -245,6 +245,7 @@ abstract class SheetModel<C extends SheetModelConfig> extends SheetModelView
   @override
   bool get shouldIgnorePointer => activity.shouldIgnorePointer;
 
+  // ignore: lines_longer_than_80_chars
   // TODO: Remote this field. The initial offset should be determined by the activity.
   SheetOffset get initialOffset;
 


### PR DESCRIPTION
## Problem / Issue

Fixes #170.

Dynamically changing the `swipeDismissible` property of a `ModalSheetPage` (e.g., in response to route arguments or state changes) can cause layout assertion errors.

The underlying issue is that, prior to thisPR, toggling the `swipeDismissible` flag dynamically affected the widget tree by conditionally adding or removing the `SheetGestureProxy. Since the sheet widget typically did not have a `GlobalKey`, this change in `SheetGestureProxy` presence caused the sheet's state to be lost. As a result, the following assertion errors were thrown:

1. `The sheet extent and the dimensions values must be finalized during the layout phase. 'package:smooth_sheets/src/foundation/sheet_viewport.dart': Failed assertion: line 88 pos 7: '_extent.metrics.hasDimensions'`
2. `NavigationSheet: markAsDimensionsWillChange() was called more times than markAsDimensionsChanged() in a frame. 'package:smooth_sheets/src/foundation/sheet_extent.dart': Failed assertion: line 304 pos 13: '_markAsDimensionsWillChangeCallCount == 0'`

## Solution

The `_SheetDismissible` widget now wraps its `child` (typically a sheet widget) in a `KeyedSubtree` assigned with a `GlobalKey`. This ensures that the child widget's state is preserved even when `SheetGestureProxy` is added or removed dynamically, depending on the `swipeDismissible` property.