### PR TITLE
feat(pkg): Add utility functions to show modal sheets

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,6 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/keyboard_dismissible.dart';
 export 'src/modal.dart';
+export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide
         ImmutableSheetLayout,

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'cupertino.dart';
+import 'modal.dart';
+
+/// Pushes a ModalSheetRoute or a CupertinoModalSheetRoute onto the current
+/// navigator's stack, depending on the current platform ("cupertino" for iOS
+/// and macOS, "material" for the others).
+Future<T?> showAdaptiveModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+}) {
+  final platform = Theme.of(context).platform;
+  final isCupertino =
+      platform == TargetPlatform.iOS || platform == TargetPlatform.macOS;
+
+  if (isCupertino) {
+    return showCupertinoModalSheet<T>(
+      context: context,
+      builder: builder,
+      useRootNavigator: useRootNavigator,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      swipeDismissible: swipeDismissible,
+      barrierLabel: barrierLabel,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    );
+  } else {
+    return showModalSheet<T>(
+      context: context,
+      builder: builder,
+      useRootNavigator: useRootNavigator,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      swipeDismissible: swipeDismissible,
+      barrierLabel: barrierLabel,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    );
+  }
+}
+
+/// Pushes a ModalSheetRoute onto the current navigator's stack.
+Future<T?> showModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color? barrierColor = Colors.black54,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets viewportPadding = EdgeInsets.zero,
+  RouteSettings? routeSettings,
+}) {
+  return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
+    ModalSheetRoute<T>(
+      builder: builder,
+      settings: routeSettings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      swipeDismissible: swipeDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      viewportPadding: viewportPadding,
+    ),
+  );
+}
+
+/// Pushes a CupertinoModalSheetRoute onto the current navigator's stack.
+Future<T?> showCupertinoModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color barrierColor = const Color(0x18000000),
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  RouteSettings? routeSettings,
+}) {
+  return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
+    CupertinoModalSheetRoute<T>(
+      builder: builder,
+      settings: routeSettings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      swipeDismissible: swipeDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    ),
+  );
+}

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -1,0 +1,371 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+
+void main() {
+  group('showAdaptiveModalSheet', () {
+    testWidgets('uses CupertinoModalSheetRoute on iOS', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('sheet-content'),
+                        child: const Text('Test Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(find.byKey(const ValueKey('sheet-content')), findsOneWidget);
+    });
+
+    testWidgets('uses CupertinoModalSheetRoute on macOS', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.macOS),
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('sheet-content'),
+                        child: const Text('Test Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(find.byKey(const ValueKey('sheet-content')), findsOneWidget);
+    });
+
+    testWidgets('uses ModalSheetRoute on Android', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('sheet-content'),
+                        child: const Text('Test Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(find.byKey(const ValueKey('sheet-content')), findsOneWidget);
+    });
+
+    testWidgets('passes parameters correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('sheet-content'),
+                        child: const Text('Test Sheet'),
+                      ),
+                      swipeDismissible: true,
+                      barrierDismissible: false,
+                      maintainState: false,
+                    );
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(find.byKey(const ValueKey('sheet-content')), findsOneWidget);
+    });
+  });
+
+  group('showModalSheet', () {
+    testWidgets('creates and pushes ModalSheetRoute', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('modal-sheet-content'),
+                        child: const Text('Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Modal Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Modal Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('modal-sheet-content')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('passes all parameters to ModalSheetRoute', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('modal-sheet-content'),
+                        child: const Text('Modal Sheet'),
+                      ),
+                      swipeDismissible: true,
+                      barrierDismissible: false,
+                      maintainState: false,
+                      barrierColor: Colors.red.withValues(alpha: 0.5),
+                      transitionDuration: const Duration(milliseconds: 500),
+                      transitionCurve: Curves.easeIn,
+                    );
+                  },
+                  child: const Text('Open Modal Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Modal Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('modal-sheet-content')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('respects useRootNavigator parameter', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Navigator(
+            onGenerateRoute: (settings) => MaterialPageRoute(
+              builder: (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showModalSheet<String>(
+                      context: context,
+                      useRootNavigator: false,
+                      builder: (context) => Container(
+                        key: const ValueKey('nested-modal-sheet'),
+                        child: const Text('Nested Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Nested Modal Sheet'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Nested Modal Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('nested-modal-sheet')),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('showCupertinoModalSheet', () {
+    testWidgets('creates and pushes CupertinoModalSheetRoute', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showCupertinoModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('cupertino-sheet-content'),
+                        child: const Text('Cupertino Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Cupertino Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Cupertino Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('cupertino-sheet-content')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('passes all parameters to CupertinoModalSheetRoute',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showCupertinoModalSheet<String>(
+                      context: context,
+                      builder: (context) => Container(
+                        key: const ValueKey('cupertino-sheet-content'),
+                        child: const Text('Cupertino Sheet'),
+                      ),
+                      swipeDismissible: true,
+                      barrierDismissible: false,
+                      maintainState: false,
+                      barrierColor: Colors.blue.withValues(alpha: 0.3),
+                      transitionDuration: const Duration(milliseconds: 400),
+                      transitionCurve: Curves.easeOut,
+                    );
+                  },
+                  child: const Text('Open Cupertino Sheet'),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Cupertino Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('cupertino-sheet-content')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('respects useRootNavigator parameter', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Navigator(
+            onGenerateRoute: (settings) => MaterialPageRoute(
+              builder: (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () async {
+                    await showCupertinoModalSheet<String>(
+                      context: context,
+                      useRootNavigator: false,
+                      builder: (context) => Container(
+                        key: const ValueKey('nested-cupertino-sheet'),
+                        child: const Text('Nested Cupertino Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Nested Cupertino Sheet'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the button to open the sheet
+      await tester.tap(find.text('Open Nested Cupertino Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the sheet content is shown
+      expect(
+        find.byKey(const ValueKey('nested-cupertino-sheet')),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Add convenience functions for showing modal sheets:
- showAdaptiveModalSheet() - platform-adaptive (iOS/macOS use Cupertino, others use Material)
- showModalSheet() - wrapper for ModalSheetRoute
- showCupertinoModalSheet() - wrapper for CupertinoModalSheetRoute

These functions provide a simple API similar to showCupertinoSheet() or showModalBottomSheet() for working with smooth_sheets modal routes.

Resolves #370

## Problem / Issue

<!-- What is the problem this PR addresses? Link the issue if available. -->
<!-- 例: Closes #123 -->

## Solution

<!-- Briefly describe how the problem is solved in this PR. -->
