### PR TITLE
chore(env): Remove Flutter version matrix from analysis job in Health workflow

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -35,4 +35,3 @@ export 'src/sheet.dart' hide DraggableScrollableSheetContent;
 export 'src/snap_grid.dart';
 export 'src/viewport.dart'
     hide BareSheet, DefaultSheetDecoration, SheetViewportState;
-


### PR DESCRIPTION
## Problem / Issue

In the health workflow, we run static analysis on the codebase against both the lowest and highest supported versions of the Flutter SDK. However, there are cases where one of those paths always fails because some SDK tools produce different output depending on their version. For example, the Dart formatter from SDK v3.29 and v3.32 may format code differently, so pushing code formatted with the v3.32 formatter may fail CI due to uncommitted changes the v3.29 formatter produces.

## Solution

Change the analysis job to run static analysis against only the highest supported SDK version. We still test the code against the lowest supported SDK version, so static analysis errors with the lowest SDK version will be caught in that job.
