### PR TITLE
fix(ci): Fix stale action is not working

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,12 +19,25 @@ jobs:
           
           # Target both issues and PRs with the specific label
           only-labels: 'waiting for customer response'
-          
-          # Days before marking as stale (we skip this step and go directly to close)
-          days-before-stale: -1
-          
+
+          # Days before marking as stale
+          days-before-stale: 30
+
           # Days before closing after marked stale
-          days-before-close: 30
+          days-before-close: 7
+
+          # Label to apply when marked stale
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+
+          # Message when marking as stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 7 days.
+
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 7 days.
           
           # Close message for issues
           close-issue-message: |


### PR DESCRIPTION
## Problem / Issue

The stale action workflow was introduced in #410 to automatically close inactive issues and PRs with the "waiting for customer response" label after 30 days of inactivity. However, the workflow configured in `.github/workflows/stale.yaml` was not functioning as intended - items were never being automatically marked as stale or closed, despite the workflow being scheduled to run weekly.

The root cause is that `days-before-stale` was set to `-1`, which disables the stale marking step entirely. The stale action requires items to first be marked as stale before they can be closed. With this step disabled, the action would never proceed to close any items, even though `days-before-close: 30` was configured.

## Solution

This PR fixes the stale action configuration to properly mark and close inactive issues and PRs.

1. **Enable Stale Marking:** Changed `days-before-stale` from `-1` to `30`, so items will be marked as stale after 30 days of inactivity.
2. **Adjust Close Timing:** Changed `days-before-close` from `30` to `7`, so items will be closed 7 days after being marked stale (37 days total from initial inactivity).
3. **Add Stale Labels:** Added `stale-issue-label` and `stale-pr-label` configuration to apply a "stale" label when items are marked.
4. **Add Stale Messages:** Added `stale-issue-message` and `stale-pr-message` to notify users when their issues or PRs are marked as stale, giving them 7 days to respond before automatic closure.

The workflow now properly handles both issues and PRs with the "waiting for customer response" label through a two-step process: mark as stale after 30 days, then close after 7 additional days if no activity occurs.