### PR TITLE
feat(pkg): Add utility functions to show modal sheets

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,6 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/keyboard_dismissible.dart';
 export 'src/modal.dart';
+export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide
         ImmutableSheetLayout,

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -278,7 +278,7 @@ class _SheetDismissibleState extends State<_SheetDismissible>
   ///
   /// Used to prevent the state of the [_SheetDismissible.child] from being
   /// discarded when the [_SheetDismissible.enabled] is dynamically changed.
-  final _childGlobalKey = GlobalKey();
+  final GlobalKey<State<StatefulWidget>> _childGlobalKey = GlobalKey();
 
   late ModalSheetRouteMixin<dynamic> _route;
 

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+
+import 'cupertino.dart';
+import 'modal.dart';
+
+/// Pushes a ModalSheetRoute or a CupertinoModalSheetRoute onto the current
+/// navigator's stack, depending on the current platform ("cupertino" for iOS
+/// and macOS, "material" for the others).
+///
+/// This function automatically chooses between [showModalSheet] and
+/// [showCupertinoModalSheet] based on the platform detected from the current
+/// theme.
+///
+/// The [context] argument is used to look up the [Navigator] for the sheet.
+/// It is only used when the method is called. Its corresponding widget can
+/// be safely removed from the tree before the sheet is closed.
+///
+/// The [builder] argument is typically used to return a Sheet widget.
+///
+/// The [useRootNavigator] argument is used to determine whether to push the
+/// sheet to the [Navigator] furthest from or nearest to the given [context].
+/// By default, `useRootNavigator` is `true` and the sheet route created by
+/// this method is pushed to the root navigator.
+///
+/// Returns a [Future] that resolves to the value (if any) that was passed to
+/// [Navigator.pop] when the sheet was closed.
+Future<T?> showAdaptiveModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color? barrierColor,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  RouteSettings? routeSettings,
+}) {
+  final platform = Theme.of(context).platform;
+  switch (platform) {
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      return showCupertinoModalSheet<T>(
+        context: context,
+        builder: builder,
+        useRootNavigator: useRootNavigator,
+        barrierDismissible: barrierDismissible,
+        swipeDismissible: swipeDismissible,
+        barrierLabel: barrierLabel,
+        barrierColor: barrierColor,
+        transitionDuration: transitionDuration,
+        transitionCurve: transitionCurve,
+        swipeDismissSensitivity: swipeDismissSensitivity,
+        routeSettings: routeSettings,
+      );
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.linux:
+    case TargetPlatform.windows:
+      return showModalSheet<T>(
+        context: context,
+        builder: builder,
+        useRootNavigator: useRootNavigator,
+        barrierDismissible: barrierDismissible,
+        swipeDismissible: swipeDismissible,
+        barrierLabel: barrierLabel,
+        barrierColor: barrierColor,
+        transitionDuration: transitionDuration,
+        transitionCurve: transitionCurve,
+        swipeDismissSensitivity: swipeDismissSensitivity,
+        routeSettings: routeSettings,
+      );
+  }
+}
+
+/// Pushes a [ModalSheetRoute] onto the current navigator's stack.
+///
+/// The [context] argument is used to look up the [Navigator] for the sheet.
+/// It is only used when the method is called. Its corresponding widget can
+/// be safely removed from the tree before the sheet is closed.
+///
+/// The [builder] argument is typically used to return a Sheet widget.
+///
+/// The [useRootNavigator] argument is used to determine whether to push the
+/// sheet to the [Navigator] furthest from or nearest to the given [context].
+/// By default, `useRootNavigator` is `true` and the sheet route created by
+/// this method is pushed to the root navigator.
+///
+/// Returns a [Future] that resolves to the value (if any) that was passed to
+/// [Navigator.pop] when the sheet was closed.
+Future<T?> showModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  bool fullscreenDialog = false,
+  String? barrierLabel,
+  Color? barrierColor,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets viewportPadding = EdgeInsets.zero,
+  RouteSettings? routeSettings,
+}) {
+  final route = ModalSheetRoute<T>(
+    builder: builder,
+    settings: routeSettings,
+    fullscreenDialog: fullscreenDialog,
+    maintainState: maintainState,
+    barrierDismissible: barrierDismissible,
+    barrierLabel: barrierLabel,
+    barrierColor: barrierColor ?? Colors.black54,
+    swipeDismissible: swipeDismissible,
+    transitionDuration: transitionDuration ?? const Duration(milliseconds: 300),
+    transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+    swipeDismissSensitivity: swipeDismissSensitivity,
+    viewportPadding: viewportPadding,
+  );
+
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(route);
+}
+
+/// Pushes a [CupertinoModalSheetRoute] onto the current navigator's stack.
+///
+/// The [context] argument is used to look up the [Navigator] for the sheet.
+/// It is only used when the method is called. Its corresponding widget can
+/// be safely removed from the tree before the sheet is closed.
+///
+/// The [builder] argument is typically used to return a Sheet widget.
+///
+/// The [useRootNavigator] argument is used to determine whether to push the
+/// sheet to the [Navigator] furthest from or nearest to the given [context].
+/// By default, `useRootNavigator` is `true` and the sheet route created by
+/// this method is pushed to the root navigator.
+///
+/// Returns a [Future] that resolves to the value (if any) that was passed to
+/// [Navigator.pop] when the sheet was closed.
+Future<T?> showCupertinoModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool useRootNavigator = true,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  bool swipeDismissible = false,
+  String? barrierLabel,
+  Color? barrierColor,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  RouteSettings? routeSettings,
+}) {
+  final route = CupertinoModalSheetRoute<T>(
+    builder: builder,
+    settings: routeSettings,
+    maintainState: maintainState,
+    barrierDismissible: barrierDismissible,
+    barrierLabel: barrierLabel,
+    barrierColor: barrierColor,
+    swipeDismissible: swipeDismissible,
+    transitionDuration:
+        transitionDuration ?? const Duration(milliseconds: 300),
+    transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+    swipeDismissSensitivity: swipeDismissSensitivity,
+  );
+
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(route);
+}

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -3,27 +3,19 @@ import 'package:flutter/material.dart';
 import 'cupertino.dart';
 import 'modal.dart';
 
