### PR TITLE
fix(pkg): Honor Theme.pageTransitionsTheme on Android for PagedSheetRoute

### DIFF
--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -828,22 +828,34 @@ abstract class _BasePagedSheetRoute<T> extends PageRoute<T>
       return builder(context, animation, secondaryAnimation, child);
     }
     final theme = Theme.of(context);
-    return switch (theme.platform) {
-      TargetPlatform.android =>
-        _FadeForwardPageTransitionWithAnimationLessBackGesture(
+    if (theme.platform == TargetPlatform.android) {
+      final androidBuilder =
+          theme.pageTransitionsTheme.builders[TargetPlatform.android];
+      // Treat all framework-provided Material defaults for Android as
+      // "no explicit override" so the package keeps applying its own
+      // animation-less back gesture transition by default. The framework
+      // default varies by Flutter version (ZoomPageTransitionsBuilder on
+      // older versions, PredictiveBackPageTransitionsBuilder on current,
+      // FadeForwardsPageTransitionsBuilder in between).
+      if (androidBuilder == null ||
+          androidBuilder.runtimeType == FadeForwardsPageTransitionsBuilder ||
+          androidBuilder.runtimeType == ZoomPageTransitionsBuilder ||
+          androidBuilder.runtimeType == PredictiveBackPageTransitionsBuilder) {
+        return _FadeForwardPageTransitionWithAnimationLessBackGesture(
           route: this,
           animation: animation,
           secondaryAnimation: secondaryAnimation,
           child: child,
-        ),
-      _ => theme.pageTransitionsTheme.buildTransitions(
-        this,
-        context,
-        animation,
-        secondaryAnimation,
-        child,
-      ),
-    };
+        );
+      }
+    }
+    return theme.pageTransitionsTheme.buildTransitions(
+      this,
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
   }
 }
 

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart' show CupertinoPageTransitionsBuilder;
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 
@@ -862,6 +863,84 @@ void main() {
       expect(find.byKey(Key('b')), findsOneWidget);
       expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
     });
+
+    // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/555.
+    // On Android, PagedSheetRoute used to always use its own built-in
+    // transition and silently ignore Theme.pageTransitionsTheme. It should
+    // honor a custom page transitions builder configured by the app.
+    testWidgets(
+      'On Android, routes should use the custom transition builder '
+      'registered in Theme.pageTransitionsTheme',
+      (tester) async {
+        final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
+        await tester.pumpWidget(
+          Theme(
+            data: ThemeData(
+              platform: TargetPlatform.android,
+              pageTransitionsTheme: const PageTransitionsTheme(
+                builders: {
+                  TargetPlatform.android: _MarkerPageTransitionsBuilder(),
+                },
+              ),
+            ),
+            child: env.testWidget,
+          ),
+        );
+
+        env.pushRoute('b', 500);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byKey(_MarkerPageTransitionsBuilder.markerKey),
+          findsWidgets,
+          reason:
+              'PagedSheetRoute should delegate to the custom '
+              'PageTransitionsBuilder registered for Android.',
+        );
+      },
+    );
+
+    // Concrete #555 scenario: CupertinoPageTransitionsBuilder on Android
+    // should bring back the iOS-style edge swipe.
+    testWidgets(
+      'On Android with CupertinoPageTransitionsBuilder, '
+      'iOS-style swipe back gesture should work',
+      (tester) async {
+        final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
+        await tester.pumpWidget(
+          Theme(
+            data: ThemeData(
+              platform: TargetPlatform.android,
+              pageTransitionsTheme: const PageTransitionsTheme(
+                builders: {
+                  TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+                  TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+                },
+              ),
+            ),
+            child: env.testWidget,
+          ),
+        );
+        env.pushRoute('b', 500);
+        await tester.pumpAndSettle();
+        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
+
+        final pointerLocation = Offset(5, testScreenSize.height - 250);
+        final gesture = await tester.startGesture(pointerLocation);
+        await gesture.moveBy(const Offset(50, 0));
+        await tester.pumpAndSettle();
+        expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+
+        await gesture.moveBy(const Offset(400, 0));
+        await tester.pumpAndSettle();
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(Key('a')), findsOneWidget);
+        expect(find.byKey(Key('b')), findsNothing);
+        expect(env.getSheetRect(tester).top, testScreenSize.height - 300);
+      },
+    );
 
     testWidgets(
       'When Android predictive back gesture is performed',
@@ -2151,6 +2230,23 @@ void main() {
       },
     );
   });
+}
+
+class _MarkerPageTransitionsBuilder extends PageTransitionsBuilder {
+  const _MarkerPageTransitionsBuilder();
+
+  static const markerKey = Key('custom-transition-marker');
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return KeyedSubtree(key: markerKey, child: child);
+  }
 }
 
 class _TestPage extends StatelessWidget {


### PR DESCRIPTION
## Problem / Issue

Closes #555

On Android, `PagedSheetRoute.buildTransitions` short-circuited and always used the package's built-in fade-forward + animation-less back gesture transition, completely bypassing `Theme.of(context).pageTransitionsTheme`. Apps that override the Android page transition app-wide — e.g.

```dart
pageTransitionsTheme: PageTransitionsTheme(
  builders: {
    TargetPlatform.android: CupertinoPageTransitionsBuilder(),
    TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
  },
),
```

— saw no effect inside a `PagedSheet`. In particular, the iOS-style edge swipe-back gesture that `CupertinoPageTransitionsBuilder` provides was never available between pages of a `PagedSheet` on Android, even when explicitly configured.

## Solution

`_BasePagedSheetRoute.buildTransitions` now inspects `Theme.pageTransitionsTheme.builders[TargetPlatform.android]`:

- If the registered builder is `null`, `FadeForwardsPageTransitionsBuilder`, or `PredictiveBackPageTransitionsBuilder` (the framework default in current Flutter, which itself wraps `FadeForwardsPageTransitionsBuilder`), the package's `_FadeForwardPageTransitionWithAnimationLessBackGesture` is still used — preserving the existing default behavior for apps that didn't customize the theme.
- Otherwise (e.g. `CupertinoPageTransitionsBuilder`, `ZoomPageTransitionsBuilder`, or any custom `PageTransitionsBuilder`), the route delegates to `theme.pageTransitionsTheme.buildTransitions`, so the user's transition is actually applied — bringing back iOS-style swipe back when configured.

The iOS path and the per-route `PagedSheetRouteThemeData.transitionsBuilder` override are unchanged.

Two regression tests are added in `PagedSheet transition test with Imperative API` (plain `Navigator`, no `auto_route` needed to reproduce):

- "On Android, routes should use the custom transition builder registered in `Theme.pageTransitionsTheme`" — uses a marker `PageTransitionsBuilder` and asserts the marker widget appears in the tree after pushing a `PagedSheetRoute`.
- "On Android with `CupertinoPageTransitionsBuilder`, iOS-style swipe back gesture should work" — the concrete #555 scenario: an edge drag sets `userGestureInProgress`, and a long drag + release pops back to the previous route.

Existing iOS swipe-back and Android predictive-back tests continue to pass, guarding the default-behavior path.
