### PR TITLE
fix(pkg): PagedSheetRoute ignores inherited ThemeData.pageTransitionsTheme on Android

### DIFF
--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -847,17 +847,23 @@ abstract class _BasePagedSheetRoute<T> extends PageRoute<T>
     if (isCurrent) {
       navigator?.pop();
     }
-    final c = controller;
-    if (c != null && c.isAnimating) {
-      late final AnimationStatusListener listener;
-      listener = (_) {
-        navigator?.didStopUserGesture();
-        c.removeStatusListener(listener);
-      };
-      c.addStatusListener(listener);
-    } else {
+
+    final controller = this.controller;
+    if (controller == null) return;
+    if (!controller.isAnimating) {
       navigator?.didStopUserGesture();
+      return;
     }
+
+    controller.reverse();
+    // Keep navigator.userGestureInProgress true during the animation
+    // since some transition builders depend on it.
+    late final AnimationStatusListener listener;
+    listener = (status) {
+      navigator?.didStopUserGesture();
+      controller.removeStatusListener(listener);
+    };
+    controller.addStatusListener(listener);
   }
 }
 

--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -7,7 +7,6 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:navigator_resizable/navigator_resizable.dart';
 
 import 'activity.dart';
@@ -827,23 +826,38 @@ abstract class _BasePagedSheetRoute<T> extends PageRoute<T>
     if (_resolvedTheme.transitionsBuilder case final builder?) {
       return builder(context, animation, secondaryAnimation, child);
     }
-    final theme = Theme.of(context);
-    return switch (theme.platform) {
-      TargetPlatform.android =>
-        _FadeForwardPageTransitionWithAnimationLessBackGesture(
-          route: this,
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
-          child: child,
-        ),
-      _ => theme.pageTransitionsTheme.buildTransitions(
-        this,
-        context,
-        animation,
-        secondaryAnimation,
-        child,
-      ),
-    };
+    return Theme.of(context).pageTransitionsTheme.buildTransitions(
+      this,
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
+  }
+
+  // Difference from `TransitionRoute.handleCommitBackGesture`: this override
+  // does NOT call `controller.reverse(from: controller.upperBound)` after
+  // pop. The framework's snap-back to 1.0 produces a visible jump in the
+  // sheet's height interpolation, because the sheet's size tracks the
+  // route animation. By letting `navigator.pop()` reverse the controller
+  // from its current value, the transition continues smoothly from the
+  // release point — matching Cupertino's swipe-back behavior.
+  @override
+  void handleCommitBackGesture() {
+    if (isCurrent) {
+      navigator?.pop();
+    }
+    final c = controller;
+    if (c != null && c.isAnimating) {
+      late final AnimationStatusListener listener;
+      listener = (_) {
+        navigator?.didStopUserGesture();
+        c.removeStatusListener(listener);
+      };
+      c.addStatusListener(listener);
+    } else {
+      navigator?.didStopUserGesture();
+    }
   }
 }
 
