### PR TITLE
docs(pkg): Add missing doc comments for public APIs

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,9 +1,25 @@
+/// @docImport 'paged_sheet.dart';
+/// @docImport 'sheet.dart';
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'model.dart';
 
+/// Controls and observes a [Sheet].
+///
+/// A [SheetController] can be passed to [Sheet.controller] (or
+/// [PagedSheet.controller]) to programmatically animate the sheet and to read
+/// the current [metrics].
+///
+/// The [value] property exposes the sheet's current offset in pixels, and
+/// changes to it are broadcast to all registered listeners.
+///
+/// See also:
+/// - [DefaultSheetController], which creates and exposes a [SheetController]
+///   to its descendants.
 class SheetController extends ChangeNotifier
     implements ValueListenable<double?> {
   SheetModel? _client;
@@ -64,6 +80,10 @@ class SheetController extends ChangeNotifier
     super.dispose();
   }
 
+  /// Animates the sheet to the given [to] offset.
+  ///
+  /// The animation runs for the given [duration] along the [curve].
+  /// Returns a [Future] that completes when the animation finishes.
   Future<void> animateTo(
     SheetOffset to, {
     Duration duration = const Duration(milliseconds: 300),
@@ -93,20 +113,44 @@ class SheetController extends ChangeNotifier
   }
 }
 
