### PR TITLE
fix(pkg): False positive layout overflow assertion

### DIFF
--- a/example/lib/tutorial/imperative_paged_sheet.dart
+++ b/example/lib/tutorial/imperative_paged_sheet.dart
@@ -41,9 +41,6 @@ class _ExampleSheet extends StatelessWidget {
 
     // Wrap the nested navigator in a PagedSheet.
     return PagedSheet(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
       decoration: MaterialSheetDecoration(
         size: SheetSize.stretch,
         borderRadius: BorderRadius.circular(20),
@@ -81,41 +78,21 @@ class _DraggablePage extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        return SizedBox(
+        return Container(
+          color: Theme.of(context).colorScheme.secondaryContainer,
           width: constraints.maxWidth,
           height: constraints.maxHeight * 0.5,
-          child: SheetContentScaffold(
-            backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-            body: Column(
-              mainAxisSize: MainAxisSize.max,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                title,
-                const SizedBox(height: 32),
-                TextField(
-                  decoration: const InputDecoration(
-                    labelText: 'Type something',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ],
-            ),
-            bottomBarVisibility: BottomBarVisibility.always(
-              ignoreBottomInset: true,
-            ),
-            bottomBar: Container(
-              color: Colors.red,
-              padding: EdgeInsets.fromLTRB(
-                16,
-                16,
-                16,
-                MediaQuery.of(context).viewPadding.bottom,
-              ),
-              child: ElevatedButton(
+          child: Column(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              title,
+              const SizedBox(height: 32),
+              TextButton(
                 onPressed: () => navigateToScrollablePage(context),
                 child: const Text('Next'),
               ),
-            ),
+            ],
           ),
         );
       },

--- a/example/lib/tutorial/imperative_paged_sheet.dart
+++ b/example/lib/tutorial/imperative_paged_sheet.dart
@@ -41,6 +41,9 @@ class _ExampleSheet extends StatelessWidget {
 
     // Wrap the nested navigator in a PagedSheet.
     return PagedSheet(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       decoration: MaterialSheetDecoration(
         size: SheetSize.stretch,
         borderRadius: BorderRadius.circular(20),
@@ -78,21 +81,41 @@ class _DraggablePage extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        return Container(
-          color: Theme.of(context).colorScheme.secondaryContainer,
+        return SizedBox(
           width: constraints.maxWidth,
           height: constraints.maxHeight * 0.5,
-          child: Column(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              title,
-              const SizedBox(height: 32),
-              TextButton(
+          child: SheetContentScaffold(
+            backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+            body: Column(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                title,
+                const SizedBox(height: 32),
+                TextField(
+                  decoration: const InputDecoration(
+                    labelText: 'Type something',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ],
+            ),
+            bottomBarVisibility: BottomBarVisibility.always(
+              ignoreBottomInset: true,
+            ),
+            bottomBar: Container(
+              color: Colors.red,
+              padding: EdgeInsets.fromLTRB(
+                16,
+                16,
+                16,
+                MediaQuery.of(context).viewPadding.bottom,
+              ),
+              child: ElevatedButton(
                 onPressed: () => navigateToScrollablePage(context),
                 child: const Text('Next'),
               ),
-            ],
+            ),
           ),
         );
       },

--- a/lib/src/content_scaffold.dart
+++ b/lib/src/content_scaffold.dart
@@ -364,9 +364,7 @@ class _ScaffoldLayout
 }
 
 class _RenderScaffoldLayout extends RenderBox
-    with
-        SlottedContainerRenderObjectMixin<_ScaffoldSlot, RenderBox>,
-        DebugOverflowIndicatorMixin {
+    with SlottedContainerRenderObjectMixin<_ScaffoldSlot, RenderBox> {
   _RenderScaffoldLayout({
     required bool extendBodyBehindTopBar,
     required bool extendBodyBehindBottomBar,
@@ -378,9 +376,6 @@ class _RenderScaffoldLayout extends RenderBox
        _ignoreBottomInset = ignoreBottomInset,
        _sheetLayoutSpec = sheetLayoutSpec,
        _viewportViewInsets = viewportViewInsets;
-
-  Rect _containerRect = Rect.zero;
-  Rect _childRect = Rect.zero;
 
   bool get extendBodyBehindTopBar => _extendBodyBehindTopBar;
   bool _extendBodyBehindTopBar;
@@ -578,8 +573,6 @@ class _RenderScaffoldLayout extends RenderBox
     size = constraints.constrain(
       Size(constraints.maxWidth, contentHeight),
     );
-    _containerRect = Offset.zero & size;
-    _childRect = Offset.zero & Size(size.width, contentHeight);
   }
 
   @override
@@ -595,11 +588,6 @@ class _RenderScaffoldLayout extends RenderBox
     paintChild(_ScaffoldSlot.body);
     paintChild(_ScaffoldSlot.topBar);
     paintChild(_ScaffoldSlot.bottomBar);
-
-    assert(() {
-      paintOverflowIndicator(context, offset, _containerRect, _childRect);
-      return true;
-    }());
   }
 
   @override

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -731,8 +731,12 @@ void main() {
       'Edge case: unstable layout should not violate parent constraints',
       (tester) async {
         // This test verifies that the scaffold does not violate its layout
-        // constraints even when the layout is unstable due to floating-point
-        // precision issues. This can happen 
+        // constraints even when the layout is unstable due to a floating-point
+        // precision issue. This can happen, for example, when the scaffold is
+        // used as the sheet's content with bottomBarVisibility set to
+        // always(ignoreBottomInset: true), and the sheet is extending the
+        // shrunk scaffold's height as the on-screen keyboard is disappearing.
+        // The bottom bar is also resized accordingly.
         final env = boilerplate(
           builder: (context) {
             return ConstrainedBox(

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -728,27 +728,24 @@ void main() {
     });
 
     testWidgets(
-      'Reports layout overflow when content exceeds available size',
+      'Edge case: unstable layout should not violate parent constraints',
       (tester) async {
+        // This test verifies that the scaffold does not violate its layout
+        // constraints even when the layout is unstable due to floating-point
+        // precision issues. This can happen 
         final env = boilerplate(
           builder: (context) {
             return ConstrainedBox(
-              constraints: BoxConstraints.tightFor(
-                height: 150,
+              constraints: BoxConstraints.tight(
+                Size.fromHeight(427.327643681333),
               ),
               child: SheetContentScaffold(
-                key: Key('scaffold'),
-                topBar: SizedBox(height: 50),
-                body: Column(
-                  children: [
-                    Container(
-                      width: double.infinity,
-                      height: 100,
-                      color: Colors.red,
-                    ),
-                  ],
+                bottomBar: Container(
+                  color: Colors.white,
+                  width: double.infinity,
+                  height: 73.62690370255032,
                 ),
-                bottomBar: SizedBox(height: 50),
+                body: SizedBox.expand(),
               ),
             );
           },
@@ -756,18 +753,11 @@ void main() {
 
         final errors = await tester.pumpWidgetAndCaptureErrors(env.testWidget);
         expect(
-          tester.getSize(find.byId('scaffold')),
-          Size(testScreenSize.width, 150),
-        );
-        expect(
           errors,
-          contains(
-            isA<FlutterErrorDetails>().having(
-              (e) => e.exception.toString(),
-              'exception',
-              contains('A RenderFlex overflowed by 50 pixels on the bottom'),
-            ),
-          ),
+          isEmpty,
+          reason:
+              '"_RenderScaffoldLayout does not meet its constraints." '
+              'should not be thrown',
         );
       },
     );


### PR DESCRIPTION
Commit 488b569 enhanced `SheetContentScaffold` to paint a layout overflow indicator, but it started causing false-positive layout overflow assertion errors due to a floating-point precision issue originating from:

```dart
// content_scaffold.dart L:552-545
final bodyMaxHeight = max(
  childConstraints.maxHeight - bodyMargin.vertical,
  0.0,
);
```

where `bodyMaxHeight + bodyMargin.vertical` exceeds `childConstraints.maxHeight` in certain cases.

It also turns out that the scaffold's content never overflows, so this PR drops support for overflow indicator painting. The constraint violation fix made in 488b569 is still preserved.