### PR TITLE
chore(pkg): Temporarily suppress deprecated_member_use warnings

### DIFF
--- a/example/lib/showcase/ai_playlist_generator.dart
+++ b/example/lib/showcase/ai_playlist_generator.dart
@@ -406,8 +406,10 @@ class _ConfirmPage extends StatelessWidget {
                   controlAffinity: ListTileControlAffinity.trailing,
                   value: '',
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   groupValue: '',
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   onChanged: (_) {},
                 ),
                 const Divider(height: 32),
@@ -558,8 +560,10 @@ class _SelectableMoodListState extends State<_SelectableMoodList> {
             selected: mood.label == selectedMood,
             value: mood.label,
             // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+            // ignore: deprecated_member_use
             groupValue: selectedMood,
             // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+            // ignore: deprecated_member_use
             onChanged: (newMooed) => setState(() {
               selectedMood = newMooed;
             }),

--- a/example/lib/tutorial/decorations.dart
+++ b/example/lib/tutorial/decorations.dart
@@ -38,17 +38,20 @@ class _ExampleHomeState extends State<_ExampleHome> {
                 RadioListTile(
                   value: SheetSize.fit,
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   groupValue: _selectedSheetSize,
                   title: Text('SheetSize.fit'),
                   subtitle:
                       Text('The sheet size is always the same as the content.'),
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   onChanged: (value) =>
                       setState(() => _selectedSheetSize = value!),
                 ),
                 RadioListTile(
                   value: SheetSize.stretch,
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   groupValue: _selectedSheetSize,
                   title: Text('SheetSize.stretch'),
                   subtitle: Text(
@@ -56,6 +59,7 @@ class _ExampleHomeState extends State<_ExampleHome> {
                     'when it is over-dragged.',
                   ),
                   // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+                  // ignore: deprecated_member_use
                   onChanged: (value) =>
                       setState(() => _selectedSheetSize = value!),
                 ),

--- a/example/lib/tutorial/keyboard_dismiss_behavior.dart
+++ b/example/lib/tutorial/keyboard_dismiss_behavior.dart
@@ -58,10 +58,12 @@ class _ExampleHomeState extends State<_ExampleHome> {
           subtitle: Text(behavior.description),
           value: behavior,
           // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+          // ignore: deprecated_member_use
           groupValue: selectedBehavior,
           contentPadding: const EdgeInsets.only(left: 32, right: 16),
           controlAffinity: ListTileControlAffinity.trailing,
           // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+          // ignore: deprecated_member_use
           onChanged: (value) => setState(() {
             selectedBehavior = value!;
           }),

--- a/example/lib/tutorial/physics_and_snap_grid.dart
+++ b/example/lib/tutorial/physics_and_snap_grid.dart
@@ -79,8 +79,10 @@ class _ExampleHomeState extends State<_ExampleHome> {
               title: Text(physics.name),
               value: physics,
               // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+              // ignore: deprecated_member_use
               groupValue: selectedPhysics,
               // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+              // ignore: deprecated_member_use
               onChanged: (value) => setState(() {
                 selectedPhysics = value!;
               }),
@@ -98,8 +100,10 @@ class _ExampleHomeState extends State<_ExampleHome> {
               title: Text(snapGrid.name),
               value: snapGrid,
               // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+              // ignore: deprecated_member_use
               groupValue: selectedSnapGrid,
               // TODO: Migrate to RadioGroup when minimum SDK version is raised to 3.35.0
+              // ignore: deprecated_member_use
               onChanged: (value) => setState(() {
                 selectedSnapGrid = value!;
               }),

--- a/lib/src/cupertino.dart
+++ b/lib/src/cupertino.dart
@@ -267,6 +267,7 @@ class _RenderTransformTransition extends RenderTransform {
       // vector_math package has been upgraded to 2.2.0 in Flutter 3.35.0,
       // in which the `scale` method has been deprecated.
       // See: https://github.com/flutter/flutter/commit/c08e9dff6865b91a3c20bb39980053951a6cae34
+      // ignore: deprecated_member_use
       ..scale(scaleFactor, scaleFactor, 1.0);
   }
 }


### PR DESCRIPTION
This PR suppresses all `deprecated_member_use` lint warnings by adding `// ignore: deprecated_member_use` comments above the flagged lines. The deprecated APIs include:

- `RadioListTile.groupValue` and `RadioListTile.onChanged` properties (deprecated after Flutter 3.32.0)
- `Matrix4.scale()` method (deprecated in vector_math 2.2.0 / Flutter 3.35.0)

These warnings were suppressed rather than migrated to maintain compatibility until the minimum SDK version is raised to 3.35.0, as indicated by existing TODO comments in the codebase.
