### PR TITLE
fix(ci): Use GitHub App token for version bump PRs to enable CI

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -131,10 +131,17 @@ jobs:
           args: --unreleased --strip=all
         env:
           OUTPUT: pr-description.txt
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NORELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
       
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VERSION: ${{ needs.check.outputs.next_version }}
           LATEST_TAG: ${{ needs.check.outputs.latest_tag }}
         run: |


### PR DESCRIPTION
## Problem / Issue

When the `bump.yaml` workflow creates a pull request using the default `GITHUB_TOKEN`, the CI workflows do not automatically trigger for the created PR. This is a known limitation of GitHub Actions where workflows triggered by the default `GITHUB_TOKEN` do not trigger additional workflow runs to prevent infinite loops.

This means that important CI checks (tests, linting, etc.) are not executed on the version bump PRs, which could lead to merging changes without proper validation.

## Solution

This PR addresses the issue by switching from the default `GITHUB_TOKEN` to a GitHub App token from the [norelease-bot](https://github.com/apps/norelease-bot) GitHub App.

1. **Generate GitHub App Token:** Added a new step to generate a token using the `actions/create-github-app-token@v1` action with the `norelease-bot` app credentials.

2. **Use App Token for PR Creation:** Modified the `Create Pull Request` step to use the generated app token instead of the default `GITHUB_TOKEN`.

GitHub App tokens have different permissions and are treated differently by GitHub's workflow triggering system. When a PR is created using a GitHub App token, it properly triggers CI workflows, ensuring that all automated checks run as expected.

The `norelease-bot` app provides the necessary permissions to create pull requests while maintaining security through proper credential management via GitHub secrets. 