### PR TITLE
fix(pkg): assertion error when push CupertinoModalSheetRoute during closing animation

### DIFF
--- a/test/cupertino_test.dart
+++ b/test/cupertino_test.dart
@@ -7,6 +7,7 @@ import 'package:smooth_sheets/src/gesture_proxy.dart';
 import 'package:smooth_sheets/src/model.dart';
 import 'package:smooth_sheets/src/model_owner.dart';
 import 'package:smooth_sheets/src/physics.dart';
+import 'package:smooth_sheets/src/sheet.dart';
 import 'package:smooth_sheets/src/snap_grid.dart';
 import 'package:smooth_sheets/src/viewport.dart';
 
@@ -337,6 +338,55 @@ void main() {
       );
     },
   );
+
+  group('Regression test', () {
+    // https://github.com/fujidaiti/smooth_sheets/issues/340
+    testWidgets(
+      'Crashes when pushing a new sheet while another is closing',
+      (tester) async {
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: Builder(
+              builder: (context) {
+                return CupertinoPageScaffold(
+                  child: Center(
+                    child: CupertinoButton(
+                      child: Text('Open modal'),
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          CupertinoModalSheetRoute<dynamic>(
+                            barrierDismissible: true,
+                            builder: (context) => Sheet(
+                              key: Key('sheet'),
+                              child: Container(height: 200),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+        expect(find.byId('sheet'), findsOneWidget);
+
+        // Tap the barrier to close the sheet.
+        await tester.tapAt(Offset(400, 300));
+        await tester.pump(Duration(milliseconds: 100));
+        // Tap the button to open a new sheet
+        // in the middle of the closing animation.
+        await tester.tap(find.text('Open modal'));
+        final errors = await tester.pumpAndSettleAndCaptureErrors();
+        expect(errors, isEmpty);
+        expect(find.byId('sheet'), findsOneWidget);
+      },
+    );
+  });
 }
 
 class _TestIdleSheetActivity extends SheetActivity {


### PR DESCRIPTION
## Problem / Issue

Fixes #340.

An assertion (`!_routeToControllerMap.containsKey(route)`) failed in `_OutgoingTransitionController` when a new `CupertinoModalSheetRoute` was pushed while a previous one was still animating closed.

The issue stemmed from an assumption that there would only ever be one `_OutgoingTransitionController` per route, stored in a global map object (`_routeToControllerMap`). However, during rapid push/pop sequences, multiple `_OutgoingTransitionState` instances could be created for the same route within a single frame. This led to multiple attempts to register controllers for that route in the global map, causing the assertion failure.

## Solution

This PR resolves the assertion error by refactoring the management of outgoing transitions for routes preceding a `CupertinoModalSheetRoute`:

1.  **Removed Static Map:** The static `_routeToControllerMap` within `_OutgoingTransitionController` has been removed.
2.  **Instance-Owned Controller:** Each `_BaseCupertinoModalSheetRoute` now owns and manages its instance of `_OutgoingTransitionController`. This ensures a strict one-to-one relationship between a route and its controller.
3.  **Introduced `_PreviousRouteEntry`:** A new sealed class `_PreviousRouteEntry` (`_NonCupertinoModalEntry`, `_CupertinoModalEntry`) manages the interaction with the previous route. It ensures that the correct outgoing transition controller (either the previous route's own if it's a `_BaseCupertinoModalSheetRoute`, or a newly created one if not) is used.
