### PR TITLE
fix(ci): h1 heading is duplicated in release note body

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,8 +87,15 @@ jobs:
           RAW: ${{ needs.detect.outputs.raw }}
         run: |
           set -e
+          # Strip the leading h1 heading and any following blank lines
+          # from the release note, since GitHub already renders the
+          # release title as h1.
+          NOTE_FILE="notes/release-note-${RAW}.md"
+          TRIMMED=$(tail -n +2 "$NOTE_FILE" | sed '/./,$!d')
+          echo "$TRIMMED" > /tmp/trimmed-note.md
+
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes-file "notes/release-note-${RAW}.md" \
+            --notes-file /tmp/trimmed-note.md \
             --target "$GITHUB_SHA"
         shell: bash


### PR DESCRIPTION
The `release.yaml` workflow attaches the release note file as-is to the GitHub Release. Since GitHub already renders the release title as an h1 heading, the h1 line in the note file (e.g., `# v1.0.1 release note`) appears duplicated on the release page.

Strip the leading h1 heading and any following blank lines from the release note before passing it to `gh release create`. This is done with `tail -n +2` (removes the first line) piped through `sed '/./,$!d'` (removes leading blank lines).
