### PR TITLE
feat(ci): Monitor example directory pubspec changes in health workflow

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -27,6 +27,8 @@ jobs:
               - '**.dart'
               - 'pubspec.yaml'
               - 'pubspec.lock'
+              - 'example/pubspec.yaml'
+              - 'example/pubspec.lock'
             dev-sdk-version-changed:
               - '.fvmrc'
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   auto_route_generator: ^10.0.1
   build_runner: ^2.4.15
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^5.0.0
   auto_route_generator: ^10.0.1
   build_runner: ^2.4.15
 


### PR DESCRIPTION
## Summary

This PR updates the health workflow to monitor changes in the `/example` directory's `pubspec.yaml` and `pubspec.lock` files. Previously, changes to these files would not trigger the CI pipeline, potentially allowing dependency issues in the example app to go unnoticed.

## Changes Made

- Added `example/pubspec.yaml` and `example/pubspec.lock` to the `flutter-file-changed` filter in `.github/workflows/health.yaml`
- This ensures that modifications to the example app's dependencies will trigger:
  - Static analysis (dart format, dart analyze) 
  - Unit tests
  - Dry publish checks including pana analysis
