### PR TITLE
fix(pkg): SheetNotification not dispatched during PagedSheet route transitions

### DIFF
--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -242,6 +242,7 @@ class _RouteTransitionSheetActivity extends SheetActivity<_PagedSheetModel> {
 
     if (destOffset != null) {
       owner.offset = lerpDouble(_startPixelOffset, destOffset, fraction)!;
+      owner.didUpdateMetrics();
     }
   }
 }

--- a/test/notification_test.dart
+++ b/test/notification_test.dart
@@ -4,14 +4,10 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:smooth_sheets/src/controller.dart';
-import 'package:smooth_sheets/src/model.dart';
-import 'package:smooth_sheets/src/notification.dart';
-import 'package:smooth_sheets/src/physics.dart';
-import 'package:smooth_sheets/src/sheet.dart';
-import 'package:smooth_sheets/src/snap_grid.dart';
-import 'package:smooth_sheets/src/viewport.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+import 'src/matchers.dart';
 
 void main() {
   testWidgets(
@@ -362,4 +358,74 @@ void main() {
     },
   );
   */
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/345
+  testWidgets(
+    'PagedSheet should dispatch SheetUpdateNotification on page change '
+    'with different initialOffset via Pages API',
+    (tester) async {
+      final reportedNotifications = <SheetNotification>[];
+      final pageA = PagedSheetPage<dynamic>(
+        child: const SizedBox(height: 300),
+      );
+      final pageB = PagedSheetPage<dynamic>(
+        child: const SizedBox(height: 400),
+      );
+      final pagesNotifier = ValueNotifier([pageA]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NotificationListener<SheetNotification>(
+            onNotification: (notification) {
+              if (notification is SheetUpdateNotification) {
+                reportedNotifications.add(notification);
+              }
+              return false;
+            },
+            child: SheetViewport(
+              child: PagedSheet(
+                key: Key('sheet'),
+                navigator: ValueListenableBuilder(
+                  valueListenable: pagesNotifier,
+                  builder: (context, pages, _) {
+                    return Navigator(
+                      pages: pages,
+                      onDidRemovePage: (page) {
+                        pagesNotifier.value = [...pages]..remove(page);
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.getRect(find.byId('sheet')).top, 300);
+      reportedNotifications.clear();
+
+      // Navigate to Page B
+      pagesNotifier.value = [pageA, pageB];
+      await tester.pumpAndSettle();
+      expect(tester.getRect(find.byId('sheet')).top, 200);
+      expect(reportedNotifications.length, greaterThan(3));
+      expect(
+        reportedNotifications.map((it) => it.metrics.offset),
+        isMonotonicallyIncreasing,
+      );
+      reportedNotifications.clear();
+
+      // Pop Page B, returning to Page A
+      pagesNotifier.value = [pageA];
+      await tester.pumpAndSettle();
+      expect(tester.getRect(find.byId('sheet')).top, 300);
+      expect(reportedNotifications.length, greaterThan(3));
+      expect(
+        reportedNotifications.map((it) => it.metrics.offset),
+        isMonotonicallyDecreasing,
+      );
+    },
+  );
 }

--- a/test/notification_test.dart
+++ b/test/notification_test.dart
@@ -366,9 +366,11 @@ void main() {
     (tester) async {
       final reportedNotifications = <SheetNotification>[];
       final pageA = PagedSheetPage<dynamic>(
+        key: const ValueKey('pageA'),
         child: const SizedBox(height: 300),
       );
       final pageB = PagedSheetPage<dynamic>(
+        key: const ValueKey('pageB'),
         child: const SizedBox(height: 400),
       );
       final pagesNotifier = ValueNotifier([pageA]);
@@ -390,9 +392,7 @@ void main() {
                   builder: (context, pages, _) {
                     return Navigator(
                       pages: pages,
-                      onDidRemovePage: (page) {
-                        pagesNotifier.value = [...pages]..remove(page);
-                      },
+                      onDidRemovePage: (_) {},
                     );
                   },
                 ),
@@ -411,6 +411,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.getRect(find.byId('sheet')).top, 200);
       expect(reportedNotifications.length, greaterThan(3));
+      expect(reportedNotifications.last.metrics.offset, 400);
       expect(
         reportedNotifications.map((it) => it.metrics.offset),
         isMonotonicallyIncreasing,
@@ -422,6 +423,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.getRect(find.byId('sheet')).top, 300);
       expect(reportedNotifications.length, greaterThan(3));
+      expect(reportedNotifications.last.metrics.offset, 300);
       expect(
         reportedNotifications.map((it) => it.metrics.offset),
         isMonotonicallyDecreasing,


### PR DESCRIPTION
## Problem / Issue

Fixes #345.

When navigating between routes within a `PagedSheet` using the `Navigator` Pages API, `SheetUpdateNotification` was not consistently dispatched during the transition animation. While the final state might eventually be reflected, listeners relying on `SheetNotification` could not observe the continuous offset changes during the route transition animation itself.

## Solution

This PR ensures that `SheetUpdateNotification` is dispatched on each frame of the route transition animation within a `PagedSheet`.
