### PR TITLE
feat(pkg): Better sheet physics

### DIFF
--- a/test/physics_test.dart
+++ b/test/physics_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: lines_longer_than_80_chars
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/widgets.dart';

--- a/test/src/matchers.dart
+++ b/test/src/matchers.dart
@@ -85,3 +85,99 @@ class _IsMonotonic extends Matcher {
       ? description.add('A sequence of monotonically increasing numbers')
       : description.add('A sequence of monotonically decreasing numbers');
 }
+
+/// Returns a matcher that verifies the directional fluctuations of a sequence
+/// of [double]s match the given signs, where +1 means an increase and -1 means
+/// a decrease.
+///
+/// The matcher compresses consecutive identical directions into a single sign
+/// and ignores zero deltas (equal consecutive values). It throws an
+/// [ArgumentError] if [expectedSigns] contains consecutive identical signs.
+///
+/// ```dart
+/// expect([1.0, 2.0, 1.0, 0.0, -1.0, 2.0], fluctuationEquals([1, -1, 1]));
+/// expect([3.0, 2.0, 1.0], fluctuationEquals([-1]));
+/// expect([1.0], isNot(fluctuationEquals([1]))); // single item never matches
+/// ```
+Matcher fluctuationEquals(List<int> expectedSigns) {
+  for (var i = 1; i < expectedSigns.length; i++) {
+    if (expectedSigns[i] == expectedSigns[i - 1]) {
+      throw ArgumentError(
+        'expectedSigns must not contain consecutive identical signs',
+      );
+    }
+  }
+  return _FluctuationEquals(expectedSigns);
+}
+
+class _FluctuationEquals extends Matcher {
+  _FluctuationEquals(this.expected);
+
+  final List<int> expected;
+
+  @override
+  bool matches(Object? item, Map<dynamic, dynamic> matchState) {
+    if (item is! Iterable<double>) {
+      return false;
+    }
+    final list = item.toList(growable: false);
+    if (list.length <= 1) {
+      return false;
+    }
+    for (final v in list) {
+      if (v.isNaN) {
+        return false;
+      }
+    }
+    final signs = _computeFluctuationSigns(list);
+    if (signs.length != expected.length) {
+      return false;
+    }
+    for (var i = 0; i < signs.length; i++) {
+      if (signs[i] != expected[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  Description describe(Description description) =>
+      description.add('fluctuation equals ').addDescriptionOf(expected);
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    final actualFluctuation = item is Iterable<double>
+        ? _computeFluctuationSigns(item)
+        : const <int>[];
+    return mismatchDescription
+        .add('has fluctuation ')
+        .addDescriptionOf(actualFluctuation);
+  }
+}
+
+List<int> _computeFluctuationSigns(Iterable<double> values) {
+  final iterator = values.iterator;
+  if (!iterator.moveNext()) {
+    return const <int>[];
+  }
+  var previous = iterator.current;
+  final signs = <int>[];
+  while (iterator.moveNext()) {
+    final current = iterator.current;
+    final delta = current - previous;
+    if (delta != 0) {
+      final sign = delta > 0 ? 1 : -1;
+      if (signs.isEmpty || signs.last != sign) {
+        signs.add(sign);
+      }
+    }
+    previous = current;
+  }
+  return signs;
+}

--- a/test/src/matchers_test.dart
+++ b/test/src/matchers_test.dart
@@ -44,4 +44,47 @@ void main() {
       expect(null, isNot(isMonotonicallyIncreasing));
     });
   });
+
+  group('fluctuationEquals', () {
+    test('matches example sequence', () {
+      expect([1.0, 2.0, 1.0, 0.0, -1.0, 2.0], fluctuationEquals([1, -1, 1]));
+    });
+
+    test('compresses consecutive identical signs', () {
+      expect([3.0, 2.0, 1.0, 0.0, -1.0, -2.0, -3.0], fluctuationEquals([-1]));
+      expect([0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0], fluctuationEquals([1]));
+    });
+
+    test('skips zero deltas between equal consecutive values', () {
+      expect(
+        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 2.0, 2.0, 1.0],
+        fluctuationEquals([1, -1, 1, -1]),
+      );
+    });
+
+    test('one item should not match any sign pattern', () {
+      expect([1.0], isNot(fluctuationEquals([])));
+      expect([1.0], isNot(fluctuationEquals([1])));
+    });
+
+    test('mismatch when signs differ', () {
+      expect([1.0, 2.0, 3.0], isNot(fluctuationEquals([1, -1])));
+      // Length mismatch (expected longer)
+      expect([1.0, 2.0, 3.0], isNot(fluctuationEquals([1, -1, 1])));
+      // All zeros should not match any non-empty pattern
+      expect([0.0, 0.0, 0.0], isNot(fluctuationEquals([1])));
+      // Flat line (no change) should not match non-empty pattern
+      expect([1.0, 1.0, 1.0, 1.0], isNot(fluctuationEquals([1])));
+      // Zigzag with extra turns vs shorter expected pattern
+      expect([1.0, 0.0, 1.0, 0.0, 1.0], isNot(fluctuationEquals([1, -1])));
+      // Reverse then ascend vs three-turn expectation
+      expect([3.0, 2.0, 3.0, 4.0], isNot(fluctuationEquals([1, -1, 1])));
+      // All descending vs descending-then-ascending expected
+      expect([5.0, 4.0, 3.0, 2.0], isNot(fluctuationEquals([-1, 1])));
+      // Non-empty expected pattern vs empty actual pattern
+      expect([1.0, 1.0], isNot(fluctuationEquals([1])));
+      // NaN in input should never match
+      expect([double.nan, 0.0], isNot(fluctuationEquals([1])));
+    });
+  });
 }


### PR DESCRIPTION
## Problem / Issue

- Closes #389
- Closes #435
- Closes #436

## Solution

- Remove ineffective property: `SheetScrollConfiguration.this.thresholdVelocityToInterruptBallisticScroll`
