### PR TITLE
fix(pkg): Assertion error in SheetContentScaffold when height is zero

### DIFF
--- a/lib/src/content_scaffold.dart
+++ b/lib/src/content_scaffold.dart
@@ -715,7 +715,7 @@ abstract class _RenderBottomBarVisibility extends RenderTransform {
               .clamp(
                 // Prevent the bar from being moved up
                 // when the content is fully outside of the viewport.
-                bottomBarSize.height - _model.contentSize.height,
+                min(0.0, bottomBarSize.height - _model.contentSize.height),
                 // We don't need to move the bar up
                 // when the content is fully visible within the viewport.
                 0.0,

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -93,8 +93,10 @@ void main() {
         Rect.fromLTWH(0, 0, testScreenSize.width, 200),
       );
     });
-  
-    testWidgets('Body with zero-height in loose box-constraints', (tester) async {
+
+    testWidgets('Body with zero-height in loose box-constraints', (
+      tester,
+    ) async {
       final bodyKey = UniqueKey();
       final env = boilerplate(
         builder: (context) {

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -93,6 +93,30 @@ void main() {
         Rect.fromLTWH(0, 0, testScreenSize.width, 200),
       );
     });
+  
+    testWidgets('Body with zero-height in loose box-constraints', (tester) async {
+      final bodyKey = UniqueKey();
+      final env = boilerplate(
+        builder: (context) {
+          return ConstrainedBox(
+            constraints: BoxConstraints.loose(testScreenSize),
+            child: SheetContentScaffold(
+              key: Key('scaffold'),
+              body: SizedBox(key: bodyKey, height: 0),
+            ),
+          );
+        },
+      );
+
+      await tester.pumpWidget(env.testWidget);
+      expect(
+        tester.getLocalRect(
+          find.byKey(bodyKey),
+          ancestor: find.byId('scaffold'),
+        ),
+        Rect.fromLTWH(0, 0, testScreenSize.width, 0),
+      );
+    });
 
     testWidgets('TopBar-Body layout with tight box-constraints', (
       tester,

--- a/test/content_scaffold_test.dart
+++ b/test/content_scaffold_test.dart
@@ -781,6 +781,7 @@ void main() {
       EdgeInsets viewportPadding = EdgeInsets.zero,
       double initialKeyboardHeight = 0,
       bool extendBodyBehindBottomBar = true,
+      Widget? body,
     }) {
       final modelOwnerKey = GlobalKey<SheetModelOwnerState>();
       final statefulKey = GlobalKey<TestStatefulWidgetState<double>>();
@@ -813,11 +814,13 @@ void main() {
                         key: Key('scaffold'),
                         bottomBarVisibility: visibility,
                         extendBodyBehindBottomBar: extendBodyBehindBottomBar,
-                        body: Container(
-                          key: Key('body'),
-                          color: Colors.white,
-                          height: double.infinity,
-                        ),
+                        body:
+                            body ??
+                            Container(
+                              key: Key('body'),
+                              color: Colors.white,
+                              height: double.infinity,
+                            ),
                         bottomBar: Container(
                           key: Key('bottomBar'),
                           color: Colors.white,
@@ -1136,6 +1139,19 @@ void main() {
         );
       },
     );
+
+    testWidgets('always - when body has zero height', (tester) async {
+      final env = boilerplate(
+        visibility: BottomBarVisibility.always(),
+        extendBodyBehindBottomBar: false,
+        body: SizedBox.shrink(key: Key('body')),
+      );
+      await tester.pumpWidget(env.testWidget);
+
+      expect(env.getScaffoldRect(tester).size, Size(800, 50));
+      expect(env.getLocalBodyRect(tester), Rect.fromLTWH(0, 0, 800, 0));
+      expect(env.getLocalBottomBarRect(tester), Rect.fromLTWH(0, 0, 800, 50));
+    });
 
     testWidgets('controlled - throws when extendBodyBehindBottomBar is false', (
       tester,


### PR DESCRIPTION
Fix #559, fix #366.

`BottomBarVisibility` throws `ArgumentError: Invalid argument(s): <bottomBarHeight>` from `_RenderBottomBarVisibility.invalidateTranslationValues` when the sheet's `contentSize` is smaller than the bottom bar's measured height.

In practice this hits users of `PagedSheet` whose inner navigator is `AutoRouter`: `AutoRouter` renders empty on its first build and only mounts the real `Navigator` after a post-frame callback, so for at least one painted frame `_PagedSheetModel` reports `contentSize = Size.zero` while the scaffold's bottom bar measures at its intrinsic height.

The offending line is in `lib/src/content_scaffold.dart`:

```dart
(...).clamp(
  bottomBarSize.height - _model.contentSize.height, // lowerLimit
  0.0,                                              // upperLimit
);
```

`double.clamp` requires `lowerLimit <= upperLimit`. Whenever `contentSize.height < bottomBarSize.height`, the lower bound becomes positive and the clamp throws.

