### PR TITLE
fix(ci): Cannot get GitHub App Token

### DIFF
--- a/.github/workflows/claude_code.yaml
+++ b/.github/workflows/claude_code.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.NORELEASE_BOT_CLIENT_ID }}
+          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
 
       - name: Run Claude Code


### PR DESCRIPTION
## Problem / Issue

Having `Integration must generate a public key` error in the Claude Code workflow. ([full log](https://github.com/fujidaiti/smooth_sheets/actions/runs/15507697511))

## Solution

Using the App ID of the [bot](https://github.com/apps/norelease-bot) instead of the client secret as the `app-id` of `actions/create-github-app-token` solved this problem.
