### PR TITLE
refactor(pkg): Remove unnecessary calls to applyPhysicsToOffset

### DIFF
--- a/lib/src/scrollable.dart
+++ b/lib/src/scrollable.dart
@@ -330,7 +330,7 @@ mixin _ScrollAwareSheetActivityMixin
       }
       // If the sheet is not at top, drag it up as much as possible
       // until it reaches at 'maxOffset'.
-      if (cmp.isLessThanOrApprox(newOffset, maxOffset)) {
+      if (cmp.isLessThan(newOffset, maxOffset)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(cmp.isLessThanOrApprox(physicsAppliedDelta, delta));
         newOffset = min(newOffset + physicsAppliedDelta, maxOffset);
@@ -355,7 +355,7 @@ mixin _ScrollAwareSheetActivityMixin
     } else if (offset < 0) {
       // If the sheet is beyond 'maxOffset', drag it down as much
       // as possible until it reaches at 'maxOffset'.
-      if (cmp.isGreaterThanOrApprox(newOffset, maxOffset)) {
+      if (cmp.isGreaterThan(newOffset, maxOffset)) {
         final physicsAppliedDelta = _applyPhysicsToOffset(delta);
         assert(cmp.isLessThanOrApprox(physicsAppliedDelta.abs(), delta.abs()));
         newOffset = max(newOffset + physicsAppliedDelta, maxOffset);


### PR DESCRIPTION
## Problem/Issue

A scrollable sheet called `SheetPhysics.applyPhysicsToOffset` repeatedly while scrolling, even in cases where it was logically obvious that the scroll delta would only change the scroll position and never affect the sheet position (e.g., when scrolling up while the sheet is fully expanded).