@@ -950,92 +964,5 @@ class _PageBasedPagedSheetRoute<T> extends _BasePagedSheetRoute<T> {
     Animation<double> secondaryAnimation,
   ) {
     return page.child;
-  }
-}
-
-/// A transition that enables Android's predictive back gesture to pop routes
-/// within the nested [Navigator], without modifying route transition progress
-/// during the gesture.
-///
-/// This is a workaround for the issue where [TransitionRoute.animation]
-/// jumps from a mid-transition value to 1.0 when the back gesture is committed,
-/// causing an abrupt pop-transition animation.
-///
-/// The root cause is that [TransitionRoute.handleUpdateBackGestureProgress]
-/// updates the [TransitionRoute.controller]'s value as the gesture progresses,
-/// but [TransitionRoute.handleCommitBackGesture] triggers the transition
-/// animation via [AnimationController.reverse] with 1.0 as the starting point,
-/// regardless of the current [TransitionRoute.controller]'s value.
-///
-/// The default back gesture handler behaves this way, but is incompatible with
-/// [PagedSheet]'s size transition. This transition widget therefore suppresses
-/// that gesture-driven transition progress while still allowing the gesture to
-/// commit a route pop.
-class _FadeForwardPageTransitionWithAnimationLessBackGesture
-    extends StatefulWidget {
-  const _FadeForwardPageTransitionWithAnimationLessBackGesture({
-    required this.route,
-    required this.animation,
-    required this.secondaryAnimation,
-    required this.child,
-  });
-
-  final PageRoute<dynamic> route;
-  final Animation<double> animation;
-  final Animation<double> secondaryAnimation;
-  final Widget child;
-
-  @override
-  State<_FadeForwardPageTransitionWithAnimationLessBackGesture> createState() =>
-      _FadeForwardPageTransitionWithAnimationLessBackGestureState();
-}
-
-class _FadeForwardPageTransitionWithAnimationLessBackGestureState
-    extends State<_FadeForwardPageTransitionWithAnimationLessBackGesture>
-    with WidgetsBindingObserver {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
-    return !backEvent.isButtonEvent &&
-        widget.route.isCurrent &&
-        !widget.route.isFirst;
-  }
-
-  @override
-  void handleCancelBackGesture() {
-    _handleEndBackGesture(isCommitted: false);
-  }
-
-  @override
-  void handleCommitBackGesture() {
-    _handleEndBackGesture(isCommitted: true);
-  }
-
-  void _handleEndBackGesture({required bool isCommitted}) {
-    if (isCommitted && widget.route.isCurrent) {
-      widget.route.navigator?.pop();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return const FadeForwardsPageTransitionsBuilder().buildTransitions(
-      widget.route,
-      context,
-      widget.animation,
-      widget.secondaryAnimation,
-      widget.child,
-    );
   }
 }

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
 
-// CupertinoPageTransitionsBuilder is re-exported from material.dart on some
-// Flutter versions (e.g. 3.41.x) but not others (e.g. 3.35.x, 3.44.x). Import
-// cupertino.dart explicitly so the test compiles across all supported
-// versions.
-// ignore: unnecessary_import
+// Flutter 3.44 stopped re-exporting CupertinoPageTransitionsBuilder from
+// material.dart, so import cupertino.dart explicitly.
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-// Flutter 3.44 stopped re-exporting CupertinoPageTransitionsBuilder from
-// material.dart, so import cupertino.dart explicitly.
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
@@ -866,10 +864,6 @@ void main() {
       expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
     });
 
-    // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/555.
-    // On Android, PagedSheetRoute used to always use its own built-in
-    // transition and silently ignore Theme.pageTransitionsTheme. It should
-    // honor a custom page transitions builder configured by the app.
     testWidgets(
       'On Android, routes should use the custom transition builder '
       'registered in Theme.pageTransitionsTheme',

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -1,5 +1,11 @@
 import 'dart:async';
 
+// CupertinoPageTransitionsBuilder is re-exported from material.dart on some
+// Flutter versions (e.g. 3.41.x) but not others (e.g. 3.35.x, 3.44.x). Import
+// cupertino.dart explicitly so the test compiles across all supported
+// versions.
+// ignore: unnecessary_import
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 

--- a/test/paged_sheet_test.dart
+++ b/test/paged_sheet_test.dart
@@ -863,12 +863,90 @@ void main() {
       expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
     });
 
