### PR TITLE
fix(pkg): Avoid crash when a SheetModel is detached during layout

### DIFF
--- a/lib/src/model_owner.dart
+++ b/lib/src/model_owner.dart
@@ -73,7 +73,12 @@ class SheetModelOwnerState<C extends SheetModelConfig>
   @override
   void dispose() {
     widget.controller?.detach(model);
-    _viewport?.setModel(null);
+    // Use unsetModel instead of setModel(null) so that disposing this owner
+    // does not detach a model that another owner attached to the same
+    // viewport after this owner was deactivated (e.g. when a sheet is
+    // rebuilt within the same frame). Otherwise the viewport may be laid
+    // out without any model attached.
+    _viewport?.unsetModel(model);
     model.dispose();
     _viewport = null;
     _model = null;
@@ -92,7 +97,7 @@ class SheetModelOwnerState<C extends SheetModelConfig>
     _devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     final viewport = SheetViewportState.of(context);
     if (viewport != _viewport) {
-      _viewport?.setModel(null);
+      _viewport?.unsetModel(model);
       _viewport = viewport?..setModel(model);
     }
   }

--- a/lib/src/viewport.dart
+++ b/lib/src/viewport.dart
@@ -261,6 +261,15 @@ class SheetViewportState extends State<SheetViewport> {
     _modelView.setModel(model);
   }
 
+  /// Detaches [model] from this viewport only if it is currently attached.
+  ///
+  /// Unlike `setModel(null)`, this does not detach a different model that
+  /// may have been attached after [model], e.g. by a new sheet that is
+  /// created in the same frame in which the owner of [model] is disposed.
+  void unsetModel(SheetModel model) {
+    _modelView.unsetModel(model);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -907,7 +916,27 @@ class _RenderSheetSkelton extends RenderShiftedBox {
     (child.parentData! as BoxParentData).offset =
         _layoutSpec.contentMargin.topLeft;
 
-    assert(_model._inner != null);
+    final maxRect = _layoutSpec.maxSheetRect;
+    final maxSize = maxRect.size;
+    final paddedChildSize = _layoutSpec.contentMargin.inflateSize(child.size);
+
+    final model = _model._inner;
+    if (model == null) {
+      // No model is attached to the viewport at the moment, e.g. when this
+      // render object is laid out in the same frame in which the owner of
+      // the previously attached model was disposed. Fall back to a
+      // best-effort size instead of crashing; the layout pass that runs
+      // after a model is (re)attached will apply the proper layout.
+      size = BoxConstraints(
+        minWidth: maxSize.width,
+        maxWidth: maxSize.width,
+        minHeight: paddedChildSize.height,
+        maxHeight: maxSize.height,
+      ).constrain(Size.fromHeight(_preferredExtent ?? paddedChildSize.height));
+      _isPerformingLayout = false;
+      return;
+    }
+
     final viewportLayout = ImmutableViewportLayout(
       contentSize: Size.copy(child.size),
       viewportSize: _layoutSpec.viewportSize,
@@ -916,11 +945,8 @@ class _RenderSheetSkelton extends RenderShiftedBox {
           _layoutSpec.viewportSize.height - _layoutSpec.maxContentRect.bottom,
       contentMargin: _layoutSpec.contentMargin,
     );
-    final newOffset = _model._inner!.dryApplyNewLayout(viewportLayout);
+    final newOffset = model.dryApplyNewLayout(viewportLayout);
     _preferredExtent = _getPreferredExtent(newOffset, viewportLayout);
-    final maxRect = _layoutSpec.maxSheetRect;
-    final maxSize = maxRect.size;
-    final paddedChildSize = _layoutSpec.contentMargin.inflateSize(child.size);
     size = BoxConstraints(
       minWidth: maxSize.width,
       maxWidth: maxSize.width,
@@ -932,8 +958,8 @@ class _RenderSheetSkelton extends RenderShiftedBox {
       viewportLayout: viewportLayout,
       size: Size.copy(size),
     );
-    _model._inner!.applyNewLayout(newLayout);
-    assert(_model._inner!.hasMetrics);
+    model.applyNewLayout(newLayout);
+    assert(model.hasMetrics);
     layoutNotifier.value = newLayout;
 
     _isPerformingLayout = false;
@@ -965,8 +991,13 @@ class _LazySheetModelView extends SheetModelView with ChangeNotifier {
 
   void setModel(SheetModel? newModel) {
     if (newModel != _inner) {
-      final oldOffset = _inner?.offset;
-      final oldRect = _inner?.rect;
+      // Only read the outgoing model's offset/rect when it actually has
+      // metrics; reading them before its initial layout throws a null-check
+      // error (SheetModel.offset/rect assert non-null internals). This can
+      // happen when the model is detached before it was ever laid out.
+      final hadMetrics = _inner?.hasMetrics ?? false;
+      final oldOffset = hadMetrics ? _inner!.offset : null;
+      final oldRect = hadMetrics ? _inner!.rect : null;
       _inner
         ?..removeListener(notifyListeners)
         ..removeRectListener(_rectNotifier.notifyListeners);
@@ -986,6 +1017,12 @@ class _LazySheetModelView extends SheetModelView with ChangeNotifier {
           _rectNotifier.notifyListeners();
         }
       }
+    }
+  }
+
+  void unsetModel(SheetModel model) {
+    if (_inner == model) {
+      setModel(null);
     }
   }
 

--- a/test/regression_test.dart
+++ b/test/regression_test.dart
@@ -185,4 +185,29 @@ void main() {
       );
     },
   );
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/349
+  testWidgets(
+    'Disposing the sheet before its first layout should not crash',
+    (tester) async {
+      // Build the sheet but stop before the layout phase so its model is
+      // attached to the viewport without having any metrics yet.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetViewport(
+            child: Sheet(child: const SizedBox(height: 400)),
+          ),
+        ),
+        phase: EnginePhase.build,
+      );
+
+      // Tearing the sheet down now detaches a model that never had metrics.
+      // Reading the outgoing model's offset/rect in that state used to throw
+      // a "Null check operator used on a null value" error.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
 }


