### PR TITLE
fix(ci): Read bot's client id from repository variables instead of secrets

### DIFF
--- a/.github/workflows/claude_code.yaml
+++ b/.github/workflows/claude_code.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ secrets.NORELEASE_BOT_CLIENT_ID }}
+          app-id: ${{ vars.NORELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
 
       - name: Run Claude Code


### PR DESCRIPTION
Attempts to fix `Integration must generate a public key` error. ([full log](https://github.com/fujidaiti/smooth_sheets/actions/runs/15507697511))