-/// Pushes a ModalSheetRoute or a CupertinoModalSheetRoute onto the current
-/// navigator's stack, depending on the current platform ("cupertino" for iOS
-/// and macOS, "material" for the others).
+/// Pushes a platform-appropriate modal sheet onto the navigator's stack.
 ///
-/// This function automatically chooses between [showModalSheet] and
-/// [showCupertinoModalSheet] based on the platform detected from the current
-/// theme.
+/// Automatically chooses between [showModalSheet] and [showCupertinoModalSheet]
+/// based on the current platform.
 ///
-/// The [context] argument is used to look up the [Navigator] for the sheet.
-/// It is only used when the method is called. Its corresponding widget can
-/// be safely removed from the tree before the sheet is closed.
-///
-/// The [builder] argument is typically used to return a Sheet widget.
-///
-/// The [useRootNavigator] argument is used to determine whether to push the
-/// sheet to the [Navigator] furthest from or nearest to the given [context].
-/// By default, `useRootNavigator` is `true` and the sheet route created by
-/// this method is pushed to the root navigator.
-///
-/// Returns a [Future] that resolves to the value (if any) that was passed to
-/// [Navigator.pop] when the sheet was closed.
+/// ```dart
+/// showAdaptiveModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(height: 300),
+///   ),
+/// );
+/// ```
 Future<T?> showAdaptiveModalSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -75,21 +67,7 @@ Future<T?> showAdaptiveModalSheet<T>({
   }
 }
 
