### PR TITLE
fix(pkg): Modal sheet disappears instantly instead of animating to bottom when dismissed by swipe

### DIFF
--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -222,9 +222,9 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
 
   /// The curve used for the transition animation.
   ///
-  /// In the middle of a dismiss gesture drag,
-  /// this returns [Curves.linear] to match the finger motion.
-  @nonVirtual
+  /// During a swipe-to-dismiss gesture (and while finishing a gesture-driven
+  /// dismissal after release), this returns [Curves.linear] to match the user's
+  /// finger motion and avoid curve changes mid-transition.
   @visibleForTesting
   Curve get effectiveCurve =>
       (navigator?.userGestureInProgress ?? false) || _isDismissingByGesture
@@ -551,10 +551,23 @@ class _SheetDismissibleState extends State<_SheetDismissible>
       _route.navigator!.pop();
       _isUserGestureInProgress = false;
       _transitionController.fling(
-        velocity: effectiveVelocity.abs() > widget.sensitivity.minFlingVelocityRatio
-            ? effectiveVelocity
-            : -1.0 * widget.sensitivity.minFlingVelocityRatio,
+        velocity:
+            effectiveVelocity.abs() > widget.sensitivity.minFlingVelocityRatio
+                ? effectiveVelocity
+                : -1.0 * widget.sensitivity.minFlingVelocityRatio,
       );
+
+      // Ensure the route returns to the default (non-linear) curve once the
+      // gesture-driven dismissal finishes.
+      late final AnimationStatusListener resetDismissingFlag;
+      resetDismissingFlag = (status) {
+        if (status == AnimationStatus.dismissed ||
+            status == AnimationStatus.completed) {
+          _route._isDismissingByGesture = false;
+          _transitionController.removeStatusListener(resetDismissingFlag);
+        }
+      };
+      _transitionController.addStatusListener(resetDismissingFlag);
     } else if (!_transitionController.isCompleted) {
       // The route won't be popped, so animate the transition
       // back to the origin.

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -218,15 +218,18 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   // marked as protected, allowing it to be used by SheetDismissible.
   AnimationController get _controller => controller!;
 
+  bool _isDismissingByGesture = false;
+
   /// The curve used for the transition animation.
   ///
   /// In the middle of a dismiss gesture drag,
   /// this returns [Curves.linear] to match the finger motion.
   @nonVirtual
   @visibleForTesting
-  Curve get effectiveCurve => (navigator?.userGestureInProgress ?? false)
-      ? Curves.linear
-      : transitionCurve;
+  Curve get effectiveCurve =>
+      (navigator?.userGestureInProgress ?? false) || _isDismissingByGesture
+          ? Curves.linear
+          : transitionCurve;
 
   Widget buildSheet(BuildContext context);
 
@@ -544,7 +547,14 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final didPop = invokePop && _canPopByGesture;
 
     if (didPop) {
+      _route._isDismissingByGesture = true;
       _route.navigator!.pop();
+      _isUserGestureInProgress = false;
+      _transitionController.fling(
+        velocity: effectiveVelocity.abs() > widget.sensitivity.minFlingVelocityRatio
+            ? effectiveVelocity
+            : -1.0 * widget.sensitivity.minFlingVelocityRatio,
+      );
     } else if (!_transitionController.isCompleted) {
       // The route won't be popped, so animate the transition
       // back to the origin.


### PR DESCRIPTION
## Problem / Issue
<!-- What is the problem this PR addresses? Link the issue if available. -->
<!-- 例: Closes #123 -->
When a modal sheet is dismissed via swipe gesture, releasing the drag causes the sheet to disappear instantly instead of animating smoothly down to the bottom of the screen. This happens because `navigator.pop()` immediately flips `userGestureInProgress` to `false`, which switches `effectiveCurve` away from `Curves.linear` mid-transition, and the transition controller isn't given an explicit velocity to continue the motion from where the gesture left off.

I couldn't find an existing open issue that describes this exact behavior. The closest related report is #250 ("Modal sheet jerks when swipe to dismiss"), but that's about jerkiness during the drag itself (with go_router 14) rather than the sheet snapping away after release, and it's already closed.

## Solution
<!-- Briefly describe how the problem is solved in this PR. -->
- Added an `_isDismissingByGesture` flag on `ModalSheetRouteMixin` that stays `true` for the duration of a gesture-driven dismissal.
- Updated `effectiveCurve` to keep using `Curves.linear` while `_isDismissingByGesture` is `true`, in addition to the existing `userGestureInProgress` check, so the curve doesn't switch back to the non-linear `transitionCurve` mid-animation.
- In `_SheetDismissibleState`, when a drag results in an actual pop, the route is now flagged via `_isDismissingByGesture = true` before popping, and `_transitionController.fling()` is called with the effective release velocity (falling back to `sensitivity.minFlingVelocityRatio` when the release velocity is too small to feel like a deliberate swipe).

Together these changes let the sheet continue its motion smoothly to the bottom of the screen using the same feel as the drag, instead of abruptly disappearing when the gesture ends.
