### PR TITLE
feat: Add modal sheet utility functions

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,6 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/keyboard_dismissible.dart';
 export 'src/modal.dart';
+export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide
         ImmutableSheetLayout,

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -210,7 +210,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    final transitionTween = Tween(begin: const Offset(0, 1), end: Offset.zero);
+    var transitionTween = Tween(begin: const Offset(0, 1), end: Offset.zero);
     return SlideTransition(
       position: animation.drive(
         transitionTween.chain(CurveTween(curve: effectiveCurve)),

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+
+import 'cupertino.dart';
+import 'modal.dart';
+
+/// Shows a modal smooth sheet.
+///
+/// A modal bottom sheet is an alternative to a menu or a dialog and prevents
+/// the user from interacting with the rest of the app.
+///
+/// The `context` argument is used to look up the [Navigator] for the sheet.
+/// It is only used when the method is called. Its corresponding widget can be
+/// removed from the tree before the sheet is closed.
+///
+/// The `builder` argument is used to build the content of the sheet.
+///
+/// The `useRootNavigator` argument is used to determine whether to push the
+/// sheet to the [Navigator] furthest from or nearest to the given `context`.
+/// By default, `useRootNavigator` is `false` and the sheet is pushed to the
+/// nearest navigator.
+///
+/// Returns a `Future` that resolves to the value (if any) that was passed to
+/// [Navigator.pop] when the sheet was closed.
+///
+/// See also:
+///
+///  * [ModalSheetRoute], which is the [PageRoute] used to implement modal
+///    bottom sheets.
+///  * [showCupertinoModalSheet], which is the Material Design version of
+///    this function.
+Future<T?> showModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  RouteSettings? settings,
+  bool fullscreenDialog = false,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color barrierColor = Colors.black54,
+  bool swipeDismissible = false,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  EdgeInsets viewportPadding = EdgeInsets.zero,
+  bool useRootNavigator = false,
+}) {
+  final navigator = Navigator.of(context, rootNavigator: useRootNavigator);
+  return navigator.push(
+    ModalSheetRoute<T>(
+      builder: builder,
+      settings: settings,
+      fullscreenDialog: fullscreenDialog,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      viewportPadding: viewportPadding,
+    ),
+  );
+}
+
+/// Pushes a CupertinoModalSheetRoute.
+Future<T?> showCupertinoModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  RouteSettings? settings,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color barrierColor = const Color(0x18000000),
+  bool swipeDismissible = false,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  bool useRootNavigator = false,
+}) {
+  final navigator = Navigator.of(context, rootNavigator: useRootNavigator);
+  return navigator.push(
+    CupertinoModalSheetRoute<T>(
+      builder: builder,
+      settings: settings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+    ),
+  );
+}
+
+/// Pushes a ModalSheetRoute or a CupertinoModalSheetRoute onto the current
+/// navigator's stack, depending on the current platform.
+Future<T?> showAdaptiveModalSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  RouteSettings? settings,
+  bool maintainState = true,
+  bool barrierDismissible = true,
+  String? barrierLabel,
+  Color barrierColor = const Color(0x18000000),
+  bool swipeDismissible = false,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity swipeDismissSensitivity =
+      const SwipeDismissSensitivity(),
+  bool useRootNavigator = false,
+}) {
+  final platform = Theme.of(context).platform;
+  if (platform == TargetPlatform.iOS || platform == TargetPlatform.macOS) {
+    return showCupertinoModalSheet(
+      context: context,
+      builder: builder,
+      settings: settings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      useRootNavigator: useRootNavigator,
+    );
+  } else {
+    return showModalSheet(
+      context: context,
+      builder: builder,
+      settings: settings,
+      maintainState: maintainState,
+      barrierDismissible: barrierDismissible,
+      barrierLabel: barrierLabel,
+      barrierColor: barrierColor,
+      swipeDismissible: swipeDismissible,
+      transitionDuration: transitionDuration,
+      transitionCurve: transitionCurve,
+      swipeDismissSensitivity: swipeDismissSensitivity,
+      useRootNavigator: useRootNavigator,
+    );
+  }
+}