+    // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/555.
+    // On Android, PagedSheetRoute used to always use its own built-in
+    // transition and silently ignore Theme.pageTransitionsTheme. It should
+    // honor a custom page transitions builder configured by the app.
+    testWidgets(
+      'On Android, routes should use the custom transition builder '
+      'registered in Theme.pageTransitionsTheme',
+      (tester) async {
+        final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
+        await tester.pumpWidget(
+          Theme(
+            data: ThemeData(
+              platform: TargetPlatform.android,
+              pageTransitionsTheme: const PageTransitionsTheme(
+                builders: {
+                  TargetPlatform.android: _MarkerPageTransitionsBuilder(),
+                },
+              ),
+            ),
+            child: env.testWidget,
+          ),
+        );
+
+        env.pushRoute('b', 500);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byKey(_MarkerPageTransitionsBuilder.markerKey),
+          findsWidgets,
+          reason:
+              'PagedSheetRoute should delegate to the custom '
+              'PageTransitionsBuilder registered for Android.',
+        );
+      },
+    );
+
+    // Concrete #555 scenario: CupertinoPageTransitionsBuilder on Android
+    // should bring back the iOS-style edge swipe.
+    testWidgets(
+      'On Android with CupertinoPageTransitionsBuilder, '
+      'iOS-style swipe back gesture should work',
+      (tester) async {
+        final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
+        await tester.pumpWidget(
+          Theme(
+            data: ThemeData(
+              platform: TargetPlatform.android,
+              pageTransitionsTheme: const PageTransitionsTheme(
+                builders: {
+                  TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+                  TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+                },
+              ),
+            ),
+            child: env.testWidget,
+          ),
+        );
+        env.pushRoute('b', 500);
+        await tester.pumpAndSettle();
+        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
+
+        final pointerLocation = Offset(5, testScreenSize.height - 250);
+        final gesture = await tester.startGesture(pointerLocation);
+        await gesture.moveBy(const Offset(50, 0));
+        await tester.pumpAndSettle();
+        expect(env.navigatorKey.currentState!.userGestureInProgress, isTrue);
+
+        await gesture.moveBy(const Offset(400, 0));
+        await tester.pumpAndSettle();
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(Key('a')), findsOneWidget);
+        expect(find.byKey(Key('b')), findsNothing);
+        expect(env.getSheetRect(tester).top, testScreenSize.height - 300);
+      },
+    );
+
     testWidgets(
       'When Android predictive back gesture is performed',
       variant: TargetPlatformVariant.only(TargetPlatform.android),
       (tester) async {
         final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
-        await tester.pumpWidget(env.testWidget);
+        await tester.pumpWidget(_withPredictiveBackTheme(env.testWidget));
         env.pushRoute('b', 500);
         await tester.pumpAndSettle();
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
@@ -877,18 +955,14 @@ void main() {
         await tester.pump();
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
 
+        final dragHistory = <double>[env.getSheetRect(tester).top];
         await tester.updateAndroidBackGestureProgress(
           x: 100.0,
           y: 300,
           progress: 0.3,
         );
         await tester.pump();
-        expect(
-          env.getSheetRect(tester).top,
-          testScreenSize.height - 500,
-          reason:
-              'Sheet position should not change while gesture is in progress.',
-        );
+        dragHistory.add(env.getSheetRect(tester).top);
 
         await tester.updateAndroidBackGestureProgress(
           x: 200.0,
@@ -896,25 +970,43 @@ void main() {
           progress: 0.6,
         );
         await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
+        dragHistory.add(env.getSheetRect(tester).top);
 
-        final sheetTopHistory = <double>[];
+        expect(
+          dragHistory,
+          isMonotonicallyIncreasing,
+          reason:
+              'Sheet height should follow the gesture progress, shrinking '
+              'toward the previous route as the user drags.',
+        );
+        expect(
+          dragHistory.last,
+          greaterThan(dragHistory.first),
+          reason: 'Sheet must actually move during the gesture.',
+        );
+
+        final commitHistory = <double>[env.getSheetRect(tester).top];
         await tester.commitAndroidBackGesture();
         await tester.pump();
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
-        await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pumpAndSettle();
 
         expect(find.byKey(Key('a')), findsOneWidget);
         expect(find.byKey(Key('b')), findsNothing);
-        expect(sheetTopHistory, isMonotonicallyIncreasing);
+        expect(
+          commitHistory,
+          isMonotonicallyIncreasing,
+          reason:
+              'On commit, the sheet must continue from the release point '
+              'monotonically toward the previous route height — no snap '
+              'back to the pre-gesture position before reversing.',
+        );
         expect(env.getSheetRect(tester).top, testScreenSize.height - 300);
       },
     );
@@ -924,7 +1016,7 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.android),
       (tester) async {
         final env = boilerplate(initialRoute: 'a', initialRouteHeight: 300);
-        await tester.pumpWidget(env.testWidget);
+        await tester.pumpWidget(_withPredictiveBackTheme(env.testWidget));
         env.pushRoute('b', 500);
         await tester.pumpAndSettle();
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
@@ -938,24 +1030,32 @@ void main() {
           progress: 0.3,
         );
         await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
-
-        await tester.cancelAndroidBackGesture();
-        await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
-
-        await tester.pump(Duration(milliseconds: 100));
+        final releasedTop = env.getSheetRect(tester).top;
         expect(
-          env.getSheetRect(tester).top,
-          testScreenSize.height - 500,
-          reason:
-              'Sheet is already at the target position, so it should not '
-              'move while the route pop transition is running.',
+          releasedTop,
+          greaterThan(testScreenSize.height - 500),
+          reason: 'Sheet must have moved during the gesture.',
         );
 
+        final cancelHistory = <double>[releasedTop];
+        await tester.cancelAndroidBackGesture();
+        await tester.pump();
+        cancelHistory.add(env.getSheetRect(tester).top);
+        await tester.pump(Duration(milliseconds: 50));
+        cancelHistory.add(env.getSheetRect(tester).top);
+        await tester.pump(Duration(milliseconds: 50));
+        cancelHistory.add(env.getSheetRect(tester).top);
         await tester.pumpAndSettle();
+
         expect(find.byKey(Key('a')), findsNothing);
         expect(find.byKey(Key('b')), findsOneWidget);
+        expect(
+          cancelHistory,
+          isMonotonicallyDecreasing,
+          reason:
+              'On cancel, the sheet must return to the current route height '
+              'smoothly from the release point.',
+        );
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
       },
     );
