### PR TITLE
fix(pkg):  Avoid constraint violation and report layout overflow in SheetContentScaffold

### DIFF
--- a/lib/src/content_scaffold.dart
+++ b/lib/src/content_scaffold.dart
@@ -364,7 +364,9 @@ class _ScaffoldLayout
 }
 
 class _RenderScaffoldLayout extends RenderBox
-    with SlottedContainerRenderObjectMixin<_ScaffoldSlot, RenderBox> {
+    with
+        SlottedContainerRenderObjectMixin<_ScaffoldSlot, RenderBox>,
+        DebugOverflowIndicatorMixin {
   _RenderScaffoldLayout({
     required bool extendBodyBehindTopBar,
     required bool extendBodyBehindBottomBar,
@@ -376,6 +378,9 @@ class _RenderScaffoldLayout extends RenderBox
        _ignoreBottomInset = ignoreBottomInset,
        _sheetLayoutSpec = sheetLayoutSpec,
        _viewportViewInsets = viewportViewInsets;
+
+  Rect _containerRect = Rect.zero;
+  Rect _childRect = Rect.zero;
 
   bool get extendBodyBehindTopBar => _extendBodyBehindTopBar;
   bool _extendBodyBehindTopBar;
@@ -569,7 +574,12 @@ class _RenderScaffoldLayout extends RenderBox
     positionChild(_ScaffoldSlot.bottomBar, Offset(0, bottomBarTop));
 
     // Finally, lay out the scaffold itself.
-    size = Size(constraints.maxWidth, bodyMargin.vertical + bodyHeight);
+    final contentHeight = bodyMargin.vertical + bodyHeight;
+    size = constraints.constrain(
+      Size(constraints.maxWidth, contentHeight),
+    );
+    _containerRect = Offset.zero & size;
+    _childRect = Offset.zero & Size(size.width, contentHeight);
   }
 
   @override
@@ -585,6 +595,11 @@ class _RenderScaffoldLayout extends RenderBox
     paintChild(_ScaffoldSlot.body);
     paintChild(_ScaffoldSlot.topBar);
     paintChild(_ScaffoldSlot.bottomBar);
+
+    assert(() {
+      paintOverflowIndicator(context, offset, _containerRect, _childRect);
+      return true;
+    }());
   }
 
   @override

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -726,6 +726,51 @@ void main() {
       await tester.pumpWidget(env.testWidget);
       expect(inheritedPadding, EdgeInsets.zero);
     });
+
+    testWidgets(
+      'Reports layout overflow when content exceeds available size',
+      (tester) async {
+        final env = boilerplate(
+          builder: (context) {
+            return ConstrainedBox(
+              constraints: BoxConstraints.tightFor(
+                height: 150,
+              ),
+              child: SheetContentScaffold(
+                key: Key('scaffold'),
+                topBar: SizedBox(height: 50),
+                body: Column(
+                  children: [
+                    Container(
+                      width: double.infinity,
+                      height: 100,
+                      color: Colors.red,
+                    ),
+                  ],
+                ),
+                bottomBar: SizedBox(height: 50),
+              ),
+            );
+          },
+        );
+
+        final errors = await tester.pumpWidgetAndCaptureErrors(env.testWidget);
+        expect(
+          tester.getSize(find.byId('scaffold')),
+          Size(testScreenSize.width, 150),
+        );
+        expect(
+          errors,
+          contains(
+            isA<FlutterErrorDetails>().having(
+              (e) => e.exception.toString(),
+              'exception',
+              contains('A RenderFlex overflowed by 50 pixels on the bottom'),
+            ),
+          ),
+        );
+      },
+    );
   });
 
   group('SheetContentScaffold - bottom-bar visibility', () {


### PR DESCRIPTION
Fixes #538, where an assertion error "_RenderScaffoldLayout does not meet its constraints" was thrown when `SheetContentScaffold` tried to expand beyond the available size.

It now constrains itself to fit within the given constraints and paints the black-and-yellow striped border to indicate a layout overflow if any.