### PR TITLE
fix(ci): "--body" is missing for `gh pr create`

### DIFF
--- a/.github/workflows/flutter_sdk_update.yaml
+++ b/.github/workflows/flutter_sdk_update.yaml
@@ -3,7 +3,7 @@ name: Flutter SDK Update
 on:
   schedule:
     # Runs every Monday at 6:00 AM JST (Sunday 21:00 UTC)
-    - cron: '0 21 * * 0'
+    - cron: "0 21 * * 0"
   workflow_dispatch:
 
 permissions:
@@ -129,5 +129,6 @@ jobs:
 
           gh pr create \
             --title "${PR_TITLE}" \
+            --body "[CHANGELOG](https://github.com/flutter/flutter/blob/stable/CHANGELOG.md)" \
             --base main \
             --reviewer "${{ github.repository_owner }}"


### PR DESCRIPTION
Fixed a runtime error caused by `gh create pr` command in the Flutter SDK auto-update workflow.

```
Run PR_TITLE="chore(env): Update Flutter SDK from ${CURRENT_VERSION} to ${LATEST_VERSION} [bot]"
must provide `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`) when not running interactively
```