@@ -1464,7 +1564,7 @@ void main() {
         final pageA = createPage(name: 'a', height: 300);
         final pageB = createPage(name: 'b', height: 500);
         final env = boilerplate(initialPages: [pageA, pageB]);
-        await tester.pumpWidget(env.testWidget);
+        await tester.pumpWidget(_withPredictiveBackTheme(env.testWidget));
         await tester.pumpAndSettle();
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
 
@@ -1472,18 +1572,14 @@ void main() {
         await tester.pump();
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
 
+        final dragHistory = <double>[env.getSheetRect(tester).top];
         await tester.updateAndroidBackGestureProgress(
           x: 100.0,
           y: 300,
           progress: 0.3,
         );
         await tester.pump();
-        expect(
-          env.getSheetRect(tester).top,
-          testScreenSize.height - 500,
-          reason:
-              'Sheet position should not change while gesture is in progress.',
-        );
+        dragHistory.add(env.getSheetRect(tester).top);
 
         await tester.updateAndroidBackGestureProgress(
           x: 200.0,
@@ -1491,25 +1587,43 @@ void main() {
           progress: 0.6,
         );
         await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
+        dragHistory.add(env.getSheetRect(tester).top);
 
-        final sheetTopHistory = <double>[];
+        expect(
+          dragHistory,
+          isMonotonicallyIncreasing,
+          reason:
+              'Sheet height should follow the gesture progress, shrinking '
+              'toward the previous route as the user drags.',
+        );
+        expect(
+          dragHistory.last,
+          greaterThan(dragHistory.first),
+          reason: 'Sheet must actually move during the gesture.',
+        );
+
+        final commitHistory = <double>[env.getSheetRect(tester).top];
         await tester.commitAndroidBackGesture();
         await tester.pump();
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
-        await tester.pump(Duration(milliseconds: 50));
-        sheetTopHistory.add(env.getSheetRect(tester).top);
+        commitHistory.add(env.getSheetRect(tester).top);
         await tester.pumpAndSettle();
 
         expect(find.byKey(Key('a')), findsOneWidget);
         expect(find.byKey(Key('b')), findsNothing);
-        expect(sheetTopHistory, isMonotonicallyIncreasing);
+        expect(
+          commitHistory,
+          isMonotonicallyIncreasing,
+          reason:
+              'On commit, the sheet must continue from the release point '
+              'monotonically toward the previous route height — no snap '
+              'back to the pre-gesture position before reversing.',
+        );
         expect(env.getSheetRect(tester).top, testScreenSize.height - 300);
       },
     );
@@ -1521,7 +1635,7 @@ void main() {
         final pageA = createPage(name: 'a', height: 300);
         final pageB = createPage(name: 'b', height: 500);
         final env = boilerplate(initialPages: [pageA, pageB]);
-        await tester.pumpWidget(env.testWidget);
+        await tester.pumpWidget(_withPredictiveBackTheme(env.testWidget));
         await tester.pumpAndSettle();
         expect(find.byKey(Key('a')).hitTestable(), findsNothing);
         expect(find.byKey(Key('b')), findsOneWidget);
@@ -1537,24 +1651,38 @@ void main() {
           progress: 0.3,
         );
         await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
-
-        await tester.cancelAndroidBackGesture();
+        await tester.updateAndroidBackGestureProgress(
+          x: 200.0,
+          y: testScreenSize.height - 250,
+          progress: 0.6,
+        );
         await tester.pump();
-        expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
-
-        await tester.pump(Duration(milliseconds: 100));
+        final releasedTop = env.getSheetRect(tester).top;
         expect(
-          env.getSheetRect(tester).top,
-          testScreenSize.height - 500,
-          reason:
-              'Sheet is already at the target position, so it should not '
-              'move while the route pop transition is running.',
+          releasedTop,
+          greaterThan(testScreenSize.height - 500),
+          reason: 'Sheet must have moved during the gesture.',
         );
 
+        final cancelHistory = <double>[releasedTop];
+        await tester.cancelAndroidBackGesture();
+        await tester.pump();
+        cancelHistory.add(env.getSheetRect(tester).top);
+        await tester.pump(Duration(milliseconds: 50));
+        cancelHistory.add(env.getSheetRect(tester).top);
+        await tester.pump(Duration(milliseconds: 50));
+        cancelHistory.add(env.getSheetRect(tester).top);
         await tester.pumpAndSettle();
+
         expect(find.byKey(Key('a')), findsNothing);
         expect(find.byKey(Key('b')), findsOneWidget);
+        expect(
+          cancelHistory,
+          isMonotonicallyDecreasing,
+          reason:
+              'On cancel, the sheet must return to the current route height '
+              'smoothly from the release point.',
+        );
         expect(env.getSheetRect(tester).top, testScreenSize.height - 500);
       },
     );
