### PR TITLE
fix(ci): Reland "Use GitHub App token for version bump PRs to enable CI #384"

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -109,13 +109,27 @@ jobs:
         with:
           cmd: yq -i '.version = "${{ needs.check.outputs.raw_next_version }}"' pubspec.yaml
 
-      - name: Configure Git
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Get Bot user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure commit author for bot
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Create and Push Branch
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VERSION: ${{ needs.check.outputs.next_version }}
         run: |
           BRANCH_NAME="release/${NEXT_VERSION}"
@@ -132,13 +146,6 @@ jobs:
         env:
           OUTPUT: pr-description.txt
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.NORELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
-      
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -150,4 +157,5 @@ jobs:
             --base main \
             --head "release/${NEXT_VERSION}" \
             --title "${PR_TITLE}" \
-            --body-file pr-description.txt
+            --body-file pr-description.txt \
+            --reviewer "${{ github.repository_owner }}"

--- a/test/src/test_ticker.dart
+++ b/test/src/test_ticker.dart
@@ -20,6 +20,7 @@ class TestTicker implements Ticker {
   @override
   bool get isTicking => isActive && !muted;
 
+  // ignore: lines_longer_than_80_chars
   // TODO: Remove the following ignore-rule once the minimum SDK is bumped to 3.29
   @override
   // ignore: omit_obvious_property_types


### PR DESCRIPTION
## Problem / Issue

The current bump workflow uses `github-actions[bot]` as the commit author, which prevents the commit from triggering CI pipelines. Additionally, the workflow reads the GitHub App ID from secrets instead of variables, and doesn't automatically assign reviewers to the created PRs.

## Solution

Improved the bump workflow to properly use the Norelease Bot GitHub App:

- Changed APP_ID source from secrets to variables for better security practices
- Configure Git to use dynamic Norelease Bot credentials instead of hardcoded github-actions bot
- Added proper GitHub App token authentication for all Git operations  
- Added automatic reviewer assignment to repository owner
- Made bot name and user ID dynamic using app-slug outputs from the token

This ensures version bump commits will trigger CI pipelines and PRs are automatically assigned for review.