### PR TITLE
chore(ci): Automate GitHub Release creation on version bump merge

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -129,9 +129,6 @@ jobs:
           NOTE="notes/release-note-${RAW_VERSION}.md"
           if [ ! -f "$NOTE" ]; then
             echo "# v${RAW_VERSION} release note" > "$NOTE"
-            echo "Created stub release note at $NOTE"
-          else
-            echo "Release note already exists at $NOTE"
           fi
         shell: bash
 

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -121,6 +121,20 @@ jobs:
         with:
           cmd: yq -i '.version = "${{ needs.check.outputs.raw_next_version }}"' pubspec.yaml
 
+      - name: Ensure release note exists
+        env:
+          RAW_VERSION: ${{ needs.check.outputs.raw_next_version }}
+        run: |
+          set -e
+          NOTE="notes/release-note-${RAW_VERSION}.md"
+          if [ ! -f "$NOTE" ]; then
+            echo "# v${RAW_VERSION} release note" > "$NOTE"
+            echo "Created stub release note at $NOTE"
+          else
+            echo "Release note already exists at $NOTE"
+          fi
+        shell: bash
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -144,10 +158,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VERSION: ${{ needs.check.outputs.next_version }}
+          RAW_NEXT_VERSION: ${{ needs.check.outputs.raw_next_version }}
         run: |
           BRANCH_NAME="release/${NEXT_VERSION}-$(date -u +%Y%m%d%H%M%S)"
           git checkout -b $BRANCH_NAME
-          git add pubspec.yaml CHANGELOG.md .old/CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md .old/CHANGELOG.md notes/release-note-${RAW_NEXT_VERSION}.md
           git commit -m "Bump package version to ${NEXT_VERSION}"
           git push origin $BRANCH_NAME
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: Create Release
+
+on:
+  push:
+    branches: [main]
+    paths: ['pubspec.yaml']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect version change
+        id: version
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -e
+          NEW=$(yq '.version' pubspec.yaml)
+          OLD=$(git show "${BEFORE_SHA}:pubspec.yaml" 2>/dev/null | yq '.version' || echo "")
+
+          echo "Old version: ${OLD}"
+          echo "New version: ${NEW}"
+
+          if [ "$OLD" = "$NEW" ]; then
+            echo "Version unchanged. Skipping release."
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version changed. Proceeding with release."
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "raw=${NEW}" >> $GITHUB_OUTPUT
+            echo "tag=v${NEW}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Generate GitHub App token
+        if: steps.version.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RAW: ${{ steps.version.outputs.raw }}
+        run: |
+          set -e
+          NOTE="notes/release-note-${RAW}.md"
+          if [ ! -f "$NOTE" ]; then
+            echo "::error::Missing release note file: $NOTE"
+            exit 1
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "$NOTE" \
+            --target "$GITHUB_SHA"
+        shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,12 +18,17 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  detect:
     runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.version.outputs.changed }}
+      raw: ${{ steps.version.outputs.raw }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # Fetching the last 2 commits is sufficient to compare pubspec.yaml for version changes
           fetch-depth: 2
 
       - name: Detect version change
@@ -39,29 +44,17 @@ jobs:
           echo "New version: ${NEW}"
 
           if [ "$OLD" = "$NEW" ]; then
-            echo "Version unchanged. Skipping release."
             echo "changed=false" >> $GITHUB_OUTPUT
           else
-            echo "Version changed. Proceeding with release."
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "raw=${NEW}" >> $GITHUB_OUTPUT
             echo "tag=v${NEW}" >> $GITHUB_OUTPUT
           fi
         shell: bash
 
-      - name: Generate GitHub App token
-        if: steps.version.outputs.changed == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Create GitHub Release
+      - name: Verify release note exists
         if: steps.version.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ steps.version.outputs.tag }}
           RAW: ${{ steps.version.outputs.raw }}
         run: |
           set -e
@@ -70,8 +63,32 @@ jobs:
             echo "::error::Missing release note file: $NOTE"
             exit 1
           fi
+        shell: bash
+
+  release:
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NORELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.NORELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          RAW: ${{ needs.detect.outputs.raw }}
+        run: |
+          set -e
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes-file "$NOTE" \
+            --notes-file "notes/release-note-${RAW}.md" \
             --target "$GITHUB_SHA"
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Detect version change
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,12 @@
+# Creates a GitHub Release (and tag) when a version-bump commit lands on main.
+#
+# Triggered by pushes to main that touch pubspec.yaml. Detects a version change
+# by diffing pubspec.yaml between the previous and current commits; if the
+# version is unchanged, the workflow exits cleanly. Otherwise it creates a
+# GitHub Release at the merge commit, using notes/release-note-<version>.md as
+# the body.
+#
+# The release will trigger the publish.yaml to publish the package to pub.dev.
 name: Create Release
 
 on:


### PR DESCRIPTION
Add a new workflow to create a GitHub Release (and tag) when a version-bump commit lands on main, causing the publish.yaml to be triggered that publish the package to pub.dev.

Also updates bump.yaml to guarantee a release-note file exists in every bump PR (creates a stub release note if it doesn't exist), and the file is included in the commit so the reviewer can fill it in on the PR branch before merging.