### PR DESCRIPTION
## Problem / Issue

Closes #349

A sheet could crash while being torn down or rebuilt with a "Null check
operator used on a null value" error (and, in a related same-frame scenario,
an `assert(_model._inner != null)` failure in
`_RenderSheetSkelton.performLayout`). Two related situations trigger it:

1. When a `SheetModelOwner` is disposed in the same frame in which a new owner
   attaches its model to the same `SheetViewport`, `dispose()` called
   `setModel(null)` unconditionally — detaching the model the new owner had
   just attached. The viewport could then be laid out with no model attached.
2. Detaching a model that had not been laid out yet threw the null-check error,
   because `setModel` read the outgoing model's `offset`/`rect` before it had
   any metrics. This is the crash reported in #349 (observed, for example, when
   calling `replaceAll` on a Navigator that hosts a `PagedSheet` wrapped by a
   `SheetViewport`).

## Solution

- Add `SheetViewportState.unsetModel` / `_LazySheetModelView.unsetModel`, which
  detach only the model that is currently attached, and use it from
  `SheetModelOwnerState.dispose()` and `didChangeDependencies()` instead of
  `setModel(null)`. Disposing an owner no longer detaches a model that another
  owner attached to the same viewport.
- Guard the outgoing model's `offset`/`rect` reads in `setModel` with a
  `hasMetrics` check, so detaching a not-yet-laid-out model no longer throws a
  null-check error.
- Make `_RenderSheetSkelton.performLayout` fall back to a best-effort size when
  no model is attached instead of asserting, so a transient null model no
  longer crashes the layout pass.

Added a regression test that reproduces #349 (disposing a sheet before its
first layout). All existing tests pass.
