### PR TITLE
chore(env): Beautify CHANGELOG format

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -11,18 +11,22 @@ body = """
     ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}\
 {% else %}\
     ## Unreleased\
-{% endif %}\
-{% for group, commits in commits | group_by(attribute="group") %}
-    {% for commit in commits %}\
-        - {% if group != "none" %}{{ group }}: {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} \
-        - [{{ commit.id | truncate(length=7, end="") }}](https://github.com/fujidaiti/smooth_sheets/commit/{{ commit.id }})
-        {% for footer in commit.footers %}\
+{% endif %}
+{% for commit in commits | sort(attribute="group") %}\
+        - {% if commit.group != "none" %}{{ commit.group }}: {% endif %}{{ commit.message | upper_first }}
+{% endfor %}\
+{% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
+{% if breaking_commits | length > 0 %}\
+\n
+> [!IMPORTANT]
+{% for commit in breaking_commits %}\
+    {% for footer in commit.footers %}\
         {% if footer.breaking %}\
-        {% raw %}  {% endraw %}- 💥 {{footer.value}}
+> - {{ footer.value }}
         {% endif %}\
-        {% endfor %}\
     {% endfor %}\
 {% endfor %}\
+{% endif %}\
 \n
 See [the release note](https://github.com/fujidaiti/smooth_sheets/releases/tag/{{ version }}) for more details.
 \n


### PR DESCRIPTION
- **What**
  - Aggregate all `BREAKING CHANGE` footers per version into a single IMPORTANT block at the end of the section.
  - Remove per-commit nested breaking footer lines.
  - Simplify commit entries: show `group` and `message`, sorted by `group`.
  - Keep existing filters and grouping behavior otherwise unchanged.

- **Why**
  - Improves readability by centralizing breaking changes.
  - Reduces noise from nested lists under individual commits.
  - Makes scanning per-version changes faster.

- **Before**
  ```markdown
  - fix: [**breaking**] Some fix (#123) - [abcd123](...)
    - 💥 Requires Flutter X
  ```

- **After**
  ```markdown
  - fix: Some fix

  > [!IMPORTANT]
  > - Requires Flutter X
  ```

- **Verification**
  - Run: `git cliff --unreleased`
  - Add multiple commits with `BREAKING CHANGE:` footers and confirm they appear under a single IMPORTANT block, preserving order and duplicates across commits.

- **Notes**
  - Commit IDs, PR links, and per-line [**breaking**] badges are intentionally omitted in the simplified entry lines.