--- a/test/modal_utils_test.dart
+++ b/test/modal_utils_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+void main() {
+  group('showModalSheet', () {
+    testWidgets('It pushes a ModalSheetRoute', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () => showModalSheet<void>(
+                  context: context,
+                  builder: (context) => const SizedBox(),
+                ),
+                child: const Text('Open'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump(); // Start animation
+      await tester.pump(); // Let it finish
+
+      expect(tester.pageRoute, isA<ModalSheetRoute<void>>());
+    });
+  });
+
+  group('showCupertinoModalSheet', () {
+    testWidgets('It pushes a CupertinoModalSheetRoute', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () => showCupertinoModalSheet<void>(
+                  context: context,
+                  builder: (context) => const SizedBox(),
+                ),
+                child: const Text('Open'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump(); // Start animation
+      await tester.pump(); // Let it finish
+
+      expect(tester.pageRoute, isA<CupertinoModalSheetRoute<void>>());
+    });
+  });
+
+  group('showAdaptiveModalSheet', () {
+    for (final platform in TargetPlatform.values) {
+      testWidgets('It pushes a correct route on $platform', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(platform: platform),
+            home: Builder(
+              builder: (context) {
+                return ElevatedButton(
+                  onPressed: () => showAdaptiveModalSheet<void>(
+                    context: context,
+                    builder: (context) => const SizedBox(),
+                  ),
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pump(); // Start animation
+        await tester.pump(); // Let it finish
+
+        switch (platform) {
+          case TargetPlatform.iOS:
+          case TargetPlatform.macOS:
+            expect(tester.pageRoute, isA<CupertinoModalSheetRoute<void>>());
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            expect(tester.pageRoute, isA<ModalSheetRoute<void>>());
+        }
+      });
+    }
+  });
+}
+
+extension on WidgetTester {
+  PageRoute<dynamic>? get pageRoute {
+    if (any(find.byType(Navigator))) {
+      final navigator = widget<Navigator>(find.byType(Navigator));
+      final navigatorState =
+          (navigator.key as GlobalObjectKey<NavigatorState>).currentState;
+      // This is a bit of a hack to get the history, but it's needed for testing.
+      // Trying to access private members to get the route history.
+      dynamic last;
+      navigatorState?.popUntil((route) {
+        last = route;
+        return true;
+      });
+      return last as PageRoute<dynamic>?;
+    }
+    return null;
+  }
+}

--- a/test/src/test_ticker.dart
+++ b/test/src/test_ticker.dart
@@ -21,7 +21,7 @@ class TestTicker implements Ticker {
   bool get isTicking => isActive && !muted;
 
   @override
-  bool muted = false;
+  var muted = false;
 
   /// Manually advances the ticker by the specified duration.
   void tick(Duration duration) {


### PR DESCRIPTION
## Problem / Issue

Fixes #370.

Currently, there is no simple, high-level function to show a modal sheet, similar to `showModalBottomSheet` in Flutter. This makes it less convenient for users who want to display a modal sheet with the features provided by this library. The original issue suggested a more complete API design than what was initially implemented.

## Solution

This PR introduces a suite of functions to show modal sheets, following the API design from the issue:

- **`showModalSheet`**: Pushes a `ModalSheetRoute`. This is the Material Design-style modal sheet.
- **`showCupertinoModalSheet`**: Pushes a `CupertinoModalSheetRoute`. This is the iOS-style modal sheet.
- **`showAdaptiveModalSheet`**: A platform-adaptive function that calls either `showModalSheet` or `showCupertinoModalSheet` depending on the target platform (`Cupertino` for iOS/macOS, `Material` for others).

These functions are all located in the new `lib/src/modal_utils.dart` file and are exported from the main library file. This makes showing modal sheets much more convenient and provides a familiar API for Flutter developers. 