@@ -2151,6 +2279,42 @@ void main() {
       },
     );
   });
+}
+
+/// Wraps [child] in a [Theme] that pins the Android page transition to
+/// [PredictiveBackPageTransitionsBuilder]. The default builder varies across
+/// Flutter versions (Zoom → FadeForwards → PredictiveBack), and only the
+/// predictive-back builder forwards platform back-gesture events to the
+/// route's `handle*BackGesture` methods. Pinning it keeps these tests
+/// version-independent and exercises the actual contract under test.
+Widget _withPredictiveBackTheme(Widget child) {
+  return Theme(
+    data: ThemeData(
+      pageTransitionsTheme: const PageTransitionsTheme(
+        builders: {
+          TargetPlatform.android: PredictiveBackPageTransitionsBuilder(),
+        },
+      ),
+    ),
+    child: child,
+  );
+}
+
+class _MarkerPageTransitionsBuilder extends PageTransitionsBuilder {
+  const _MarkerPageTransitionsBuilder();
+
+  static const markerKey = Key('custom-transition-marker');
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return KeyedSubtree(key: markerKey, child: child);
+  }
 }
 
 class _TestPage extends StatelessWidget {


### PR DESCRIPTION
Fixes #560.

On Android, `PagedSheetRoute` ignored the app's `pageTransitionsTheme` and forced its own animation-less back-gesture transition. As a result, any user-supplied page transition builder was silently dropped.

The reason the package overrode the transition in the first place was to sidestep a visual jump on predictive back: after the gesture commits, `TransitionRoute._handleDragEnd` snaps the route's controller to `upperBound` (1.0) before reversing, which propagates into PagedSheet's height interpolation as a noticeable jump back to the pre-gesture position before the pop completes.

# Solution

`_BasePagedSheetRoute` now overrides `handleCommitBackGesture` to omit the framework's `controller.reverse(from: upperBound)` snap, so the transition continues linearly from where the finger was released. 

This change eliminates the need of the transition override in `buildTransitions` on Android; it delegates straight to `Theme.pageTransitionsTheme.buildTransitions`.