+/// A widget that creates a [SheetController] and makes it available to
+/// all descendants via [DefaultSheetController.of].
+///
+/// The controller is automatically disposed when this widget is removed from
+/// the tree.
+///
+/// ```dart
+/// DefaultSheetController(
+///   child: Sheet(
+///     child: MySheetContent(),
+///   ),
+/// )
+/// ```
+///
+/// See also:
+/// - [DefaultSheetController.of], which retrieves the nearest controller.
 class DefaultSheetController extends StatefulWidget {
   const DefaultSheetController({super.key, required this.child});
 
+  /// The widget below this widget in the tree.
+  ///
+  /// A [SheetController] is made available to all descendants.
   final Widget child;
 
   @override
   State<DefaultSheetController> createState() => _DefaultSheetControllerState();
 
+  /// Returns the nearest [SheetController] in the widget tree, or `null` if
+  /// no [DefaultSheetController] ancestor exists.
   static SheetController? maybeOf(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<SheetControllerScope>()
         ?.controller;
   }
 
+  /// Returns the nearest [SheetController] in the widget tree.
+  ///
+  /// Throws a [FlutterError] if no [DefaultSheetController] ancestor exists.
   static SheetController of(BuildContext context) {
     final controller = maybeOf(context);
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -116,9 +116,6 @@ class SheetController extends ChangeNotifier
 /// A widget that creates a [SheetController] and makes it available to
 /// all descendants via [DefaultSheetController.of].
 ///
-/// The controller is automatically disposed when this widget is removed from
-/// the tree.
-///
 /// ```dart
 /// DefaultSheetController(
 ///   child: Sheet(
@@ -133,8 +130,6 @@ class DefaultSheetController extends StatefulWidget {
   const DefaultSheetController({super.key, required this.child});
 
   /// The widget below this widget in the tree.
-  ///
-  /// A [SheetController] is made available to all descendants.
   final Widget child;
 
   @override

--- a/lib/src/cupertino.dart
+++ b/lib/src/cupertino.dart
@@ -1,3 +1,6 @@
+/// @docImport 'modal_utils.dart';
+library;
+
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -631,6 +634,20 @@ abstract class _BaseCupertinoModalSheetRoute<T> extends PageRoute<T>
   }
 }
 
+/// A [Page] that shows a modal sheet route using the iOS-style stacking
+/// transition.
+///
+/// When this page is pushed, the underlying route scales down and gains a
+/// rounded top corner, mimicking the sheet stacking behavior of iOS.
+///
+/// Use this with a [Navigator] that supports the [Page] API (e.g.,
+/// [Navigator.pages]) to show a Cupertino-style modal sheet as part of
+/// declarative navigation.
+///
+/// See also:
+/// - [CupertinoModalSheetRoute], for the imperative equivalent.
+/// - [showCupertinoModalSheet], a convenience function that pushes a
+///   [CupertinoModalSheetRoute].
 class CupertinoModalSheetPage<T> extends Page<T> {
   const CupertinoModalSheetPage({
     super.key,
@@ -653,23 +670,36 @@ class CupertinoModalSheetPage<T> extends Page<T> {
   /// The content to be shown in the [Route] created by this page.
   final Widget child;
 
+  /// A builder that customizes the [SheetViewport] wrapping the sheet.
+  ///
+  /// Use this to control the viewport padding (e.g., to push the sheet above
+  /// the keyboard). The `preferredTopInset` argument passed to the builder is
+  /// the recommended top padding for the viewport so the sheet is not covered
+  /// by the outgoing route's scaled-down content.
   final CupertinoSheetViewportBuilder? viewportBuilder;
 
   /// {@macro flutter.widgets.ModalRoute.maintainState}
   final bool maintainState;
 
+  /// The color of the modal barrier.
   final Color? barrierColor;
 
+  /// Whether tapping the modal barrier dismisses the sheet.
   final bool barrierDismissible;
 
+  /// Whether the sheet can be dismissed by swiping it down.
   final bool swipeDismissible;
 
+  /// Semantic label for the modal barrier used by accessibility tools.
   final String? barrierLabel;
 
+  /// Duration of the route entry/exit animation.
   final Duration transitionDuration;
 
+  /// The animation curve used for the route entry/exit transition.
   final Curve transitionCurve;
 
+  /// Fine-grained sensitivity settings for the swipe-to-dismiss gesture.
   final SwipeDismissSensitivity swipeDismissSensitivity;
 
   /// {@macro cupertino._BaseCupertinoModalSheetRoute.overlayColor}
@@ -739,6 +769,22 @@ class _PageBasedCupertinoModalSheetRoute<T>
   }
 }
 
+/// A [PageRoute] that presents a sheet with the iOS-style stacking transition.
+///
+/// When this route is pushed, the underlying route scales down and gains a
+/// rounded top corner, mimicking the sheet stacking behavior of iOS.
+///
+/// ```dart
+/// Navigator.push(
+///   context,
+///   CupertinoModalSheetRoute(builder: (context) => MySheet()),
+/// );
+/// ```
+///
+/// See also:
+/// - [CupertinoModalSheetPage], the declarative equivalent for
+///   [Navigator.pages].
+/// - [showCupertinoModalSheet], a convenience function for this route.
 class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
   CupertinoModalSheetRoute({
     super.settings,
@@ -756,8 +802,14 @@ class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
     this.barrierBuilder,
   });
 
+  /// Builds the sheet widget shown in this route.
   final WidgetBuilder builder;
 
+  /// A builder that customizes the [SheetViewport] wrapping the sheet.
+  ///
+  /// Use this to control the viewport padding. The `preferredTopInset` argument
+  /// passed to the builder is the recommended top padding for the viewport so
+  /// the sheet is not covered by the outgoing route's scaled-down content.
   final CupertinoSheetViewportBuilder? viewportBuilder;
 
   @override

--- a/lib/src/decorations.dart
+++ b/lib/src/decorations.dart
@@ -3,8 +3,28 @@ import 'package:flutter/material.dart';
 import 'model.dart';
 import 'viewport.dart';
 
-enum SheetSize { fit, stretch }
+/// Determines how a [SizedSheetDecoration] sizes the sheet vertically.
+enum SheetSize {
+  /// The sheet sizes itself to fit its content.
+  ///
+  /// The decorated widget's height matches the intrinsic height of the content.
+  fit,
 
+  /// The sheet stretches to fill the space from its current offset to the
+  /// top of the viewport.
+  ///
+  /// This is useful for creating a sheet whose visual background extends all
+  /// the way up as the user drags it higher.
+  stretch,
+}
+
+/// A base class for [SheetDecoration]s that adjust the sheet's height based
+/// on a [SheetSize] value.
+///
+/// Subclasses must implement [build] to provide the visual decoration.
+/// The [size] determines whether the sheet sizes itself to fit its content
+/// ([SheetSize.fit]) or stretches to fill the space between the sheet's
+/// bottom edge and the top of the viewport ([SheetSize.stretch]).
 abstract class SizedSheetDecoration implements SheetDecoration {
   const SizedSheetDecoration({required this.size});
 
@@ -113,6 +133,23 @@ class BoxSheetDecoration extends SizedSheetDecoration {
   }
 }
 
+/// A [SizedSheetDecoration] that delegates decoration to a builder callback.
+///
+/// Use this when the decoration depends on [BuildContext] or when you want
+/// to compose multiple widgets around the sheet content without creating
+/// a custom [SheetDecoration] subclass.
+///
+/// ```dart
+/// SheetDecorationBuilder(
+///   size: SheetSize.fit,
+///   builder: (context, child) {
+///     return ClipRRect(
+///       borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+///       child: child,
+///     );
+///   },
+/// )
+/// ```
 class SheetDecorationBuilder extends SizedSheetDecoration {
   const SheetDecorationBuilder({required super.size, required this.builder});
 

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -1,3 +1,7 @@
+/// @docImport 'cupertino.dart';
+/// @docImport 'modal_utils.dart';
+library;
+
 import 'dart:async';
 import 'dart:math';
 
@@ -32,9 +36,33 @@ const Cubic _releasedPageForwardAnimationCurve = Curves.fastLinearToSlowEaseIn;
 typedef ModalSheetBarrierBuilder<T> =
     Widget Function(ModalRoute<T> route, VoidCallback onDismissCallback);
 
+/// Signature for builders that wrap a sheet in a custom [SheetViewport].
+///
+/// The [child] is the sheet widget. The returned widget must include a
+/// [SheetViewport] that contains [child].
 typedef SheetViewportBuilder =
     Widget Function(BuildContext context, Widget child);
 
+/// A [Page] that shows a modal sheet route using the standard material-style
+/// transition.
+///
+/// Use this with a [Navigator] that supports the [Page] API (e.g.,
+/// [Navigator.pages]) to show a modal sheet as part of declarative navigation.
+///
+/// ```dart
+/// Navigator(
+///   pages: [
+///     MaterialPage(child: HomeScreen()),
+///     if (showSheet)
+///       ModalSheetPage(child: MySheet()),
+///   ],
+///   onDidRemovePage: (page) { ... },
+/// )
+/// ```
+///
+/// See also:
+/// - [ModalSheetRoute], for the imperative equivalent.
+/// - [showModalSheet], a convenience function that pushes a [ModalSheetRoute].
 class ModalSheetPage<T> extends Page<T> {
   const ModalSheetPage({
     super.key,
@@ -58,25 +86,37 @@ class ModalSheetPage<T> extends Page<T> {
   /// The content to be shown in the [Route] created by this page.
   final Widget child;
 
+  /// A builder that wraps the default [SheetViewport] widget.
+  ///
+  /// Use this to customize the viewport — for example, to adjust the
+  /// padding dynamically based on the keyboard height.
   final SheetViewportBuilder? viewportBuilder;
 
   /// {@macro flutter.widgets.ModalRoute.maintainState}
   final bool maintainState;
 
+  /// Whether this page acts as a fullscreen dialog.
   final bool fullscreenDialog;
 
+  /// The color of the modal barrier.
   final Color? barrierColor;
 
+  /// Whether tapping the modal barrier dismisses the sheet.
   final bool barrierDismissible;
 
+  /// Semantic label for the modal barrier used by accessibility tools.
   final String? barrierLabel;
 
+  /// Whether the sheet can be dismissed by swiping it down.
   final bool swipeDismissible;
 
+  /// Duration of the route entry/exit animation.
   final Duration transitionDuration;
 
+  /// The animation curve used for the route entry/exit transition.
   final Curve transitionCurve;
 
+  /// Fine-grained sensitivity settings for the swipe-to-dismiss gesture.
   final SwipeDismissSensitivity swipeDismissSensitivity;
 
   /// {@macro modal_sheet_barrier_builder}
@@ -141,6 +181,21 @@ class _PageBasedModalSheetRoute<T> extends PageRoute<T>
   }
 }
 
+/// A [PageRoute] that presents a sheet with the standard material-style
+/// modal transition.
+///
+/// Use [showModalSheet] as a convenience, or push this route directly:
+///
+/// ```dart
+/// Navigator.push(
+///   context,
+///   ModalSheetRoute(builder: (context) => MySheet()),
+/// );
+/// ```
+///
+/// See also:
+/// - [ModalSheetPage], the declarative equivalent for [Navigator.pages].
+/// - [CupertinoModalSheetRoute], for the iOS-style stacking transition.
 class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
   ModalSheetRoute({
     super.settings,
@@ -158,8 +213,13 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
     this.barrierBuilder,
   });
 
+  /// Builds the sheet widget shown in this route.
   final WidgetBuilder builder;
 
+  /// A builder that wraps the default [SheetViewport] widget.
+  ///
+  /// Use this to customize the viewport — for example, to adjust the
+  /// padding dynamically based on the keyboard height.
   final SheetViewportBuilder? viewportBuilder;
 
   @override

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1,4 +1,6 @@
 /// @docImport 'controller.dart';
+/// @docImport 'snap_grid.dart';
+/// @docImport 'viewport.dart';
 library;
 
 import 'package:flutter/cupertino.dart';
@@ -563,6 +565,11 @@ abstract class SheetModel<C extends SheetModelConfig> extends SheetModelView
 }
 
 // TODO: Make this an immutable data class.
+/// Describes the geometry of the viewport and the sheet's content within it.
+///
+/// Instances of [ViewportLayout] are passed to [SheetSnapGrid.getSnapOffset],
+/// [SheetDecoration.preferredExtent], and other layout-aware APIs to allow
+/// them to make decisions based on the current viewport and content dimensions.
 abstract interface class ViewportLayout {
   /// {@template ViewportLayout.viewportSize}
   /// The size of the *viewport*, which is the rectangle
@@ -592,6 +599,7 @@ abstract interface class ViewportLayout {
   double get contentBaseline;
 }
 
+/// Extends [ViewportLayout] with the current sheet size.
 abstract interface class SheetLayout extends ViewportLayout {
   /// The size of the sheet.
   Size get size;

--- a/lib/src/offset_driven_animation.dart
+++ b/lib/src/offset_driven_animation.dart
@@ -3,6 +3,27 @@ import 'package:flutter/animation.dart';
 import 'controller.dart';
 import 'model.dart';
 
+/// An [Animation] whose value tracks the position of a sheet.
+///
+/// The animation value is `0.0` when the sheet is at [startOffset] and `1.0`
+/// when it is at [endOffset]. When the sheet is between these two offsets, the
+/// value is interpolated linearly.
+///
+/// If [startOffset] is `null`, [SheetMetrics.minOffset] is used as the start.
+/// If [endOffset] is `null`, [SheetMetrics.maxOffset] is used as the end.
+///
+/// [initialValue] is returned before the [SheetController] has a client (i.e.,
+/// before the sheet is laid out).
+///
+/// ```dart
+/// final animation = SheetOffsetDrivenAnimation(
+///   controller: sheetController,
+///   initialValue: 0.0,
+///   startOffset: SheetOffset(0.5),
+///   endOffset: SheetOffset(1.0),
+/// );
+/// // Use `animation` with FadeTransition, AnimatedBuilder, etc.
+/// ```
 class SheetOffsetDrivenAnimation extends Animation<double> {
   SheetOffsetDrivenAnimation({
     required SheetController controller,
@@ -13,8 +34,18 @@ class SheetOffsetDrivenAnimation extends Animation<double> {
        assert(initialValue >= 0.0 && initialValue <= 1.0);
 
   final SheetController _controller;
+
+  /// The animation value returned before the sheet is laid out.
   final double initialValue;
+
+  /// The sheet offset that corresponds to animation value `0.0`.
+  ///
+  /// Defaults to [SheetMetrics.minOffset] when `null`.
   final SheetOffset? startOffset;
+
+  /// The sheet offset that corresponds to animation value `1.0`.
+  ///
+  /// Defaults to [SheetMetrics.maxOffset] when `null`.
   final SheetOffset? endOffset;
 
   @override

--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -502,6 +502,36 @@ class _PostTransitionWithoutAnimationActivity
   }
 }
 
+/// A sheet that hosts an embedded [Navigator] and animates its size and
+/// offset when the navigator transitions between routes.
+///
+/// Each route inside the [navigator] can specify its own [SheetSnapGrid],
+/// [SheetScrollConfiguration], and other parameters via [PagedSheetRoute] or
+/// [PagedSheetPage]. When a route transition occurs, [PagedSheet] smoothly
+/// interpolates the sheet's offset and size between the departing and arriving
+/// routes.
+///
+/// Share default route settings across all routes by placing a
+/// [PagedSheetRouteTheme] above the [PagedSheet]:
+///
+/// ```dart
+/// PagedSheetRouteTheme(
+///   data: PagedSheetRouteThemeData(
+///     scrollConfiguration: SheetScrollConfiguration.enabled(),
+///   ),
+///   child: PagedSheet(
+///     navigator: Navigator(
+///       onGenerateRoute: (settings) => PagedSheetRoute(
+///         builder: (context) => MyPage(),
+///       ),
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// See also:
+/// - [PagedSheetRoute] and [PagedSheetPage], for per-route configuration.
+/// - [PagedSheetRouteTheme], to set shared defaults for all routes.
 class PagedSheet extends StatelessWidget {
   const PagedSheet({
     super.key,
@@ -514,14 +544,17 @@ class PagedSheet extends StatelessWidget {
     required this.navigator,
   });
 
+  /// An object that can be used to control and observe the sheet.
   final SheetController? controller;
 
+  /// How the sheet position responds to drag gestures and boundary conditions.
   final SheetPhysics physics;
 
   /// The [Curve] used for both the offset and size transition animations
   /// when navigating to a new route within the [navigator].
   final Curve transitionCurve;
 
+  /// Provides the visual appearance of the sheet.
   final SheetDecoration decoration;
 
   /// {@macro viewport.BareSheet.padding}
@@ -550,6 +583,10 @@ class PagedSheet extends StatelessWidget {
   /// ```
   final Widget Function(BuildContext, Widget)? builder;
 
+  /// The [Navigator] widget whose route stack determines the sheet's content.
+  ///
+  /// Routes inside the navigator should be [PagedSheetRoute] or
+  /// [PagedSheetPage] instances to integrate with the sheet's animations.
   final Widget navigator;
 
   @override

--- a/lib/src/physics.dart
+++ b/lib/src/physics.dart
@@ -32,6 +32,19 @@ const _kDefaultSheetSpring = SpringDescription(
 /// The default [SheetPhysics] used by sheet widgets.
 const kDefaultSheetPhysics = BouncingSheetPhysics();
 
+/// Determines how a sheet responds to pointer events and boundary conditions.
+///
+/// When the user drags the sheet or releases it with a velocity,
+/// the physics object decides how much the sheet should move and
+/// whether it should bounce, clamp, or simulate ballistic motion.
+///
+/// Built-in implementations:
+/// - [ClampingSheetPhysics] prevents the sheet from going outside its bounds.
+/// - [BouncingSheetPhysics] allows the sheet to go slightly beyond its bounds
+///   with a rubber-band effect.
+///
+/// See also:
+/// - [kDefaultSheetPhysics], the default physics used when none is specified.
 abstract class SheetPhysics {
   const SheetPhysics();
 
@@ -46,12 +59,24 @@ abstract class SheetPhysics {
         _ => null,
       };
 
+  /// Returns the number of pixels that a drag of [delta] pixels would overflow
+  /// the bounds of the sheet.
+  ///
+  /// If the drag would not cause the sheet to exceed its bounds, returns 0.
   double computeOverflow(double delta, SheetMetrics metrics);
 
   // TODO: Change to return a tuple of (physicsAppliedOffset, overflow)
   // to avoid recomputation of the overflow.
+  /// Returns the actual offset change to apply when the user drags by [delta].
+  ///
+  /// Implementations may reduce the movement near boundaries (e.g., for a
+  /// rubber-band effect) or clamp it entirely.
   double applyPhysicsToOffset(double delta, SheetMetrics metrics);
 
+  /// Creates a [Simulation] that drives the sheet to a resting position
+  /// after the user releases it with the given [velocity].
+  ///
+  /// May return `null` if the sheet is already at a resting position.
   Simulation? createBallisticSimulation(
     double velocity,
     SheetMetrics metrics,
@@ -123,6 +148,13 @@ mixin SheetPhysicsMixin on SheetPhysics {
   }
 }
 
+/// A [SheetPhysics] that prevents the sheet from going beyond its offset
+/// bounds.
+///
+/// When the user drags past [SheetMetrics.minOffset] or
+/// [SheetMetrics.maxOffset], movement is clamped so the sheet stops at the
+/// boundary. After release, a spring simulation returns the sheet to the
+/// nearest snap position.
 class ClampingSheetPhysics extends SheetPhysics with SheetPhysicsMixin {
   const ClampingSheetPhysics({this.spring = _kDefaultSheetSpring});
 

--- a/lib/src/sheet.dart
+++ b/lib/src/sheet.dart
@@ -1,3 +1,7 @@
+/// @docImport 'decorations.dart';
+/// @docImport 'paged_sheet.dart';
+library;
+
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
@@ -54,6 +58,26 @@ class _DraggableScrollableSheetModel
       config.scrollConfiguration;
 }
 
+/// A scrollable, draggable bottom sheet.
+///
+/// [Sheet] is the core widget of this library. It manages the sheet's
+/// position, integrates with scrollable content, and handles drag gestures.
+///
+/// ```dart
+/// Sheet(
+///   decoration: MaterialSheetDecoration(
+///     size: SheetSize.fit,
+///     borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+///   ),
+///   child: MySheetContent(),
+/// )
+/// ```
+///
+/// See also:
+/// - [SheetController], to programmatically control the sheet.
+/// - [SheetSnapGrid], to configure the snap positions.
+/// - [SheetPhysics], to configure drag and bounce behavior.
+/// - [PagedSheet], for a sheet with nested navigation.
 class Sheet extends StatelessWidget {
   const Sheet({
     super.key,
@@ -74,6 +98,10 @@ class Sheet extends StatelessWidget {
   /// {@macro SheetPosition.physics}
   final SheetPhysics? physics;
 
+  /// The positions to which this sheet can snap.
+  ///
+  /// Defaults to a [SingleSnapGrid] that snaps to fully-expanded
+  /// (`SheetOffset(1)`).
   final SheetSnapGrid snapGrid;
 
   /// An object that can be used to control and observe the sheet height.
@@ -91,6 +119,10 @@ class Sheet extends StatelessWidget {
   /// being dragged.
   final SheetDragConfiguration dragConfiguration;
 
+  /// Provides the visual appearance of the sheet.
+  ///
+  /// Use [MaterialSheetDecoration] or [BoxSheetDecoration] for common styles,
+  /// or implement [SheetDecoration] for custom appearances.
   final SheetDecoration decoration;
 
   /// {@macro viewport.BareSheet.padding}

--- a/lib/src/snap_grid.dart
+++ b/lib/src/snap_grid.dart
@@ -1,3 +1,6 @@
+/// @docImport 'sheet.dart';
+library;
+
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -5,15 +8,38 @@ import 'package:flutter/gestures.dart';
 
 import 'model.dart';
 
+/// Defines the positions to which a sheet can snap after a drag or fling.
+///
+/// Use one of the factory constructors to create an appropriate snap grid:
+/// - [SheetSnapGrid.new] (or [MultiSnapGrid]) for discrete snap positions.
+/// - [SheetSnapGrid.single] (or [SingleSnapGrid]) when only one position
+///   is needed.
+/// - [SheetSnapGrid.stepless] (or [SteplessSnapGrid]) to allow the sheet
+///   to rest at any offset between a minimum and maximum.
+///
+/// See also:
+/// - [Sheet.snapGrid], which accepts a [SheetSnapGrid].
 abstract interface class SheetSnapGrid {
+  /// Creates a snap grid with multiple discrete snap positions.
+  ///
+  /// When the user releases the sheet, it snaps to the nearest position in
+  /// [snaps]. If the release velocity exceeds [minFlingSpeed], it snaps in
+  /// the direction of the fling instead.
   const factory SheetSnapGrid({
     required List<SheetOffset> snaps,
     double minFlingSpeed,
   }) = MultiSnapGrid;
 
+  /// Creates a snap grid with a single snap position.
+  ///
+  /// The sheet always snaps to [snap] regardless of velocity.
   const factory SheetSnapGrid.single({required SheetOffset snap}) =
       SingleSnapGrid;
 
+  /// Creates a snap grid that allows the sheet to rest at any offset.
+  ///
+  /// The sheet can settle anywhere between [minOffset] and [maxOffset],
+  /// preserving the exact offset at the moment the user releases it.
   const factory SheetSnapGrid.stepless({
     SheetOffset minOffset,
     SheetOffset maxOffset,
@@ -31,6 +57,12 @@ abstract interface class SheetSnapGrid {
   (SheetOffset, SheetOffset) getBoundaries(ViewportLayout layout);
 }
 
+/// A [SheetSnapGrid] with exactly one snap position.
+///
+/// The sheet always returns to [snap] after a drag or fling, regardless of
+/// the release velocity.
+///
+/// Created via [SheetSnapGrid.single].
 class SingleSnapGrid implements SheetSnapGrid {
   const SingleSnapGrid({required this.snap});
 
@@ -51,6 +83,14 @@ class SingleSnapGrid implements SheetSnapGrid {
   }
 }
 
+/// A [SheetSnapGrid] that allows the sheet to settle at any offset between
+/// [minOffset] and [maxOffset].
+///
+/// Unlike [MultiSnapGrid], there are no discrete snap positions — the sheet
+/// stays wherever the user releases it, as long as it is within the allowed
+/// range.
+///
+/// Created via [SheetSnapGrid.stepless].
 class SteplessSnapGrid implements SheetSnapGrid {
   const SteplessSnapGrid({
     this.minOffset = const SheetOffset(0),

--- a/lib/src/viewport.dart
+++ b/lib/src/viewport.dart
@@ -1,4 +1,6 @@
 /// @docImport 'decorations.dart';
+/// @docImport 'paged_sheet.dart';
+/// @docImport 'sheet.dart';
 library;
 
 import 'dart:math';
@@ -72,6 +74,8 @@ class SheetLayoutSpec {
   int get hashCode => Object.hash(viewportSize, viewportPadding, contentMargin);
 }
 
+/// A [ValueListenable] that holds the current [SheetLayout], or `null` before
+/// the sheet has been laid out.
 typedef SheetLayoutListenable = ValueListenable<SheetLayout?>;
 
 /// Stores the geometry of the viewport and the layout constraints
@@ -220,6 +224,25 @@ class _InheritedSheetMediaQuery extends InheritedWidget {
       layoutNotifier != oldWidget.layoutNotifier;
 }
 
+/// The layout region in which a sheet is positioned and sized.
+///
+/// [SheetViewport] is typically placed directly around a [Sheet] (or
+/// [PagedSheet]) to define the coordinate space the sheet occupies. It
+/// connects the sheet to the framework's layout and routing systems and
+/// exposes sheet metrics to descendant widgets via [SheetMediaQuery].
+///
+/// Only one [SheetViewport] can exist within the same route. When used inside a
+/// modal route, one is inserted automatically, so you only need to provide your
+/// own when you need to customize [padding].
+///
+/// ```dart
+/// SheetViewport(
+///   padding: EdgeInsets.only(
+///     bottom: MediaQuery.viewInsetsOf(context).bottom,
+///   ),
+///   child: Sheet(child: MyContent()),
+/// )
+/// ```
 class SheetViewport extends StatefulWidget {
   const SheetViewport({
     super.key,
@@ -495,9 +518,28 @@ class _SheetConstraints extends BoxConstraints {
   );
 }
 
+/// Controls the visual appearance and height behavior of a sheet.
+///
+/// A [SheetDecoration] wraps the sheet's child widget with a visual
+/// treatment (e.g., background color, border radius) and reports its
+/// preferred vertical extent, which determines how tall the decorated
+/// sheet should be.
+///
+/// Built-in implementations:
+/// - [MaterialSheetDecoration] — wraps the sheet in a [Material] widget.
+/// - [BoxSheetDecoration] — wraps the sheet in a [DecoratedBox].
+/// - [SheetDecorationBuilder] — delegates to a builder callback.
 @immutable
 abstract interface class SheetDecoration {
+  /// Returns the preferred height of the decorated sheet in pixels.
+  ///
+  /// The [offset] is the current sheet offset in pixels, and [layout] provides
+  /// the current viewport and content geometry.
   double preferredExtent(double offset, ViewportLayout layout);
+
+  /// Wraps [child] (the sheet's content) with the visual decoration.
+  ///
+  /// The returned widget must not change the layout size of [child].
   Widget build(BuildContext context, Widget child);
 }
 


### PR DESCRIPTION
## Problem / Issue

Many public API symbols in the package had no doc comments, leaving users to infer behavior from type signatures alone or dig into the source code.

## Solution

Added `///` doc comments to all previously undocumented public symbols across 11 source files, including:

- **Widgets**: `Sheet`, `PagedSheet`, `SheetViewport`, `DefaultSheetController`
- **Routes & Pages**: `ModalSheetRoute`, `ModalSheetPage`, `CupertinoModalSheetRoute`, `CupertinoModalSheetPage`
- **Physics**: `SheetPhysics` (abstract methods), `ClampingSheetPhysics`
- **Snap grids**: `SheetSnapGrid` (interface + factory constructors), `SingleSnapGrid`, `SteplessSnapGrid`
- **Decorations**: `SheetDecoration` (interface + methods), `SizedSheetDecoration`, `SheetDecorationBuilder`, `SheetSize` enum values
- **Other**: `SheetController`, `SheetOffsetDrivenAnimation`, `ViewportLayout`, `SheetLayout`, `SheetLayoutListenable`, `SheetViewportBuilder`

Where helpful, short code examples were added. Cross-file references are wired up via `@docImport` directives so all `[Foo]` links resolve cleanly with `dart analyze`.
