### PR TITLE
feat(pkg): Add utility functions for modal sheets

### DIFF
--- a/example/lib/tutorial/utility_functions.dart
+++ b/example/lib/tutorial/utility_functions.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+class UtilityFunctionsExample extends StatefulWidget {
+  const UtilityFunctionsExample({super.key});
+
+  @override
+  State<UtilityFunctionsExample> createState() =>
+      _UtilityFunctionsExampleState();
+}
+
+class _UtilityFunctionsExampleState extends State<UtilityFunctionsExample> {
+  String? lastResult;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Utility Functions'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Utility Functions for Modal Sheets',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'These utility functions provide a convenient way to show modal sheets, similar to showModalBottomSheet() in Flutter.',
+            ),
+            const SizedBox(height: 24),
+            if (lastResult != null) ...[
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.green.withValues(alpha: 0.1),
+                  border: Border.all(color: Colors.green),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text('Last result: $lastResult'),
+              ),
+              const SizedBox(height: 16),
+            ],
+            ElevatedButton(
+              onPressed: () => _showModalSheet(context),
+              child: const Text('Show Material Modal Sheet'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => _showCupertinoModalSheet(context),
+              child: const Text('Show Cupertino Modal Sheet'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => _showAdaptiveModalSheet(context),
+              child: const Text('Show Adaptive Modal Sheet'),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Note: The adaptive modal sheet automatically chooses between Material and Cupertino styles based on the current platform.',
+              style: TextStyle(
+                fontStyle: FontStyle.italic,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showModalSheet(BuildContext context) async {
+    final result = await showModalSheet<String>(
+      context: context,
+      swipeDismissible: true,
+      builder: (context) => _buildSheetContent(
+        context,
+        title: 'Material Modal Sheet',
+        subtitle: 'Using showModalSheet()',
+        color: Theme.of(context).primaryColor,
+      ),
+    );
+
+    if (result != null) {
+      setState(() => lastResult = result);
+    }
+  }
+
+  Future<void> _showCupertinoModalSheet(BuildContext context) async {
+    final result = await showCupertinoModalSheet<String>(
+      context: context,
+      swipeDismissible: true,
+      builder: (context) => _buildSheetContent(
+        context,
+        title: 'Cupertino Modal Sheet',
+        subtitle: 'Using showCupertinoModalSheet()',
+        color: Colors.blue,
+      ),
+    );
+
+    if (result != null) {
+      setState(() => lastResult = result);
+    }
+  }
+
+  Future<void> _showAdaptiveModalSheet(BuildContext context) async {
+    final result = await showAdaptiveModalSheet<String>(
+      context: context,
+      swipeDismissible: true,
+      builder: (context) => _buildSheetContent(
+        context,
+        title: 'Adaptive Modal Sheet',
+        subtitle: 'Using showAdaptiveModalSheet()',
+        color: Colors.purple,
+      ),
+    );
+
+    if (result != null) {
+      setState(() => lastResult = result);
+    }
+  }
+
+  Widget _buildSheetContent(
+    BuildContext context, {
+    required String title,
+    required String subtitle,
+    required Color color,
+  }) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Icon(
+                Icons.layers,
+                size: 48,
+                color: color,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                subtitle,
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Colors.grey[600],
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              const Text(
+                'This modal sheet was created using a utility function. You can swipe down to dismiss it or use the buttons below.',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Cancel'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.pop(context, 'Confirmed!'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: color,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: const Text('Confirm'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,6 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/keyboard_dismissible.dart';
 export 'src/modal.dart';
+export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide
         ImmutableSheetLayout,

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
-
 import 'drag.dart';
 import 'gesture_proxy.dart';
 import 'internal/float_comp.dart';
@@ -278,7 +277,7 @@ class _SheetDismissibleState extends State<_SheetDismissible>
   ///
   /// Used to prevent the state of the [_SheetDismissible.child] from being
   /// discarded when the [_SheetDismissible.enabled] is dynamically changed.
-  final _childGlobalKey = GlobalKey();
+  final GlobalKey<State<StatefulWidget>> _childGlobalKey = GlobalKey();
 
   late ModalSheetRouteMixin<dynamic> _route;
 

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+
+import 'cupertino.dart';
+import 'modal.dart';
+
+/// Shows a modal bottom sheet using the Material Design style.
+///
+/// This function follows Flutter's convention for modal sheet APIs and creates
+/// a [ModalSheetRoute] with the provided configuration. It returns a [Future]
+/// that resolves to the value returned by [Navigator.pop] when the sheet is
+/// dismissed.
+///
+/// Example usage:
+/// ```dart
+/// await showModalSheet<String>(
+///   context: context,
+///   builder: (context) => Container(
+///     height: 200,
+///     child: Text('Modal Sheet Content'),
+///   ),
+/// );
+/// ```
+///
+/// See also:
+/// * [showCupertinoModalSheet] for iOS-style modal sheets
+/// * [showAdaptiveModalSheet] for platform-adaptive modal sheets
+/// * [ModalSheetRoute] for the underlying route implementation
+Future<T?> showModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color barrierColor = Colors.black54,
+  bool swipeDismissible = false,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets viewportPadding = EdgeInsets.zero,
+  RouteSettings? routeSettings,
+}) {
+  return Navigator.push<T>(
+    context,
+    ModalSheetRoute<T>(
+      settings: routeSettings,
+      builder: builder,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      viewportPadding: viewportPadding,
+    ),
+  );
+}
+
+/// Shows a modal bottom sheet using the iOS-style Cupertino design.
+///
+/// This function follows Flutter's convention for modal sheet APIs and creates
+/// a [CupertinoModalSheetRoute] with the provided configuration. It returns a
+/// [Future] that resolves to the value returned by [Navigator.pop] when the
+/// sheet is dismissed.
+///
+/// The Cupertino modal sheet includes iOS-specific visual features such as:
+/// * Corner radius animation
+/// * Minimized sheet scaling for background content
+/// * iOS-style transition curves
+/// * Appropriate barrier color for iOS
+///
+/// Example usage:
+/// ```dart
+/// await showCupertinoModalSheet<String>(
+///   context: context,
+///   builder: (context) => Container(
+///     height: 200,
+///     child: Text('Cupertino Modal Sheet Content'),
+///   ),
+/// );
+/// ```
+///
+/// See also:
+/// * [showModalSheet] for Material Design modal sheets
+/// * [showAdaptiveModalSheet] for platform-adaptive modal sheets
+/// * [CupertinoModalSheetRoute] for the underlying route implementation
+Future<T?> showCupertinoModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color? barrierColor,
+  bool swipeDismissible = false,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  RouteSettings? routeSettings,
+}) {
+  return Navigator.push<T>(
+    context,
+    CupertinoModalSheetRoute<T>(
+      settings: routeSettings,
+      builder: builder,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration:
+          transitionDuration ?? const Duration(milliseconds: 300),
+      transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    ),
+  );
+}
+
+/// Shows a modal bottom sheet using platform-adaptive design.
+///
+/// This function automatically chooses between Material Design and Cupertino
+/// styles based on the current platform and theme. On iOS, it uses
+/// [showCupertinoModalSheet]. On other platforms, it uses [showModalSheet].
+///
+/// This function follows Flutter's convention for modal sheet APIs and returns
+/// a [Future] that resolves to the value returned by [Navigator.pop] when the
+/// sheet is dismissed.
+///
+/// Example usage:
+/// ```dart
+/// await showAdaptiveModalSheet<String>(
+///   context: context,
+///   builder: (context) => Container(
+///     height: 200,
+///     child: Text('Platform-adaptive Modal Sheet Content'),
+///   ),
+/// );
+/// ```
+///
+/// See also:
+/// * [showModalSheet] for Material Design modal sheets
+/// * [showCupertinoModalSheet] for iOS-style modal sheets
+/// * [ModalSheetRoute] and [CupertinoModalSheetRoute] for the underlying route implementations
+Future<T?> showAdaptiveModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color? barrierColor,
+  bool swipeDismissible = false,
+  Duration? transitionDuration,
+  Curve? transitionCurve,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets? viewportPadding,
+  RouteSettings? routeSettings,
+}) {
+  final theme = Theme.of(context);
+  final isCupertino = theme.platform == TargetPlatform.iOS ||
+      theme.platform == TargetPlatform.macOS;
+
+  if (isCupertino) {
+    return showCupertinoModalSheet<T>(
+      context: context,
+      builder: builder,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      routeSettings: routeSettings,
+    );
+  } else {
+    return showModalSheet<T>(
+      context: context,
+      builder: builder,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor ?? Colors.black54,
+      swipeDismissible: swipeDismissible,
+      transitionDuration:
+          transitionDuration ?? const Duration(milliseconds: 300),
+      transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      viewportPadding: viewportPadding ?? EdgeInsets.zero,
+      routeSettings: routeSettings,
+    );
+  }
+}

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+
+void main() {
+  group('Modal utility functions', () {
+    testWidgets('showModalSheet creates and shows ModalSheetRoute',
+        (tester) async {
+      Widget? capturedChild;
+
+      final app = MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showModalSheet<String>(
+                      context: context,
+                      builder: (context) => capturedChild = SizedBox(
+                        height: 200,
+                        child: const Text('Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Modal Sheet'), findsOneWidget);
+      expect(capturedChild, isNotNull);
+
+      // Verify that the modal sheet can be found, which means the route was
+      // created
+      final modalSheetWidget = find.text('Modal Sheet').evaluate().first.widget;
+      expect(modalSheetWidget, isNotNull);
+    });
+
+    testWidgets(
+        'showCupertinoModalSheet creates and shows Cupertino modal sheet',
+        (tester) async {
+      Widget? capturedChild;
+
+      final app = MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showCupertinoModalSheet<String>(
+                      context: context,
+                      builder: (context) => capturedChild = SizedBox(
+                        height: 200,
+                        child: const Text('Cupertino Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Cupertino Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Cupertino Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Cupertino Modal Sheet'), findsOneWidget);
+      expect(capturedChild, isNotNull);
+    });
+
+    testWidgets('showAdaptiveModalSheet works on iOS platform', (tester) async {
+      final app = MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('Adaptive Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Adaptive Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Adaptive Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Adaptive Modal Sheet'), findsOneWidget);
+    });
+
+    testWidgets('showAdaptiveModalSheet works on Android platform',
+        (tester) async {
+      final app = MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('Adaptive Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Adaptive Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Adaptive Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Adaptive Modal Sheet'), findsOneWidget);
+    });
+
+    testWidgets('Utility functions return Future<T?> that resolves when popped',
+        (tester) async {
+      String? result;
+
+      final app = MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    result = await showModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: ElevatedButton(
+                          onPressed: () =>
+                              Navigator.pop(context, 'test_result'),
+                          child: const Text('Close'),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Close'), findsOneWidget);
+      expect(result, isNull);
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+
+      expect(result, equals('test_result'));
+    });
+
+    testWidgets('showModalSheet with custom parameters', (tester) async {
+      final app = MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('Custom Modal Sheet'),
+                      ),
+                      swipeDismissible: true,
+                      barrierColor: Colors.red.withValues(alpha: 0.5),
+                      transitionDuration: const Duration(milliseconds: 500),
+                      maintainState: false,
+                    );
+                  },
+                  child: const Text('Open Custom Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Custom Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Custom Modal Sheet'), findsOneWidget);
+    });
+
+    testWidgets('showCupertinoModalSheet with custom parameters',
+        (tester) async {
+      final app = MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showCupertinoModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('Custom Cupertino Modal Sheet'),
+                      ),
+                      swipeDismissible: true,
+                      barrierDismissible: false,
+                      transitionDuration: const Duration(milliseconds: 500),
+                    );
+                  },
+                  child: const Text('Open Custom Cupertino Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Custom Cupertino Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Custom Cupertino Modal Sheet'), findsOneWidget);
+    });
+
+    testWidgets(
+        'showAdaptiveModalSheet chooses Material on non-Apple platforms',
+        (tester) async {
+      final app = MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('Linux Adaptive Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Linux Adaptive Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open Linux Adaptive Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Linux Adaptive Modal Sheet'), findsOneWidget);
+    });
+
+    testWidgets('showAdaptiveModalSheet chooses Cupertino on macOS',
+        (tester) async {
+      final app = MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.macOS),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showAdaptiveModalSheet<String>(
+                      context: context,
+                      builder: (context) => SizedBox(
+                        height: 200,
+                        child: const Text('macOS Adaptive Modal Sheet'),
+                      ),
+                    );
+                  },
+                  child: const Text('Open macOS Adaptive Modal'),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(app);
+      await tester.tap(find.text('Open macOS Adaptive Modal'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('macOS Adaptive Modal Sheet'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Problem / Issue

Users need a convenient way to display modal sheets without manually creating routes, similar to Flutter's `showModalBottomSheet()` function. The current API requires users to manually create and push routes, which is verbose for simple use cases.

Closes #370

## Solution

Add three utility functions that follow Flutter's convention for modal sheet APIs:

- `showModalSheet()` - Material Design modal sheets using `ModalSheetRoute`
- `showCupertinoModalSheet()` - iOS-style modal sheets using `CupertinoModalSheetRoute`  
- `showAdaptiveModalSheet()` - Platform-adaptive modal sheets that automatically choose between Material and Cupertino styles based on the platform

These functions provide the same level of convenience as Flutter's built-in sheet functions while leveraging the smooth_sheets package's powerful features like swipe-to-dismiss, custom physics, and smooth animations.