### PR TITLE
feat(pkg): Add SheetScrollHandlingBehavior for precise control over scroll gesture handling

### DIFF
--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -27,6 +27,8 @@ mixin _PagedSheetEntry {
 
   SheetOffset get initialOffset;
 
+  SheetScrollConfiguration? get scrollConfiguration;
+
   SheetOffset? _targetOffset;
 
   Size? _contentSize;
@@ -68,6 +70,10 @@ class _PagedSheetModel extends SheetModel<_PagedSheetModelConfig>
   @override
   SheetOffset get initialOffset =>
       _currentEntry?.initialOffset ?? const SheetOffset(1);
+
+  @override
+  SheetScrollConfiguration get scrollConfiguration =>
+      _currentEntry?.scrollConfiguration ?? const SheetScrollConfiguration();
 
   @override
   set config(_PagedSheetModelConfig value) {
@@ -435,9 +441,6 @@ abstract class _BasePagedSheetRoute<T> extends PageRoute<T>
   RouteTransitionsBuilder? get transitionsBuilder;
 
   SheetDragConfiguration? get dragConfiguration;
-
-  // TODO: Apply new configuration when the current route changes.
-  SheetScrollConfiguration? get scrollConfiguration;
 
   @override
   Color? get barrierColor => null;

--- a/lib/src/scrollable.dart
+++ b/lib/src/scrollable.dart
@@ -16,11 +16,11 @@ import 'model_owner.dart';
 // TODO: Expose this from the ScrollableSheet's constructor
 const double _kMaxScrollSpeedToInterrupt = double.infinity;
 
-/// {@template smooth_sheets.scrollable.SheetScrollSyncMode}
+/// {@template smooth_sheets.scrollable.SheetScrollHandlingBehavior}
 /// Defines how the sheet position is synced with scroll gestures
 /// performed on a scrollable content.
 /// {@endtemplate}
-enum SheetScrollSyncMode {
+enum SheetScrollHandlingBehavior {
   /// The sheet always takes precedence over the scrollable content
   /// when handling scroll gestures.
   ///
@@ -48,15 +48,15 @@ enum SheetScrollSyncMode {
 class SheetScrollConfiguration {
   const SheetScrollConfiguration({
     this.thresholdVelocityToInterruptBallisticScroll = double.infinity,
-    this.scrollSyncMode = SheetScrollSyncMode.always,
+    this.scrollSyncMode = SheetScrollHandlingBehavior.always,
   });
 
   // TODO: Come up with a better name.
   // TODO: Apply this value to the model.
   final double thresholdVelocityToInterruptBallisticScroll;
 
-  /// {@macro smooth_sheets.scrollable.SheetScrollSyncMode}
-  final SheetScrollSyncMode scrollSyncMode;
+  /// {@macro smooth_sheets.scrollable.SheetScrollHandlingBehavior}
+  final SheetScrollHandlingBehavior scrollSyncMode;
 }
 
 @internal
@@ -261,8 +261,8 @@ mixin ScrollAwareSheetModelMixin<C extends SheetModelConfig> on SheetModel<C>
 
   bool _shouldHandleScroll(ScrollPosition scrollPosition) =>
       switch (scrollConfiguration.scrollSyncMode) {
-        SheetScrollSyncMode.always => true,
-        SheetScrollSyncMode.onlyFromTop => scrollPosition.pixels == 0,
+        SheetScrollHandlingBehavior.always => true,
+        SheetScrollHandlingBehavior.onlyFromTop => scrollPosition.pixels == 0,
       };
 }
 

--- a/lib/src/scrollable.dart
+++ b/lib/src/scrollable.dart
@@ -12,30 +12,35 @@ import 'drag.dart';
 import 'internal/float_comp.dart';
 import 'model.dart';
 import 'model_owner.dart';
-import 'physics.dart';
 
 // TODO: Expose this from the ScrollableSheet's constructor
 const double _kMaxScrollSpeedToInterrupt = double.infinity;
 
 /// {@template smooth_sheets.scrollable.SheetScrollSyncMode}
-/// Defines how the sheet position is synced with the scroll gesture
+/// Defines how the sheet position is synced with scroll gestures
 /// performed on a scrollable content.
 /// {@endtemplate}
 enum SheetScrollSyncMode {
-  /// The sheet may move downward or upward when the gesture attempts to
-  /// overscroll the scrollable content.
+  /// The sheet always takes precedence over the scrollable content
+  /// when handling scroll gestures.
   ///
-  /// How the sheet moves in response to the overscroll is determined by
-  /// the [SheetPhysics]. On the other hand, the [ScrollPhysics] of the
-  /// scrollable doesn not affect it.
+  /// For example, when the user attempts to overscroll the list view,
+  /// the sheet may move downward or upward in response to the overscroll
+  /// gesture. In this case, the list view will not perform any overscroll-
+  /// driven animations such as the bouncing effect for [BouncingScrollPhysics].
   always,
 
-  /// The sheet behaves the same as [always] mode only when the scroll
-  /// starts from the top of the scrollable content.
+  /// The sheet behaves the same as [always] mode only when scrolling
+  /// starts from the top of the scrollable content; otherwise, the scrollable
+  /// content handles scroll gestures exclusively.
   ///
-  /// More precisely, the sheet may move downward or upward in response to
-  /// the overscroll gesture if the [ScrollPosition.pixels] of the scrollable
-  /// content is 0 when the scroll starts.
+  /// For example, when the user attempts to overscroll the list view,
+  /// the sheet may move downward or upward in response to the overscroll
+  /// gesture **only if** [ScrollPosition.pixels] of the list view
+  /// is 0 when scrolling starts.
+  /// Otherwise, the sheet will not handle the scroll gesture, and the list
+  /// view may perform overscroll-driven animations such as the bouncing effect
+  /// for [BouncingScrollPhysics] as usual.
   onlyFromTop,
 }
 

--- a/lib/src/scrollable.dart
+++ b/lib/src/scrollable.dart
@@ -54,11 +54,6 @@ class SheetScrollConfiguration {
   final SheetScrollSyncMode scrollSyncMode;
 }
 
-mixin ScrollAwareSheetModelConfigMixin on SheetModelConfig {
-  /// {@macro smooth_sheets.scrollable.SheetScrollConfiguration}
-  SheetScrollConfiguration get scrollConfiguration;
-}
-
 @internal
 mixin ScrollAwareSheetModelMixin<C extends SheetModelConfig> on SheetModel<C>
     implements _SheetScrollPositionDelegate {

--- a/lib/src/sheet.dart
+++ b/lib/src/sheet.dart
@@ -12,17 +12,6 @@ import 'snap_grid.dart';
 import 'viewport.dart';
 
 @immutable
-class SheetScrollConfiguration {
-  const SheetScrollConfiguration({
-    this.thresholdVelocityToInterruptBallisticScroll = double.infinity,
-  });
-
-  // TODO: Come up with a better name.
-  // TODO: Apply this value to the model.
-  final double thresholdVelocityToInterruptBallisticScroll;
-}
-
-@immutable
 class SheetDragConfiguration {
   const SheetDragConfiguration({
     this.hitTestBehavior = HitTestBehavior.translucent,
@@ -36,18 +25,24 @@ class _DraggableScrollableSheetModelConfig extends SheetModelConfig {
     required super.physics,
     required super.snapGrid,
     required super.gestureProxy,
+    required this.scrollConfiguration,
   });
+
+  /// {@macro smooth_sheets.scrollable.SheetScrollConfiguration}
+  final SheetScrollConfiguration scrollConfiguration;
 
   @override
   _DraggableScrollableSheetModelConfig copyWith({
     SheetPhysics? physics,
     SheetSnapGrid? snapGrid,
     SheetGestureProxyMixin? gestureProxy,
+    SheetScrollConfiguration? scrollConfiguration,
   }) {
     return _DraggableScrollableSheetModelConfig(
       physics: physics ?? this.physics,
       snapGrid: snapGrid ?? this.snapGrid,
       gestureProxy: gestureProxy ?? this.gestureProxy,
+      scrollConfiguration: scrollConfiguration ?? this.scrollConfiguration,
     );
   }
 }
@@ -63,6 +58,10 @@ class _DraggableScrollableSheetModel
 
   @override
   final SheetOffset initialOffset;
+
+  @override
+  SheetScrollConfiguration get scrollConfiguration =>
+      config.scrollConfiguration;
 }
 
 class Sheet extends StatelessWidget {
@@ -117,6 +116,8 @@ class Sheet extends StatelessWidget {
         physics: physics ?? kDefaultSheetPhysics,
         snapGrid: snapGrid,
         gestureProxy: SheetGestureProxy.maybeOf(context),
+        scrollConfiguration:
+            scrollConfiguration ?? const SheetScrollConfiguration(),
       ),
       child: BareSheet(
         decoration: decoration,

--- a/test/scrollable_test.dart
+++ b/test/scrollable_test.dart
@@ -133,8 +133,7 @@ void main() {
   });
 }
 
-class _TestModelConfig extends SheetModelConfig
-    with ScrollAwareSheetModelConfigMixin {
+class _TestModelConfig extends SheetModelConfig {
   const _TestModelConfig({
     required super.physics,
     required super.snapGrid,
@@ -142,7 +141,6 @@ class _TestModelConfig extends SheetModelConfig
     required this.scrollConfiguration,
   });
 
-  @override
   final SheetScrollConfiguration scrollConfiguration;
 
   @override

--- a/test/scrollable_test.dart
+++ b/test/scrollable_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/widgets.dart';
+import 'package:smooth_sheets/src/gesture_proxy.dart';
+import 'package:smooth_sheets/src/model.dart';
+import 'package:smooth_sheets/src/model_owner.dart';
+import 'package:smooth_sheets/src/physics.dart';
+import 'package:smooth_sheets/src/scrollable.dart';
+import 'package:smooth_sheets/src/snap_grid.dart';
+import 'package:smooth_sheets/src/viewport.dart';
+
+import 'src/flutter_test_x.dart';
+import 'src/object_ref.dart';
+
+void main() {
+  group('SheetScrollSyncMode', () {
+    ({
+      Widget testWidget,
+      ObjectRef<ScrollController> scrollControllerRef,
+    }) boilerplate({
+      required SheetScrollConfiguration scrollConfiguration,
+    }) {
+      final scrollControllerRef = ObjectRef<ScrollController>();
+      final testWidget = SheetViewport(
+        child: _TestSheet(
+          key: Key('sheet'),
+          initialOffset: SheetOffset(1),
+          scrollConfiguration: scrollConfiguration,
+          physics: BouncingSheetPhysics(),
+          builder: (context, controller) {
+            scrollControllerRef.value = controller;
+            return SizedBox.fromSize(
+              size: Size.fromHeight(300),
+              child: SingleChildScrollView(
+                key: Key('scrollable'),
+                physics: BouncingScrollPhysics(),
+                controller: controller,
+                child: SizedBox.fromSize(
+                  size: Size.fromHeight(1000),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      return (
+        testWidget: testWidget,
+        scrollControllerRef: scrollControllerRef,
+      );
+    }
+
+    testWidgets(
+      'always: sheet should move downward when scrollable is overscrolled',
+      (tester) async {
+        final env = boilerplate(
+          scrollConfiguration: SheetScrollConfiguration(
+            scrollSyncMode: SheetScrollSyncMode.always,
+          ),
+        );
+        await tester.pumpWidget(env.testWidget);
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 0);
+
+        final gesture =
+            await tester.startGesture(tester.getCenter(find.byId('sheet')));
+        await gesture.moveDownwardBy(100);
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, greaterThan(300));
+        expect(env.scrollControllerRef.value!.offset, 0);
+
+        await gesture.moveUpwardBy(200);
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 100);
+      },
+    );
+
+    testWidgets(
+      'onlyFromTop: sheet should move downward when scrollable is overscrolled '
+      'and the scroll starts from the top',
+      (tester) async {
+        final env = boilerplate(
+          scrollConfiguration: SheetScrollConfiguration(
+            scrollSyncMode: SheetScrollSyncMode.onlyFromTop,
+          ),
+        );
+        await tester.pumpWidget(env.testWidget);
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 0);
+
+        final gesture =
+            await tester.startGesture(tester.getCenter(find.byId('sheet')));
+        await gesture.moveDownwardBy(100);
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, greaterThan(300));
+        expect(env.scrollControllerRef.value!.offset, 0);
+
+        await gesture.moveUpwardBy(200);
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 100);
+      },
+    );
+
+    testWidgets(
+      'onlyFromTop: sheet should not move downward when scrollable is '
+      'overscrolled but the scroll does not start from the top',
+      (tester) async {
+        final env = boilerplate(
+          scrollConfiguration: SheetScrollConfiguration(
+            scrollSyncMode: SheetScrollSyncMode.onlyFromTop,
+          ),
+        );
+        await tester.pumpWidget(env.testWidget);
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 0);
+
+        await tester.dragUpward(find.byId('scrollable'), deltaY: 100);
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, 100);
+
+        final gesture =
+            await tester.startGesture(tester.getCenter(find.byId('sheet')));
+        await gesture.moveDownwardBy(200);
+        await tester.pumpAndSettle();
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(env.scrollControllerRef.value!.offset, lessThan(0));
+        await gesture.up();
+      },
+    );
+  });
+}
+
+class _TestModelConfig extends SheetModelConfig
+    with ScrollAwareSheetModelConfigMixin {
+  const _TestModelConfig({
+    required super.physics,
+    required super.snapGrid,
+    required super.gestureProxy,
+    required this.scrollConfiguration,
+  });
+
+  @override
+  final SheetScrollConfiguration scrollConfiguration;
+
+  @override
+  _TestModelConfig copyWith({
+    SheetPhysics? physics,
+    SheetSnapGrid? snapGrid,
+    SheetGestureProxyMixin? gestureProxy,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _TestModel extends SheetModel<_TestModelConfig>
+    with ScrollAwareSheetModelMixin {
+  _TestModel(super.context, super.config, this.initialOffset);
+
+  @override
+  SheetScrollConfiguration get scrollConfiguration =>
+      config.scrollConfiguration;
+
+  @override
+  final SheetOffset initialOffset;
+}
+
+class _TestSheet extends StatelessWidget {
+  const _TestSheet({
+    super.key,
+    required this.scrollConfiguration,
+    required this.initialOffset,
+    this.physics = kDefaultSheetPhysics,
+    required this.builder,
+  });
+
+  final SheetOffset initialOffset;
+  final SheetScrollConfiguration scrollConfiguration;
+  final SheetPhysics physics;
+  final ScrollableWidgetBuilder builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return SheetModelOwner(
+      factory: (context, config) => _TestModel(context, config, initialOffset),
+      config: _TestModelConfig(
+        gestureProxy: null,
+        physics: kDefaultSheetPhysics,
+        snapGrid: const SteplessSnapGrid(),
+        scrollConfiguration: scrollConfiguration,
+      ),
+      child: BareSheet(
+        child: SheetScrollable(
+          builder: builder,
+        ),
+      ),
+    );
+  }
+}

--- a/test/scrollable_test.dart
+++ b/test/scrollable_test.dart
@@ -11,7 +11,7 @@ import 'src/flutter_test_x.dart';
 import 'src/object_ref.dart';
 
 void main() {
-  group('SheetScrollSyncMode', () {
+  group('SheetScrollHandlingBehavior', () {
     ({
       Widget testWidget,
       ObjectRef<ScrollController> scrollControllerRef,
@@ -52,7 +52,7 @@ void main() {
       (tester) async {
         final env = boilerplate(
           scrollConfiguration: SheetScrollConfiguration(
-            scrollSyncMode: SheetScrollSyncMode.always,
+            scrollSyncMode: SheetScrollHandlingBehavior.always,
           ),
         );
         await tester.pumpWidget(env.testWidget);
@@ -80,7 +80,7 @@ void main() {
       (tester) async {
         final env = boilerplate(
           scrollConfiguration: SheetScrollConfiguration(
-            scrollSyncMode: SheetScrollSyncMode.onlyFromTop,
+            scrollSyncMode: SheetScrollHandlingBehavior.onlyFromTop,
           ),
         );
         await tester.pumpWidget(env.testWidget);
@@ -108,7 +108,7 @@ void main() {
       (tester) async {
         final env = boilerplate(
           scrollConfiguration: SheetScrollConfiguration(
-            scrollSyncMode: SheetScrollSyncMode.onlyFromTop,
+            scrollSyncMode: SheetScrollHandlingBehavior.onlyFromTop,
           ),
         );
         await tester.pumpWidget(env.testWidget);

--- a/test/src/flutter_test_x.dart
+++ b/test/src/flutter_test_x.dart
@@ -204,6 +204,22 @@ extension type WidgetTesterX(t.WidgetTester self) implements t.WidgetTester {
     return gesture;
   }
 
+  /// Attempts to drag the given widget upward by the given [deltaY],
+  /// by starting a drag in the middle of the widget.
+  Future<void> dragUpward(
+    t.FinderBase<Element> finder, {
+    required double deltaY,
+  }) =>
+      drag(finder, Offset(0, -deltaY));
+
+  /// Attempts to drag the given widget downward by the given [deltaY],
+  /// by starting a drag in the middle of the widget.
+  Future<void> dragDownward(
+    t.FinderBase<Element> finder, {
+    required double deltaY,
+  }) =>
+      drag(finder, Offset(0, deltaY));
+
   /// Returns the local rectangle of the widget specified by the [finder].
   ///
   /// If [ancestor] is specified, the rectangle is relative to the ancestor.
@@ -222,5 +238,19 @@ extension type WidgetTesterX(t.WidgetTester self) implements t.WidgetTester {
     } else {
       return Offset.zero & box.size;
     }
+  }
+}
+
+extension TestGestureX on t.TestGesture {
+  /// Send a move event moving the pointer upward by the given [deltaY].
+  Future<void> moveUpwardBy(double deltaY) async {
+    assert(deltaY >= 0);
+    await moveBy(Offset(0, -deltaY));
+  }
+
+  /// Send a move event moving the pointer downward by the given [deltaY].
+  Future<void> moveDownwardBy(double deltaY) async {
+    assert(deltaY >= 0);
+    await moveBy(Offset(0, deltaY));
   }
 }

--- a/test/src/flutter_test_x_test.dart
+++ b/test/src/flutter_test_x_test.dart
@@ -384,4 +384,91 @@ void main() {
       expect(FlutterError.onError, same(originalOnError));
     });
   });
+
+  group('TestGestureX', () {
+    late Widget testWidget;
+    DragUpdateDetails? dragUpdateDetails;
+
+    setUp(() {
+      dragUpdateDetails = null;
+      testWidget = GestureDetector(
+        onPanUpdate: (details) {
+          dragUpdateDetails = details;
+        },
+        child: Container(
+          width: 200,
+          height: 200,
+          color: Colors.white,
+        ),
+      );
+    });
+
+    testWidgets('moveUpwardBy should move pointer upward by deltaY',
+        (tester) async {
+      await tester.pumpWidget(testWidget);
+      final center = tester.getCenter(find.byType(Container));
+
+      final gesture = await tester.startGesture(center);
+      await gesture.moveUpwardBy(50.0);
+
+      expect(dragUpdateDetails?.delta.dx, 0.0);
+      expect(dragUpdateDetails?.delta.dy, -50.0);
+
+      await gesture.up();
+    });
+
+    testWidgets('moveDownwardBy should move pointer downward by deltaY',
+        (tester) async {
+      await tester.pumpWidget(testWidget);
+      final center = tester.getCenter(find.byType(Container));
+
+      final gesture = await tester.startGesture(center);
+      await gesture.moveDownwardBy(30.0);
+
+      expect(dragUpdateDetails?.delta.dx, 0.0);
+      expect(dragUpdateDetails?.delta.dy, 30.0);
+
+      await gesture.up();
+    });
+  });
+
+  group('WidgetTesterX.dragUpward and dragDownward', () {
+    late Widget testWidget;
+    DragUpdateDetails? dragUpdateDetails;
+
+    setUp(() {
+      dragUpdateDetails = null;
+      testWidget = MaterialApp(
+        home: GestureDetector(
+          onPanUpdate: (details) {
+            dragUpdateDetails = details;
+          },
+          child: Container(
+            key: Key('draggable'),
+            width: 200,
+            height: 200,
+            color: Colors.blue,
+          ),
+        ),
+      );
+    });
+
+    testWidgets(
+      'dragUpward should drag widget upward by deltaY',
+      (tester) async {
+        await tester.pumpWidget(testWidget);
+        await tester.dragUpward(find.byKey(Key('draggable')), deltaY: 20);
+        expect(dragUpdateDetails?.delta, Offset(0, -20));
+      },
+    );
+
+    testWidgets(
+      'dragDownward should drag widget downward by deltaY',
+      (tester) async {
+        await tester.pumpWidget(testWidget);
+        await tester.dragDownward(find.byKey(Key('draggable')), deltaY: 20);
+        expect(dragUpdateDetails?.delta, Offset(0, 20));
+      },
+    );
+  });
 }

--- a/test/src/object_ref.dart
+++ b/test/src/object_ref.dart
@@ -1,0 +1,8 @@
+class ObjectRef<T> {
+  const ObjectRef();
+
+  static final _refs = Expando<Object>();
+
+  T? get value => _refs[this] as T?;
+  set value(T? value) => _refs[this] = value;
+}


### PR DESCRIPTION
## Problem / Issue

Closes #284.

Currently, when scroll gestures are performed on scrollable content within a sheet, the sheet always takes precedence over the scrollable content when handling these gestures. This prevents the scrollable content from handling scroll gestures as intended, including overscroll-driven animations such as the bouncing effect for `BouncingScrollPhysics`.

The specific behavior requested in issue #284 requires more nuanced control: allowing the scrollable content to handle scroll gestures exclusively in certain conditions, while still maintaining the sheet's responsiveness when appropriate.

## Solution

This PR introduces `SheetScrollHandlingBehavior` to control the precedence between the sheet and scrollable content when handling scroll gestures.

### `SheetScrollHandlingBehavior` enum:

- **`always`**: The sheet always takes precedence over the scrollable content when handling scroll gestures (existing behavior, maintains backward compatibility)
- **`onlyFromTop`**: The sheet behaves the same as `always` mode only when scrolling starts from the top of the scrollable content; otherwise, the scrollable content handles scroll gestures exclusively

### Behavior with `onlyFromTop` mode:

- **When `ScrollPosition.pixels == 0` at scroll start**: Sheet takes precedence (same as `always` mode)
- **When `ScrollPosition.pixels != 0` at scroll start**: Scrollable content handles scroll gestures exclusively, enabling all intended scroll behaviors such as overscroll effects

### Usage:

```dart
Sheet(
  scrollConfiguration: SheetScrollConfiguration(
    scrollSyncMode: SheetScrollHandlingBehavior.onlyFromTop,
  ),
  child: ListView(...),
)
```
