### PR TITLE
fix(pkg): Crashes when popping a non-modal sheet route just below a modal sheet route

### DIFF
--- a/lib/src/cupertino.dart
+++ b/lib/src/cupertino.dart
@@ -368,22 +368,25 @@ sealed class _PreviousRouteEntry {
   final PageRoute<dynamic> value;
 
   _OutgoingTransitionController get outgoingTransitionController;
-
-  void dispose() {}
 }
 
 class _NonCupertinoModalEntry extends _PreviousRouteEntry {
-  _NonCupertinoModalEntry(super.value)
-      : outgoingTransitionController =
-            _OutgoingTransitionController(route: value);
-
-  @override
-  final _OutgoingTransitionController outgoingTransitionController;
-
-  @override
-  void dispose() {
-    outgoingTransitionController.dispose();
+  _NonCupertinoModalEntry(super.value) {
+    _controllers[value]?.dispose();
+    _controllers[value] = _OutgoingTransitionController(route: value);
   }
+
+  /// Stores animation controllers for routes that are not of type
+  /// [_BaseCupertinoModalSheetRoute].
+  ///
+  /// An [Expando] is used intentionally to tie the controller's lifecycle
+  /// to that of the route. While this means the controllers may not be
+  /// explicitly disposed, this is unlikely to cause any issues.
+  static final _controllers = Expando<_OutgoingTransitionController>();
+
+  @override
+  _OutgoingTransitionController get outgoingTransitionController =>
+      _controllers[value]!;
 }
 
 class _CupertinoModalEntry extends _PreviousRouteEntry {
@@ -438,7 +441,6 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
 
   @override
   void dispose() {
-    _previousRouteEntry?.dispose();
     _outgoingTransitionController.dispose();
     super.dispose();
   }

--- a/test/cupertino_test.dart
+++ b/test/cupertino_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:smooth_sheets/src/activity.dart';
 import 'package:smooth_sheets/src/cupertino.dart';
 import 'package:smooth_sheets/src/gesture_proxy.dart';
@@ -387,119 +388,92 @@ void main() {
       },
     );
 
+    // https://github.com/fujidaiti/smooth_sheets/issues/355
     testWidgets(
-      '#355: Pop after closing a sheet from a pushed page causes exception (Navigator)',
+      'Crashes when popping a route just below the modal sheet',
       (tester) async {
-        const homeToDetailButtonKey = ValueKey('home_to_detail_button');
-        const detailShowSheetButtonKey = ValueKey('detail_show_sheet_button');
-        const detailGoHomeButtonKey = ValueKey('detail_go_home_button');
-        const sheetCloseButtonKey = ValueKey('sheet_close_button');
+        Widget buildSheet(BuildContext context) {
+          return Sheet(
+            key: const ValueKey('sheet'),
+            child: Container(
+              color: CupertinoColors.systemBackground.resolveFrom(context),
+              height: 300,
+              alignment: Alignment.center,
+              child: CupertinoButton(
+                child: const Text('Close Sheet'),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ),
+          );
+        }
 
-        await tester.pumpWidget(
-          CupertinoApp(
-            home: Builder(builder: (homeContext) {
-              // Home Page
-              return CupertinoPageScaffold(
-                child: Center(
-                  child: CupertinoButton(
-                    key: homeToDetailButtonKey,
-                    child: const Text('Go to Detail'),
+        Widget buildDetailPage(BuildContext context) {
+          return CupertinoPageScaffold(
+            key: const ValueKey('detail-page'),
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  CupertinoButton(
+                    child: const Text('Show Modal Sheet'),
                     onPressed: () {
-                      Navigator.of(homeContext).push(
-                        CupertinoPageRoute(builder: (detailContext) {
-                          // Detail Page
-                          return CupertinoPageScaffold(
-                            navigationBar: const CupertinoNavigationBar(
-                                middle: Text('Detail Page')),
-                            child: Center(
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  CupertinoButton(
-                                    key: detailShowSheetButtonKey,
-                                    child: const Text('Show Modal Sheet'),
-                                    onPressed: () {
-                                      Navigator.of(detailContext).push(
-                                        CupertinoModalSheetRoute(
-                                          builder: (sheetContext) {
-                                            // Sheet Content
-                                            return Sheet(
-                                              child: Container(
-                                                color: CupertinoColors
-                                                    .systemBackground
-                                                    .resolveFrom(sheetContext),
-                                                height: 300,
-                                                alignment: Alignment.center,
-                                                child: CupertinoButton(
-                                                  key: sheetCloseButtonKey,
-                                                  child:
-                                                      const Text('Close Sheet'),
-                                                  onPressed: () =>
-                                                      Navigator.of(sheetContext)
-                                                          .pop(),
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                        ),
-                                      );
-                                    },
-                                  ),
-                                  CupertinoButton(
-                                    key: detailGoHomeButtonKey,
-                                    child: const Text('Go to Home'),
-                                    onPressed: () => Navigator.of(detailContext)
-                                        .pop(), // This pops DetailPage
-                                  ),
-                                ],
-                              ),
-                            ),
-                          );
-                        }),
+                      Navigator.of(context).push(
+                        CupertinoModalSheetRoute<dynamic>(
+                          builder: buildSheet,
+                        ),
                       );
                     },
                   ),
-                ),
-              );
-            }),
-          ),
+                  CupertinoButton(
+                    child: const Text('Go to Home'),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        Widget buildHomePage(BuildContext context) {
+          return CupertinoPageScaffold(
+            key: const ValueKey('home-page'),
+            child: Center(
+              child: CupertinoButton(
+                child: const Text('Go to Detail'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<dynamic>(
+                      builder: buildDetailPage,
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+        }
+
+        await tester.pumpWidget(
+          CupertinoApp(home: Builder(builder: buildHomePage)),
         );
+        expect(find.byId('home-page'), findsOneWidget);
 
-        // 1. Initial state: Home page
-        expect(find.byKey(homeToDetailButtonKey), findsOneWidget);
-
-        // 2. Navigate to Detail page
-        await tester.tap(find.byKey(homeToDetailButtonKey));
+        await tester.tap(find.text('Go to Detail'));
         await tester.pumpAndSettle();
-        expect(find.text('Detail Page'), findsOneWidget);
-        expect(find.byKey(detailShowSheetButtonKey), findsOneWidget);
-        expect(find.byKey(detailGoHomeButtonKey), findsOneWidget);
+        expect(find.byId('detail-page'), findsOneWidget);
 
-        // 3. Show Modal Sheet
-        await tester.tap(find.byKey(detailShowSheetButtonKey));
+        await tester.tap(find.text('Show Modal Sheet'));
         await tester.pumpAndSettle();
-        expect(find.byKey(sheetCloseButtonKey), findsOneWidget);
+        expect(find.byId('sheet'), findsOneWidget);
 
-        // 4. Close Modal Sheet
-        await tester.tap(find.byKey(sheetCloseButtonKey));
+        await tester.tap(find.text('Close Sheet'));
         await tester.pumpAndSettle();
-        // We should be back on the Detail page
-        expect(find.text('Detail Page'), findsOneWidget);
-        expect(find.byKey(sheetCloseButtonKey), findsNothing);
-        expect(find.byKey(detailShowSheetButtonKey), findsOneWidget);
+        expect(find.byId('detail-page'), findsOneWidget);
 
-        // 5. Go to Home from Detail page (Pop DetailPage)
-        // This is the step that was causing an exception.
-        await tester.tap(find.byKey(detailGoHomeButtonKey));
+        await tester.tap(find.text('Go to Home'));
+        await tester.pumpAndSettle();
         final errors = await tester.pumpAndSettleAndCaptureErrors();
-
-        // Assert no errors
-        expect(errors, isEmpty,
-            reason:
-                'Expected no errors after popping DetailPage, but got: $errors');
-        // Assert we are on the Home page
-        expect(find.byKey(homeToDetailButtonKey), findsOneWidget);
-        expect(find.text('Detail Page'), findsNothing);
+        expect(errors, isEmpty);
+        expect(find.byId('detail-page'), findsNothing);
       },
     );
   });


### PR DESCRIPTION
## Problem / Issue

Fixes #355.

When a `CupertinoModalSheetRoute` is pushed, and the route immediately below it (the "previous route") is not a subclass of `_BaseCupertinoModalSheetRoute` (e.g., a standard `MaterialPageRoute` or `CupertinoPageRoute`), the following exception would occur if this previous route was popped *after* the modal sheet was dismissed.

```
A _OutgoingTransitionController was used after being disposed.
```

The exception happened because the `_OutgoingTransitionController` associated with this non-modal previous route was being disposed prematurely. Specifically, its `dispose` method was called when the `CupertinoModalSheetRoute` itself was disposed, rather than when the previous route it was managing was disposed.

## Solution

This PR modifies how `_OutgoingTransitionController` instances are managed for previous routes that are *not* subclasses of `_BaseCupertinoModalSheetRoute`.

1.  Controller Management with Expando:
    *   An `Expando<_OutgoingTransitionController>` named `_controllers` is introduced in the `_NonCupertinoModalEntry` class.
    *   When a `_NonCupertinoModalEntry` is created for a previous route, its `_OutgoingTransitionController` is now stored in this `Expando`, keyed by the route instance itself.
    *   This ties the lifecycle of the `_OutgoingTransitionController` directly to the lifecycle of its associated route. The controller will be garbage-collected when the route is no longer referenced.

2.  Removed Premature Disposal:
    *   The explicit call to `_previousRouteEntry?.dispose()` within `_BaseCupertinoModalSheetRoute.dispose()` has been removed. This was the source of the premature disposal for `_NonCupertinoModalEntry` controllers.
