### PR TITLE
chore(env): Trigger health checks when workflow file changes

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       flutter-file-changed: ${{ steps.filter.outputs.flutter-file-changed }}
       dev-sdk-version-changed: ${{ steps.filter.outputs.dev-sdk-version-changed }}
+      workflow-changed: ${{ steps.filter.outputs.workflow-changed }}
       flutter-lower-bound: ${{ steps.flutter-version-constraint.outputs.lower-bound }}
       flutter-upper-bound: ${{ steps.flutter-version-constraint.outputs.upper-bound }}
     steps:
@@ -31,6 +32,8 @@ jobs:
               - 'example/pubspec.lock'
             dev-sdk-version-changed:
               - '.fvmrc'
+            workflow-changed:
+              - '.github/workflows/health.yaml'
 
       - name: Get Flutter SDK version constraint
         id: flutter-version-constraint
@@ -50,7 +53,7 @@ jobs:
 
   analysis:
     needs: setup
-    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' }}
+    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' || needs.setup.outputs.workflow-changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,7 +72,7 @@ jobs:
 
   testing:
     needs: setup
-    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' }}
+    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' || needs.setup.outputs.workflow-changed == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -117,7 +120,7 @@ jobs:
 
   dry-publish:
     needs: setup
-    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' }}
+    if: ${{ needs.setup.outputs.flutter-file-changed == 'true' || needs.setup.outputs.dev-sdk-version-changed == 'true' || needs.setup.outputs.workflow-changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem / Issue

The health check workflow does not re-run when the workflow file itself is modified, making it difficult to test workflow changes without manual intervention.

## Solution

Added detection for changes to the `health.yaml` workflow file:
- Added `workflow-changed` output to the setup job that tracks changes to `.github/workflows/health.yaml`
- Updated the conditional logic for `analysis`, `testing`, and `dry-publish` jobs to trigger when the workflow file changes, in addition to Flutter and SDK version changes

This ensures that any modifications to the health check workflow are automatically validated by running the full health check suite.
