### PR TITLE
chore(ci): Add links to corresponding GitHub release pages in CHANGELOG

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -20,7 +20,9 @@ body = """
         {% raw %}  {% endraw %}- {{commit.breaking_description}}
         {% endif -%}
     {% endfor %}\
-{% endfor %}\n
+{% endfor %}
+
+See [the release note](https://github.com/fujidaiti/smooth_sheets/releases/tag/{{ version }}) for more details.\n
 """
 
 [git]


### PR DESCRIPTION
`cliff.toml` has been updated to add links to the corresponding GitHub release pages for each version section in `CHANGELOG.md`.