### PR TITLE
Add modal utils

### DIFF
--- a/lib/modal_utils.dart
+++ b/lib/modal_utils.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+import 'src/cupertino.dart';
+import 'src/modal.dart';
+
+/// Pushes a [ModalSheetRoute] onto the current navigator.
+///
+/// This is a convenience wrapper around [Navigator.push].
+///
+/// ```dart
+/// final result = await showModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(),
+///   ),
+/// );
+/// ```
+Future<T?> showModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  RouteSettings? settings,
+  bool fullscreenDialog = false,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color barrierColor = Colors.black54,
+  bool swipeDismissible = false,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets viewportPadding = EdgeInsets.zero,
+}) {
+  final route = ModalSheetRoute<T>(
+    settings: settings,
+    fullscreenDialog: fullscreenDialog,
+    builder: builder,
+    maintainState: maintainState,
+    barrierDismissible: barrierDismissible,
+    barrierLabel: barrierLabel,
+    barrierColor: barrierColor,
+    swipeDismissible: swipeDismissible,
+    transitionDuration: transitionDuration,
+    transitionCurve: transitionCurve,
+    swipeDismissSensitivity: swipeDismissSensitivity,
+    viewportPadding: viewportPadding,
+  );
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(route);
+}
+
+/// Pushes a [CupertinoModalSheetRoute] onto the current navigator.
+///
+/// This is a convenience wrapper around [Navigator.push].
+///
+/// ```dart
+/// final result = await showCupertinoModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(),
+///   ),
+/// );
+/// ```
+Future<T?> showCupertinoModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  RouteSettings? settings,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color barrierColor = const Color(0x18000000),
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+}) {
+  final route = CupertinoModalSheetRoute<T>(
+    settings: settings,
+    builder: builder,
+    maintainState: maintainState,
+    barrierDismissible: barrierDismissible,
+    swipeDismissible: swipeDismissible,
+    barrierLabel: barrierLabel,
+    barrierColor: barrierColor,
+    transitionDuration: transitionDuration,
+    transitionCurve: transitionCurve,
+    swipeDismissSensitivity: swipeDismissSensitivity,
+  );
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(route);
+}
+
+/// Pushes a modal sheet adapted to the current platform.
+///
+/// Depending on [ThemeData.platform], this calls either
+/// [showCupertinoModalSheet] on iOS and macOS or [showModalSheet] on other
+/// platforms.
+///
+/// ```dart
+/// final result = await showAdaptiveModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(),
+///   ),
+/// );
+/// ```
+Future<T?> showAdaptiveModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  RouteSettings? settings,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color? barrierColor,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+}) {
+  final platform = Theme.of(context).platform;
+  if (platform == TargetPlatform.iOS || platform == TargetPlatform.macOS) {
+    return showCupertinoModalSheet<T>(
+      context: context,
+      builder: builder,
+      useRootNavigator: useRootNavigator,
+      settings: settings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      swipeDismissible: swipeDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor ?? const Color(0x18000000),
+      transitionDuration:
+          transitionDuration ?? const Duration(milliseconds: 300),
+      transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    );
+  }
+
+  return showModalSheet<T>(
+    context: context,
+    builder: builder,
+    useRootNavigator: useRootNavigator,
+    settings: settings,
+    maintainState: maintainState,
+    barrierDismissible: barrierDismissible,
+    swipeDismissible: swipeDismissible,
+    barrierLabel: barrierLabel,
+    barrierColor: barrierColor ?? Colors.black54,
+    transitionDuration: transitionDuration ?? const Duration(milliseconds: 300),
+    transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+    swipeDismissSensitivity: swipeDismissSensitivity,
+  );
+}

--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -3,6 +3,7 @@
 /// the iOS flavor), and more.
 library;
 
+export 'modal_utils.dart';
 export 'src/content_scaffold.dart';
 export 'src/controller.dart' hide SheetControllerScope;
 export 'src/cupertino.dart';

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+
+class _Observer extends NavigatorObserver {
+  Route<dynamic>? pushed;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushed = route;
+    super.didPush(route, previousRoute);
+  }
+}
+
+Widget _materialApp(
+    {required WidgetBuilder builder, NavigatorObserver? observer}) {
+  return MaterialApp(
+    home: Builder(builder: builder),
+    navigatorObservers:
+        observer != null ? [observer] : const <NavigatorObserver>[],
+  );
+}
+
+Widget _cupertinoApp(
+    {required WidgetBuilder builder, NavigatorObserver? observer}) {
+  return CupertinoApp(
+    home: Builder(builder: builder),
+    navigatorObservers:
+        observer != null ? [observer] : const <NavigatorObserver>[],
+  );
+}
+
+void main() {
+  testWidgets('showModalSheet pushes ModalSheetRoute', (tester) async {
+    final observer = _Observer();
+    await tester.pumpWidget(
+      _materialApp(
+        observer: observer,
+        builder: (context) => ElevatedButton(
+          onPressed: () {
+            showModalSheet<void>(
+              context: context,
+              builder: (_) => Sheet(
+                child: Container(key: const Key('sheet')),
+              ),
+            );
+          },
+          child: const Text('Open'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(observer.pushed, isA<ModalSheetRoute<void>>());
+    expect(find.byKey(const Key('sheet')), findsOneWidget);
+
+    Navigator.of(tester.element(find.byKey(const Key('sheet')))).pop();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('sheet')), findsNothing);
+  });
+
+  testWidgets('showCupertinoModalSheet pushes CupertinoModalSheetRoute',
+      (tester) async {
+    final observer = _Observer();
+    await tester.pumpWidget(
+      _cupertinoApp(
+        observer: observer,
+        builder: (context) => CupertinoButton(
+          onPressed: () {
+            showCupertinoModalSheet<void>(
+              context: context,
+              builder: (_) => Sheet(
+                child: Container(key: const Key('cupertino_sheet')),
+              ),
+            );
+          },
+          child: const Text('Open'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(observer.pushed, isA<CupertinoModalSheetRoute<void>>());
+    expect(find.byKey(const Key('cupertino_sheet')), findsOneWidget);
+
+    Navigator.of(tester.element(find.byKey(const Key('cupertino_sheet'))))
+        .pop();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('cupertino_sheet')), findsNothing);
+  });
+
+  testWidgets('showAdaptiveModalSheet picks cupertino on iOS', (tester) async {
+    final observer = _Observer();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
+        navigatorObservers: [observer],
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              showAdaptiveModalSheet<void>(
+                context: context,
+                builder: (_) => Sheet(
+                  child: Container(key: const Key('adaptive_sheet')),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(observer.pushed, isA<CupertinoModalSheetRoute<void>>());
+  });
+
+  testWidgets('showAdaptiveModalSheet picks material on Android',
+      (tester) async {
+    final observer = _Observer();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        navigatorObservers: [observer],
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              showAdaptiveModalSheet<void>(
+                context: context,
+                builder: (_) => Sheet(
+                  child: Container(key: const Key('adaptive_sheet_android')),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(observer.pushed, isA<ModalSheetRoute<void>>());
+  });
+}


### PR DESCRIPTION
## Summary
- add `showModalSheet`, `showCupertinoModalSheet` and `showAdaptiveModalSheet` utilities
- export them via the public API
- test new helpers
- fix lints

## Testing
- `flutter test`
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6842d8a3a6708324b8fb31e49e871b6a