-/// Pushes a [ModalSheetRoute] onto the current navigator's stack.
-///
-/// The [context] argument is used to look up the [Navigator] for the sheet.
-/// It is only used when the method is called. Its corresponding widget can
-/// be safely removed from the tree before the sheet is closed.
-///
-/// The [builder] argument is typically used to return a Sheet widget.
-///
-/// The [useRootNavigator] argument is used to determine whether to push the
-/// sheet to the [Navigator] furthest from or nearest to the given [context].
-/// By default, `useRootNavigator` is `true` and the sheet route created by
-/// this method is pushed to the root navigator.
-///
-/// Returns a [Future] that resolves to the value (if any) that was passed to
-/// [Navigator.pop] when the sheet was closed.
+/// Pushes a [ModalSheetRoute] onto the navigator's stack.
 Future<T?> showModalSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -125,21 +103,7 @@ Future<T?> showModalSheet<T>({
   return Navigator.of(context, rootNavigator: useRootNavigator).push(route);
 }
 
-/// Pushes a [CupertinoModalSheetRoute] onto the current navigator's stack.
-///
-/// The [context] argument is used to look up the [Navigator] for the sheet.
-/// It is only used when the method is called. Its corresponding widget can
-/// be safely removed from the tree before the sheet is closed.
-///
-/// The [builder] argument is typically used to return a Sheet widget.
-///
-/// The [useRootNavigator] argument is used to determine whether to push the
-/// sheet to the [Navigator] furthest from or nearest to the given [context].
-/// By default, `useRootNavigator` is `true` and the sheet route created by
-/// this method is pushed to the root navigator.
-///
-/// Returns a [Future] that resolves to the value (if any) that was passed to
-/// [Navigator.pop] when the sheet was closed.
+/// Pushes a [CupertinoModalSheetRoute] onto the navigator's stack.
 Future<T?> showCupertinoModalSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -163,8 +127,7 @@ Future<T?> showCupertinoModalSheet<T>({
     barrierLabel: barrierLabel,
     barrierColor: barrierColor,
     swipeDismissible: swipeDismissible,
-    transitionDuration:
-        transitionDuration ?? const Duration(milliseconds: 300),
+    transitionDuration: transitionDuration ?? const Duration(milliseconds: 300),
     transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
     swipeDismissSensitivity: swipeDismissSensitivity,
   );

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -2,11 +2,18 @@ import 'package:flutter/material.dart';
 
 import 'cupertino.dart';
 import 'modal.dart';
+import 'viewport.dart';
 
 /// Pushes a platform-appropriate modal sheet onto the navigator's stack.
 ///
 /// Automatically chooses between [showModalSheet] and [showCupertinoModalSheet]
 /// based on the current platform.
+///
+/// * On iOS and macOS: Uses [CupertinoModalSheetRoute]
+/// * On Android, Fuchsia, Linux, and Windows: Uses [ModalSheetRoute]
+///
+/// The [builder] function should not return a [SheetViewport] as
+/// the modal route will automatically insert it above the sheet.
 ///
 /// ```dart
 /// showAdaptiveModalSheet(
@@ -68,6 +75,18 @@ Future<T?> showAdaptiveModalSheet<T>({
 }
 
 /// Pushes a [ModalSheetRoute] onto the navigator's stack.
+///
+/// The [builder] function should not return a [SheetViewport] as
+/// the modal route will automatically insert it above the sheet.
+///
+/// ```dart
+/// showModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(height: 300),
+///   ),
+/// );
+/// ```
 Future<T?> showModalSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -104,6 +123,18 @@ Future<T?> showModalSheet<T>({
 }
 
 /// Pushes a [CupertinoModalSheetRoute] onto the navigator's stack.
+///
+/// The [builder] function should not return a [SheetViewport] as
+/// the modal route will automatically insert it above the sheet.
+///
+/// ```dart
+/// showCupertinoModalSheet(
+///   context: context,
+///   builder: (context) => Sheet(
+///     child: Container(height: 300),
+///   ),
+/// );
+/// ```
 Future<T?> showCupertinoModalSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -4,544 +4,161 @@ import 'package:smooth_sheets/smooth_sheets.dart';
 
 import 'src/flutter_test_x.dart';
 
-class _MaterialBoilerplate extends StatelessWidget {
-  const _MaterialBoilerplate({
-    required this.onPressed,
-    this.platform = TargetPlatform.android,
-  });
-
-  final VoidCallback onPressed;
-  final TargetPlatform platform;
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ThemeData(platform: platform),
-      home: Scaffold(
-        body: Center(
-          child: ElevatedButton(
-            onPressed: onPressed,
-            child: const Text('Open modal'),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _CupertinoBoilerplate extends StatelessWidget {
-  const _CupertinoBoilerplate({
-    required this.onPressed,
-  });
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoApp(
-      home: CupertinoPageScaffold(
-        child: Center(
-          child: CupertinoButton.filled(
-            onPressed: onPressed,
-            child: const Text('Open modal'),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-Widget _testSheet({Key? key}) {
-  return Sheet(
-    child: Container(
-      key: key ?? const Key('sheet'),
-      color: Colors.white,
-      width: double.infinity,
-      height: 400,
-    ),
-  );
-}
-
 void main() {
   group('showAdaptiveModalSheet', () {
-    testWidgets(
-      'should show CupertinoModalSheet on iOS platform',
-      (tester) async {
-        Future<String?>? result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            platform: TargetPlatform.iOS,
-            onPressed: () {
-              result = showAdaptiveModalSheet<String>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
+    Future<void> boilerplate(
+      WidgetTester tester,
+      TargetPlatform platform,
+      Matcher routeMatcher,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Scaffold(
+            body: Center(
+              child: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showAdaptiveModalSheet<dynamic>(
+                    context: context,
+                    builder: (context) => Sheet(
+                      child: Container(
+                        key: const Key('sheet'),
+                        color: Colors.white,
+                        width: double.infinity,
+                        height: 400,
+                      ),
+                    ),
+                  ),
+                  child: const Text('Open modal'),
+                ),
+              ),
+            ),
           ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-        expect(result, isA<Future<String?>>());
-
-        // Verify it's a Cupertino modal by checking the route type
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-        expect(route, isA<CupertinoModalSheetRoute<dynamic>>());
-      },
-    );
-
-    testWidgets(
-      'should show CupertinoModalSheet on macOS platform',
-      (tester) async {
-        Future<String?>? result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            platform: TargetPlatform.macOS,
-            onPressed: () {
-              result = showAdaptiveModalSheet<String>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-        expect(result, isA<Future<String?>>());
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-        expect(route, isA<CupertinoModalSheetRoute<dynamic>>());
-      },
-    );
-
-    void testMaterialPlatform(String description, TargetPlatform platform) {
-      testWidgets(description, (tester) async {
-        Future<String?>? result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            platform: platform,
-            onPressed: () {
-              result = showAdaptiveModalSheet<String>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-        expect(result, isA<Future<String?>>());
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-        expect(route, isA<ModalSheetRoute<dynamic>>());
-      });
+        ),
+      );
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+      expect(find.byId('sheet'), findsOneWidget);
+      expect(ModalRoute.of(tester.element(find.byId('sheet'))), routeMatcher);
     }
 
-    testMaterialPlatform(
-        'should show ModalSheet on Android platform', TargetPlatform.android);
-    testMaterialPlatform(
-        'should show ModalSheet on Fuchsia platform', TargetPlatform.fuchsia);
-    testMaterialPlatform(
-        'should show ModalSheet on Linux platform', TargetPlatform.linux);
-    testMaterialPlatform(
-        'should show ModalSheet on Windows platform', TargetPlatform.windows);
+    testWidgets('should show CupertinoModalSheet on iOS platform',
+        (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.iOS,
+        isA<CupertinoModalSheetRoute<dynamic>>(),
+      );
+    });
 
-    testWidgets(
-      'should pass through all parameters correctly',
-      (tester) async {
-        const testKey = Key('custom-sheet');
-        const testColor = Colors.red;
-        const testDuration = Duration(milliseconds: 500);
-        const testCurve = Curves.bounceIn;
-        const testSensitivity = SwipeDismissSensitivity(
-          minDragDistance: 50,
-          minFlingVelocityRatio: 2.0,
-        );
+    testWidgets('should show CupertinoModalSheet on macOS platform',
+        (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.macOS,
+        isA<CupertinoModalSheetRoute<dynamic>>(),
+      );
+    });
 
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            platform: TargetPlatform.android,
-            onPressed: () {
-              showAdaptiveModalSheet<void>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(key: testKey),
-                useRootNavigator: false,
-                barrierDismissible: false,
-                swipeDismissible: true,
-                barrierLabel: 'Test barrier',
-                barrierColor: testColor,
-                transitionDuration: testDuration,
-                transitionCurve: testCurve,
-                swipeDismissSensitivity: testSensitivity,
-                routeSettings: const RouteSettings(name: 'test-route'),
-              );
-            },
-          ),
-        );
+    testWidgets('should show ModalSheet on Android platform', (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.android,
+        isA<ModalSheetRoute<dynamic>>(),
+      );
+    });
 
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
+    testWidgets('should show ModalSheet on Fuchsia platform', (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.fuchsia,
+        isA<ModalSheetRoute<dynamic>>(),
+      );
+    });
 
-        expect(find.byKey(testKey), findsOneWidget);
+    testWidgets('should show ModalSheet on Linux platform', (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.linux,
+        isA<ModalSheetRoute<dynamic>>(),
+      );
+    });
 
-        final route = ModalRoute.of(tester.element(find.byKey(testKey)))!
-            as ModalSheetRoute<dynamic>;
-        expect(route.barrierDismissible, isFalse);
-        expect(route.barrierColor, testColor);
-        expect(route.transitionDuration, testDuration);
-        expect(route.settings.name, 'test-route');
-      },
-    );
+    testWidgets('should show ModalSheet on Windows platform', (tester) async {
+      await boilerplate(
+        tester,
+        TargetPlatform.windows,
+        isA<ModalSheetRoute<dynamic>>(),
+      );
+    });
   });
 
   group('showModalSheet', () {
-    testWidgets(
-      'should create and push ModalSheetRoute',
-      (tester) async {
-        Future<int?>? result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              result = showModalSheet<int>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-        expect(result, isA<Future<int?>>());
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-        expect(route, isA<ModalSheetRoute<int>>());
-      },
-    );
-
-    testWidgets(
-      'should apply default values correctly',
-      (tester) async {
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              showModalSheet<void>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
-                as ModalSheetRoute<dynamic>;
-
-        expect(route.barrierColor, Colors.black54);
-        expect(route.transitionDuration, const Duration(milliseconds: 300));
-        expect(route.transitionCurve, Curves.fastEaseInToSlowEaseOut);
-        expect(route.barrierDismissible, isTrue);
-        expect(route.maintainState, isTrue);
-      },
-    );
-
-    testWidgets(
-      'should handle custom parameters',
-      (tester) async {
-        const testColor = Colors.blue;
-        const testDuration = Duration(milliseconds: 600);
-        const testCurve = Curves.elasticIn;
-        const testSensitivity = SwipeDismissSensitivity(
-          minDragDistance: 75,
-          minFlingVelocityRatio: 1.5,
-        );
-        const testPadding = EdgeInsets.all(16);
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              showModalSheet<void>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-                useRootNavigator: false,
-                maintainState: false,
-                barrierDismissible: false,
-                swipeDismissible: true,
-                fullscreenDialog: true,
-                barrierLabel: 'Custom barrier',
-                barrierColor: testColor,
-                transitionDuration: testDuration,
-                transitionCurve: testCurve,
-                swipeDismissSensitivity: testSensitivity,
-                viewportPadding: testPadding,
-                routeSettings: const RouteSettings(name: 'custom-modal'),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
-                as ModalSheetRoute<dynamic>;
-
-        expect(route.barrierColor, testColor);
-        expect(route.transitionDuration, testDuration);
-        expect(route.transitionCurve, testCurve);
-        expect(route.barrierDismissible, isFalse);
-        expect(route.maintainState, isFalse);
-        expect(route.fullscreenDialog, isTrue);
-        expect(route.settings.name, 'custom-modal');
-      },
-    );
-
-    testWidgets(
-      'should return result when modal is popped',
-      (tester) async {
-        const testResult = 42;
-        late Future<int?> result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              result = showModalSheet<int>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => ElevatedButton(
-                  onPressed: () => Navigator.pop(context, testResult),
-                  child: const Text('Close with result'),
+    testWidgets('should create and push ModalSheetRoute', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showModalSheet<int>(
+                  context: context,
+                  builder: (context) => Sheet(
+                    child: Container(
+                      key: const Key('sheet'),
+                      color: Colors.white,
+                      width: double.infinity,
+                      height: 400,
+                    ),
+                  ),
                 ),
-              );
-            },
+                child: const Text('Open modal'),
+              ),
+            ),
           ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Close with result'));
-        await tester.pumpAndSettle();
-
-        expect(await result, testResult);
-      },
-    );
+        ),
+      ));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+      expect(find.byId('sheet'), findsOneWidget);
+      expect(
+        ModalRoute.of(tester.element(find.byId('sheet'))),
+        isA<ModalSheetRoute<int>>(),
+      );
+    });
   });
 
   group('showCupertinoModalSheet', () {
-    testWidgets(
-      'should create and push CupertinoModalSheetRoute',
-      (tester) async {
-        Future<int?>? result;
-
-        await tester.pumpWidget(
-          _CupertinoBoilerplate(
-            onPressed: () {
-              result = showCupertinoModalSheet<int>(
-                context: tester.element(find.byType(CupertinoPageScaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.byType(CupertinoButton));
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-        expect(result, isA<Future<int?>>());
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-        expect(route, isA<CupertinoModalSheetRoute<int>>());
-      },
-    );
-
-    testWidgets(
-      'should apply default values correctly',
-      (tester) async {
-        await tester.pumpWidget(
-          _CupertinoBoilerplate(
-            onPressed: () {
-              showCupertinoModalSheet<void>(
-                context: tester.element(find.byType(CupertinoPageScaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.byType(CupertinoButton));
-        await tester.pumpAndSettle();
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
-                as CupertinoModalSheetRoute<dynamic>;
-
-        expect(route.transitionDuration, const Duration(milliseconds: 300));
-        expect(route.transitionCurve, Curves.fastEaseInToSlowEaseOut);
-        expect(route.barrierDismissible, isTrue);
-        expect(route.maintainState, isTrue);
-      },
-    );
-
-    testWidgets(
-      'should handle custom parameters',
-      (tester) async {
-        const testColor = Colors.purple;
-        const testDuration = Duration(milliseconds: 450);
-        const testCurve = Curves.bounceOut;
-        const testSensitivity = SwipeDismissSensitivity(
-          minDragDistance: 60,
-          minFlingVelocityRatio: 3.0,
-        );
-
-        await tester.pumpWidget(
-          _CupertinoBoilerplate(
-            onPressed: () {
-              showCupertinoModalSheet<void>(
-                context: tester.element(find.byType(CupertinoPageScaffold)),
-                builder: (context) => _testSheet(),
-                useRootNavigator: false,
-                maintainState: false,
-                barrierDismissible: false,
-                swipeDismissible: true,
-                barrierLabel: 'Cupertino barrier',
-                barrierColor: testColor,
-                transitionDuration: testDuration,
-                transitionCurve: testCurve,
-                swipeDismissSensitivity: testSensitivity,
-                routeSettings: const RouteSettings(name: 'cupertino-modal'),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.byType(CupertinoButton));
-        await tester.pumpAndSettle();
-
-        final route =
-            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
-                as CupertinoModalSheetRoute<dynamic>;
-
-        expect(route.barrierColor, testColor);
-        expect(route.transitionDuration, testDuration);
-        expect(route.transitionCurve, testCurve);
-        expect(route.barrierDismissible, isFalse);
-        expect(route.maintainState, isFalse);
-        expect(route.settings.name, 'cupertino-modal');
-      },
-    );
-
-    testWidgets(
-      'should return result when modal is popped',
-      (tester) async {
-        const testResult = 'cupertino_result';
-        late Future<String?> result;
-
-        await tester.pumpWidget(
-          _CupertinoBoilerplate(
-            onPressed: () {
-              result = showCupertinoModalSheet<String>(
-                context: tester.element(find.byType(CupertinoPageScaffold)),
-                builder: (context) => CupertinoButton.filled(
-                  onPressed: () => Navigator.pop(context, testResult),
-                  child: const Text('Close with result'),
+    testWidgets('should create and push CupertinoModalSheetRoute',
+        (tester) async {
+      await tester.pumpWidget(CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: Builder(
+              builder: (context) => CupertinoButton.filled(
+                onPressed: () => showCupertinoModalSheet<int>(
+                  context: context,
+                  builder: (context) => Sheet(
+                    child: Container(
+                      key: const Key('sheet'),
+                      color: Colors.white,
+                      width: double.infinity,
+                      height: 400,
+                    ),
+                  ),
                 ),
-              );
-            },
+                child: const Text('Open modal'),
+              ),
+            ),
           ),
-        );
-
-        await tester.tap(find.byType(CupertinoButton).first);
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Close with result'));
-        await tester.pumpAndSettle();
-
-        expect(await result, testResult);
-      },
-    );
-  });
-
-  group('Edge cases', () {
-    testWidgets(
-      'should work with null result type',
-      (tester) async {
-        late Future<void> result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              result = showModalSheet<void>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-
-        Navigator.pop(tester.element(find.byKey(const Key('sheet'))));
-        await tester.pumpAndSettle();
-
-        await result;
-      },
-    );
-
-    testWidgets(
-      'should handle barrier tap dismissal',
-      (tester) async {
-        late Future<String?> result;
-
-        await tester.pumpWidget(
-          _MaterialBoilerplate(
-            onPressed: () {
-              result = showAdaptiveModalSheet<String>(
-                context: tester.element(find.byType(Scaffold)),
-                builder: (context) => _testSheet(),
-                barrierDismissible: true,
-              );
-            },
-          ),
-        );
-
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-        expect(find.byKey(const Key('sheet')), findsOneWidget);
-
-        // Tap on barrier to dismiss
-        await tester
-            .tapAt(const Offset(50, 50)); // Top-left corner should be barrier
-        await tester.pumpAndSettle();
-
-        expect(find.byKey(const Key('sheet')), findsNothing);
-        expect(await result, isNull);
-      },
-    );
+        ),
+      ));
+      await tester.tap(find.byType(CupertinoButton));
+      await tester.pumpAndSettle();
+      expect(find.byId('sheet'), findsOneWidget);
+      expect(
+        ModalRoute.of(tester.element(find.byId('sheet'))),
+        isA<CupertinoModalSheetRoute<int>>(),
+      );
+    });
   });
 }

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -123,41 +123,42 @@ void main() {
       },
     );
 
-    for (final platform in [
-      TargetPlatform.android,
-      TargetPlatform.fuchsia,
-      TargetPlatform.linux,
-      TargetPlatform.windows,
-    ]) {
-      testWidgets(
-        'should show ModalSheet on $platform platform',
-        (tester) async {
-          Future<String?>? result;
+    void testMaterialPlatform(String description, TargetPlatform platform) {
+      testWidgets(description, (tester) async {
+        Future<String?>? result;
 
-          await tester.pumpWidget(
-            _MaterialBoilerplate(
-              platform: platform,
-              onPressed: () {
-                result = showAdaptiveModalSheet<String>(
-                  context: tester.element(find.byType(Scaffold)),
-                  builder: (context) => _testSheet(),
-                );
-              },
-            ),
-          );
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            platform: platform,
+            onPressed: () {
+              result = showAdaptiveModalSheet<String>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
 
-          await tester.tap(find.text('Open modal'));
-          await tester.pumpAndSettle();
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
 
-          expect(find.byKey(const Key('sheet')), findsOneWidget);
-          expect(result, isA<Future<String?>>());
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+        expect(result, isA<Future<String?>>());
 
-          final route =
-              ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
-          expect(route, isA<ModalSheetRoute<dynamic>>());
-        },
-      );
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+        expect(route, isA<ModalSheetRoute<dynamic>>());
+      });
     }
+
+    testMaterialPlatform(
+        'should show ModalSheet on Android platform', TargetPlatform.android);
+    testMaterialPlatform(
+        'should show ModalSheet on Fuchsia platform', TargetPlatform.fuchsia);
+    testMaterialPlatform(
+        'should show ModalSheet on Linux platform', TargetPlatform.linux);
+    testMaterialPlatform(
+        'should show ModalSheet on Windows platform', TargetPlatform.windows);
 
     testWidgets(
       'should pass through all parameters correctly',

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -1,0 +1,546 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+
+class _MaterialBoilerplate extends StatelessWidget {
+  const _MaterialBoilerplate({
+    required this.onPressed,
+    this.platform = TargetPlatform.android,
+  });
+
+  final VoidCallback onPressed;
+  final TargetPlatform platform;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(platform: platform),
+      home: Scaffold(
+        body: Center(
+          child: ElevatedButton(
+            onPressed: onPressed,
+            child: const Text('Open modal'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CupertinoBoilerplate extends StatelessWidget {
+  const _CupertinoBoilerplate({
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Center(
+          child: CupertinoButton.filled(
+            onPressed: onPressed,
+            child: const Text('Open modal'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Widget _testSheet({Key? key}) {
+  return Sheet(
+    child: Container(
+      key: key ?? const Key('sheet'),
+      color: Colors.white,
+      width: double.infinity,
+      height: 400,
+    ),
+  );
+}
+
+void main() {
+  group('showAdaptiveModalSheet', () {
+    testWidgets(
+      'should show CupertinoModalSheet on iOS platform',
+      (tester) async {
+        Future<String?>? result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            platform: TargetPlatform.iOS,
+            onPressed: () {
+              result = showAdaptiveModalSheet<String>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+        expect(result, isA<Future<String?>>());
+
+        // Verify it's a Cupertino modal by checking the route type
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+        expect(route, isA<CupertinoModalSheetRoute<dynamic>>());
+      },
+    );
+
+    testWidgets(
+      'should show CupertinoModalSheet on macOS platform',
+      (tester) async {
+        Future<String?>? result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            platform: TargetPlatform.macOS,
+            onPressed: () {
+              result = showAdaptiveModalSheet<String>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+        expect(result, isA<Future<String?>>());
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+        expect(route, isA<CupertinoModalSheetRoute<dynamic>>());
+      },
+    );
+
+    for (final platform in [
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    ]) {
+      testWidgets(
+        'should show ModalSheet on $platform platform',
+        (tester) async {
+          Future<String?>? result;
+
+          await tester.pumpWidget(
+            _MaterialBoilerplate(
+              platform: platform,
+              onPressed: () {
+                result = showAdaptiveModalSheet<String>(
+                  context: tester.element(find.byType(Scaffold)),
+                  builder: (context) => _testSheet(),
+                );
+              },
+            ),
+          );
+
+          await tester.tap(find.text('Open modal'));
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const Key('sheet')), findsOneWidget);
+          expect(result, isA<Future<String?>>());
+
+          final route =
+              ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+          expect(route, isA<ModalSheetRoute<dynamic>>());
+        },
+      );
+    }
+
+    testWidgets(
+      'should pass through all parameters correctly',
+      (tester) async {
+        const testKey = Key('custom-sheet');
+        const testColor = Colors.red;
+        const testDuration = Duration(milliseconds: 500);
+        const testCurve = Curves.bounceIn;
+        const testSensitivity = SwipeDismissSensitivity(
+          minDragDistance: 50,
+          minFlingVelocityRatio: 2.0,
+        );
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            platform: TargetPlatform.android,
+            onPressed: () {
+              showAdaptiveModalSheet<void>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(key: testKey),
+                useRootNavigator: false,
+                barrierDismissible: false,
+                swipeDismissible: true,
+                barrierLabel: 'Test barrier',
+                barrierColor: testColor,
+                transitionDuration: testDuration,
+                transitionCurve: testCurve,
+                swipeDismissSensitivity: testSensitivity,
+                routeSettings: const RouteSettings(name: 'test-route'),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(testKey), findsOneWidget);
+
+        final route = ModalRoute.of(tester.element(find.byKey(testKey)))!
+            as ModalSheetRoute<dynamic>;
+        expect(route.barrierDismissible, isFalse);
+        expect(route.barrierColor, testColor);
+        expect(route.transitionDuration, testDuration);
+        expect(route.settings.name, 'test-route');
+      },
+    );
+  });
+
+  group('showModalSheet', () {
+    testWidgets(
+      'should create and push ModalSheetRoute',
+      (tester) async {
+        Future<int?>? result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              result = showModalSheet<int>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+        expect(result, isA<Future<int?>>());
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+        expect(route, isA<ModalSheetRoute<int>>());
+      },
+    );
+
+    testWidgets(
+      'should apply default values correctly',
+      (tester) async {
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              showModalSheet<void>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+                as ModalSheetRoute<dynamic>;
+
+        expect(route.barrierColor, Colors.black54);
+        expect(route.transitionDuration, const Duration(milliseconds: 300));
+        expect(route.transitionCurve, Curves.fastEaseInToSlowEaseOut);
+        expect(route.barrierDismissible, isTrue);
+        expect(route.maintainState, isTrue);
+      },
+    );
+
+    testWidgets(
+      'should handle custom parameters',
+      (tester) async {
+        const testColor = Colors.blue;
+        const testDuration = Duration(milliseconds: 600);
+        const testCurve = Curves.elasticIn;
+        const testSensitivity = SwipeDismissSensitivity(
+          minDragDistance: 75,
+          minFlingVelocityRatio: 1.5,
+        );
+        const testPadding = EdgeInsets.all(16);
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              showModalSheet<void>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+                useRootNavigator: false,
+                maintainState: false,
+                barrierDismissible: false,
+                swipeDismissible: true,
+                fullscreenDialog: true,
+                barrierLabel: 'Custom barrier',
+                barrierColor: testColor,
+                transitionDuration: testDuration,
+                transitionCurve: testCurve,
+                swipeDismissSensitivity: testSensitivity,
+                viewportPadding: testPadding,
+                routeSettings: const RouteSettings(name: 'custom-modal'),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+                as ModalSheetRoute<dynamic>;
+
+        expect(route.barrierColor, testColor);
+        expect(route.transitionDuration, testDuration);
+        expect(route.transitionCurve, testCurve);
+        expect(route.barrierDismissible, isFalse);
+        expect(route.maintainState, isFalse);
+        expect(route.fullscreenDialog, isTrue);
+        expect(route.settings.name, 'custom-modal');
+      },
+    );
+
+    testWidgets(
+      'should return result when modal is popped',
+      (tester) async {
+        const testResult = 42;
+        late Future<int?> result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              result = showModalSheet<int>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => ElevatedButton(
+                  onPressed: () => Navigator.pop(context, testResult),
+                  child: const Text('Close with result'),
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Close with result'));
+        await tester.pumpAndSettle();
+
+        expect(await result, testResult);
+      },
+    );
+  });
+
+  group('showCupertinoModalSheet', () {
+    testWidgets(
+      'should create and push CupertinoModalSheetRoute',
+      (tester) async {
+        Future<int?>? result;
+
+        await tester.pumpWidget(
+          _CupertinoBoilerplate(
+            onPressed: () {
+              result = showCupertinoModalSheet<int>(
+                context: tester.element(find.byType(CupertinoPageScaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.byType(CupertinoButton));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+        expect(result, isA<Future<int?>>());
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!;
+        expect(route, isA<CupertinoModalSheetRoute<int>>());
+      },
+    );
+
+    testWidgets(
+      'should apply default values correctly',
+      (tester) async {
+        await tester.pumpWidget(
+          _CupertinoBoilerplate(
+            onPressed: () {
+              showCupertinoModalSheet<void>(
+                context: tester.element(find.byType(CupertinoPageScaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.byType(CupertinoButton));
+        await tester.pumpAndSettle();
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+                as CupertinoModalSheetRoute<dynamic>;
+
+        expect(route.transitionDuration, const Duration(milliseconds: 300));
+        expect(route.transitionCurve, Curves.fastEaseInToSlowEaseOut);
+        expect(route.barrierDismissible, isTrue);
+        expect(route.maintainState, isTrue);
+      },
+    );
+
+    testWidgets(
+      'should handle custom parameters',
+      (tester) async {
+        const testColor = Colors.purple;
+        const testDuration = Duration(milliseconds: 450);
+        const testCurve = Curves.bounceOut;
+        const testSensitivity = SwipeDismissSensitivity(
+          minDragDistance: 60,
+          minFlingVelocityRatio: 3.0,
+        );
+
+        await tester.pumpWidget(
+          _CupertinoBoilerplate(
+            onPressed: () {
+              showCupertinoModalSheet<void>(
+                context: tester.element(find.byType(CupertinoPageScaffold)),
+                builder: (context) => _testSheet(),
+                useRootNavigator: false,
+                maintainState: false,
+                barrierDismissible: false,
+                swipeDismissible: true,
+                barrierLabel: 'Cupertino barrier',
+                barrierColor: testColor,
+                transitionDuration: testDuration,
+                transitionCurve: testCurve,
+                swipeDismissSensitivity: testSensitivity,
+                routeSettings: const RouteSettings(name: 'cupertino-modal'),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.byType(CupertinoButton));
+        await tester.pumpAndSettle();
+
+        final route =
+            ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+                as CupertinoModalSheetRoute<dynamic>;
+
+        expect(route.barrierColor, testColor);
+        expect(route.transitionDuration, testDuration);
+        expect(route.transitionCurve, testCurve);
+        expect(route.barrierDismissible, isFalse);
+        expect(route.maintainState, isFalse);
+        expect(route.settings.name, 'cupertino-modal');
+      },
+    );
+
+    testWidgets(
+      'should return result when modal is popped',
+      (tester) async {
+        const testResult = 'cupertino_result';
+        late Future<String?> result;
+
+        await tester.pumpWidget(
+          _CupertinoBoilerplate(
+            onPressed: () {
+              result = showCupertinoModalSheet<String>(
+                context: tester.element(find.byType(CupertinoPageScaffold)),
+                builder: (context) => CupertinoButton.filled(
+                  onPressed: () => Navigator.pop(context, testResult),
+                  child: const Text('Close with result'),
+                ),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.byType(CupertinoButton).first);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Close with result'));
+        await tester.pumpAndSettle();
+
+        expect(await result, testResult);
+      },
+    );
+  });
+
+  group('Edge cases', () {
+    testWidgets(
+      'should work with null result type',
+      (tester) async {
+        late Future<void> result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              result = showModalSheet<void>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+
+        Navigator.pop(tester.element(find.byKey(const Key('sheet'))));
+        await tester.pumpAndSettle();
+
+        await result;
+      },
+    );
+
+    testWidgets(
+      'should handle barrier tap dismissal',
+      (tester) async {
+        late Future<String?> result;
+
+        await tester.pumpWidget(
+          _MaterialBoilerplate(
+            onPressed: () {
+              result = showAdaptiveModalSheet<String>(
+                context: tester.element(find.byType(Scaffold)),
+                builder: (context) => _testSheet(),
+                barrierDismissible: true,
+              );
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+
+        // Tap on barrier to dismiss
+        await tester
+            .tapAt(const Offset(50, 50)); // Top-left corner should be barrier
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('sheet')), findsNothing);
+        expect(await result, isNull);
+      },
+    );
+  });
+}

--- a/test/src/test_ticker.dart
+++ b/test/src/test_ticker.dart
@@ -20,7 +20,9 @@ class TestTicker implements Ticker {
   @override
   bool get isTicking => isActive && !muted;
 
+  // TODO: Remove the following ignore-rule once the minimum SDK is bumped to 3.29
   @override
+  // ignore: omit_obvious_property_types
   bool muted = false;
 
   /// Manually advances the ticker by the specified duration.


### PR DESCRIPTION
This PR introduces utility functions that simplify modal sheet usage and provide platform-adaptive behavior:

### New Functions

1. **`showAdaptiveModalSheet`**: Automatically selects the appropriate modal sheet based on the current platform:
   - iOS/macOS: Uses `CupertinoModalSheetRoute` 
   - Android/Fuchsia/Linux/Windows: Uses `ModalSheetRoute`

2. **`showModalSheet`**: Convenience function for creating and pushing `ModalSheetRoute` with sensible defaults

3. **`showCupertinoModalSheet`**: Convenience function for creating and pushing `CupertinoModalSheetRoute` with sensible defaults

### Key Benefits

- **Platform Adaptive**: `showAdaptiveModalSheet` eliminates the need for manual platform detection
- **Simplified API**: Consistent interface across all modal sheet types
- **Convenience**: Direct navigation handling without manual route creation
- **Flexibility**: All original configuration options remain available

### Usage Examples

```dart
// Platform-adaptive modal sheet
showAdaptiveModalSheet(
  context: context,
  builder: (context) => Sheet(
    child: Container(height: 300),
  ),
);

// Explicit Material modal sheet
showModalSheet(
  context: context,
  builder: (context) => Sheet(
    child: Container(height: 300),
  ),
);

// Explicit Cupertino modal sheet
showCupertinoModalSheet(
  context: context,
  builder: (context) => Sheet(
    child: Container(height: 300),
  ),
);
```

### Testing

Comprehensive test coverage includes:
- Platform detection verification for all supported platforms
- Correct route type creation for each function
- Proper navigation behavior validation 