### PR TITLE
feat(ci): Add automated GitHub Release creation workflow

### DIFF
--- a/release-workflow.yaml
+++ b/release-workflow.yaml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   release:
     # Only run when a release PR is merged
@@ -25,6 +22,13 @@ jobs:
           # Fetch all history and tags for git-cliff
           fetch-depth: 0
           ref: main
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
 
       - name: Extract version from PR title
         id: extract-version
@@ -89,7 +93,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.extract-version.outputs.version }}
         run: |
           # Create the release with the tag


### PR DESCRIPTION
Implements the workflow proposed in issue #396 to automatically create GitHub Releases when release PRs are merged.

The workflow:
- Triggers when a release PR (created by bump.yaml) is merged into main
- Extracts the version from the PR title
- Checks for manual release notes in note/release-note-X.Y.Z.md
- Falls back to auto-generated changelog using git-cliff if manual notes don't exist
- Creates a GitHub Release with the appropriate tag and notes

This completes the publishing pipeline by eliminating manual release creation steps.

Note: File is temporarily placed at root as release-workflow.yaml to work around GitHub App permissions. Move to .github/workflows/release.yaml to activate.

## Problem / Issue

<!-- What is the problem this PR addresses? Link the issue if available. -->
<!-- 例: Closes #123 -->

## Solution

<!-- Briefly describe how the problem is solved in this PR. -->
