### PR TITLE
fix(ci): Test job fails with latest auto_route

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,14 @@ dependencies:
     sdk: flutter
   meta: ^1.9.1
   navigator_resizable: ^3.0.0
+
+# Dependencies for testing
 dev_dependencies:
-  auto_route: ^10.0.1
+  # Since v10.2.0 introduced a breaking change incompatible with
+  # Flutter 3.29.0 (our minimum supported version), CI failed.
+  # Adding this upper bound as a workaround.
+  auto_route: <10.2.0
+
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Problem / Issue

The auto_route v10.2.0 introduced a breaking change incompatible with our minimum supported SDK version (Flutter 3.29.0), causing CI test failures. 

## Solution

This PR adds an upper bound (<10.2.0) to the auto_route version as a workaround.