### PR TITLE
feat(ci): Configure Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Main package dependencies
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "build(pkg)"
+      prefix-development: "chore(pkg)"
+    labels: []
+    groups:
+      dependencies:
+        dependency-type: "production"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # Example project dependencies
+  - package-ecosystem: "pub"
+    directory: "/example"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "build(example)"
+    labels: []

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fujidaiti


### PR DESCRIPTION
- Configure Dependabot to automatically update dependencies weekly on Sundays at 9AM JST
- Separate update PRs for main package dependencies, dev dependencies, and example project
- Use conventional commit prefixes: `build(pkg)` for main dependencies, `chore(pkg)` for dev dependencies, `build(example)` for example project
