### PR TITLE
chore(ci): Improve bump workflow

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -156,7 +156,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --bump --unreleased --strip=all
+          args: --unreleased --strip=all
         env:
           OUTPUT: pr-description.raw.txt
 

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -93,16 +93,28 @@ jobs:
           # Fetch all history and tags for git-cliff and version calculation
           fetch-depth: 0
           
-      - name: Generate CHANGELOG using git-cliff
+      - name: Snapshot current CHANGELOG
+        run: cp CHANGELOG.md .old/CHANGELOG.md
+
+      - name: Generate new CHANGELOG section using git-cliff
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --bump
+          args: --bump --unreleased
         env:
-          OUTPUT: CHANGELOG.md
+          OUTPUT: NEW_CHANGELOG.md
 
-      - name: Append old CHANGELOG
-        run: cat .old/CHANGELOG.md >> CHANGELOG.md
+      - name: Prepend new section to CHANGELOG
+        run: |
+          set -e
+          {
+            echo "# Changelog"
+            echo
+            tail -n +3 NEW_CHANGELOG.md
+            tail -n +3 .old/CHANGELOG.md
+          } > CHANGELOG.md
+          rm NEW_CHANGELOG.md
+        shell: bash
 
       - name: Bump package version
         uses: mikefarah/yq@v4
@@ -128,34 +140,41 @@ jobs:
           git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Create and Push Branch
+        id: create-branch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VERSION: ${{ needs.check.outputs.next_version }}
         run: |
-          BRANCH_NAME="release/${NEXT_VERSION}"
+          BRANCH_NAME="release/${NEXT_VERSION}-$(date -u +%Y%m%d%H%M%S)"
           git checkout -b $BRANCH_NAME
-          git add pubspec.yaml CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md .old/CHANGELOG.md
           git commit -m "Bump package version to ${NEXT_VERSION}"
           git push origin $BRANCH_NAME
-          
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
       - name: Generate PR description
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --unreleased --strip=all
+          args: --bump --unreleased --strip=all
         env:
-          OUTPUT: pr-description.txt
+          OUTPUT: pr-description.raw.txt
+
+      - name: Strip version header from PR description
+        run: tail -n +2 pr-description.raw.txt > pr-description.txt
+        shell: bash
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VERSION: ${{ needs.check.outputs.next_version }}
           LATEST_TAG: ${{ needs.check.outputs.latest_tag }}
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
         run: |
           PR_TITLE="chore(pkg): Bump package version to ${NEXT_VERSION} [bot]"
           gh pr create \
             --base main \
-            --head "release/${NEXT_VERSION}" \
+            --head "${BRANCH_NAME}" \
             --title "${PR_TITLE}" \
             --body-file pr-description.txt \
             --reviewer "${{ github.repository_owner }}"

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,18 +16,6 @@ body = """
         - {% if commit.group != "none" %}{{ commit.group }}: {% endif %}{{ commit.message | upper_first }} \
         - [{{ commit.id | truncate(length=7, end="") }}](https://github.com/fujidaiti/smooth_sheets/commit/{{ commit.id }})
 {% endfor %}\
-{% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
-{% if breaking_commits | length > 0 %}\
-\n
-> [!IMPORTANT]
-{% for commit in breaking_commits %}\
-    {% for footer in commit.footers %}\
-        {% if footer.breaking %}\
-> - {{ footer.value }}
-        {% endif %}\
-    {% endfor %}\
-{% endfor %}\
-{% endif %}\
 \n
 See [the release note](https://github.com/fujidaiti/smooth_sheets/releases/tag/{{ version }}) for more details.
 \n


### PR DESCRIPTION
- Snapshot the current `CHANGELOG.md` into `.old/CHANGELOG.md` before each run, then generate only the new version's section and prepend it. Prior entries (including manual edits) are preserved as-is.
- Append a UTC timestamp to the release branch name so manual re-runs don't collide with existing branches.
- The generated CHANGELOG no longer includes the Important section.
