### PR TITLE
feat(pkg): Add SheetController.jumpTo for non-animated, finger-following positioning

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -73,6 +73,23 @@ class SheetController extends ChangeNotifier
     return _client!.animateTo(to, duration: duration, curve: curve);
   }
 
+  /// Immediately sets the sheet position to [to] without animation.
+  ///
+  /// Unlike [animateTo], this jumps to the target on the same frame, making it
+  /// suitable for driving the sheet directly from a drag gesture (finger
+  /// following).
+  ///
+  /// It also retargets the idle activity to [to] so a layout change (e.g. the
+  /// sheet content resizing in response to the new offset) does not snap the
+  /// sheet back to its previous snap position. Call [animateTo] on release to
+  /// settle to a final position.
+  void jumpTo(SheetOffset to) {
+    assert(_client != null);
+    _client!
+      ..offset = to.resolve(_client!)
+      ..goIdle(targetOffset: to);
+  }
+
   @override
   void notifyListeners() {
     _immediateListeners.notifyListeners();


### PR DESCRIPTION
## Problem / Issue

Closes #551

`SheetController` only exposes `animateTo`. There is no public way to set the sheet position **on the same frame**, which is needed to drive the sheet directly from a custom drag gesture (finger following). `animateTo` with a zero `Duration` is not equivalent: it still routes through an animation activity (a frame of lag that fights the gesture) and does not retarget the idle activity, so a content resize in response to the new offset snaps the sheet back to its previous snap position.

The required internals already exist (`SheetModel.offset` setter and `goIdle(targetOffset:)`); they are just not reachable from outside the package.

## Solution

Add a `jumpTo(SheetOffset)` method to `SheetController` that sets the offset immediately and retargets the idle activity to the same target:

```dart
void jumpTo(SheetOffset to) {
  assert(_client != null);
  _client!
    ..offset = to.resolve(_client!)
    ..goIdle(targetOffset: to);
}
```

Use case: map a drag gesture straight to the sheet offset each frame via `jumpTo`, then call `animateTo` on release to settle to the nearest snap.

No behavior change to existing APIs; this is purely additive.

Happy to add a unit test mirroring the existing `animateTo` widget tests if you'd like one in this PR.
