### PR TITLE
fix(pkg): Null check operator error in _LazySheetModelView.setModel due to uninitialized old model offset

### DIFF
--- a/lib/src/viewport.dart
+++ b/lib/src/viewport.dart
@@ -964,28 +964,34 @@ class _LazySheetModelView extends SheetModelView with ChangeNotifier {
   final _rectNotifier = ChangeNotifier();
 
   void setModel(SheetModel? newModel) {
-    if (newModel != _inner) {
-      final oldOffset = _inner?.offset;
-      final oldRect = _inner?.rect;
-      _inner
-        ?..removeListener(notifyListeners)
-        ..removeRectListener(_rectNotifier.notifyListeners);
-      _inner = newModel
-        ?..addListener(notifyListeners)
-        ..addRectListener(_rectNotifier.notifyListeners);
+    if (newModel == _inner) {
+      return;
+    }
 
-      if (newModel case SheetModel(
-        hasMetrics: true,
-        :final offset,
-        :final rect,
-      )) {
-        if (offset != oldOffset) {
-          notifyListeners();
-        }
-        if (rect != oldRect) {
-          _rectNotifier.notifyListeners();
-        }
-      }
+    final double? oldOffset;
+    final Rect? oldRect;
+    if (_inner case final m? when m.hasMetrics) {
+      oldOffset = m.offset;
+      oldRect = m.rect;
+    } else {
+      oldOffset = oldRect = null;
+    }
+
+    _inner
+      ?..removeListener(notifyListeners)
+      ..removeRectListener(_rectNotifier.notifyListeners);
+    _inner = newModel
+      ?..addListener(notifyListeners)
+      ..addRectListener(_rectNotifier.notifyListeners);
+
+    if (newModel == null || !newModel.hasMetrics) {
+      return;
+    }
+    if (newModel.offset != oldOffset) {
+      notifyListeners();
+    }
+    if (newModel.rect != oldRect) {
+      _rectNotifier.notifyListeners();
     }
   }
 

--- a/test/regression_test.dart
+++ b/test/regression_test.dart
@@ -185,4 +185,29 @@ void main() {
       );
     },
   );
+
+  // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/349
+  testWidgets(
+    'Disposing the sheet before its first layout should not crash',
+    (tester) async {
+      // Build the sheet but stop before the layout phase so its model is
+      // attached to the viewport without having any metrics yet.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetViewport(
+            child: Sheet(child: const SizedBox(height: 400)),
+          ),
+        ),
+        phase: EnginePhase.build,
+      );
+
+      // Tearing the sheet down now detaches a model that never had metrics.
+      // Reading the outgoing model's offset/rect in that state used to throw
+      // a "Null check operator used on a null value" error.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
 }


### PR DESCRIPTION
Fixes #349, where disposing a sheet before the first layout phase causes a null check error on  the `offset` getter since, the model doesn't have any layout metrics value at that moment:

```
I/flutter ( 4546): Null check operator used on a null value
I/flutter ( 4546): #0      SheetModel.offset (package:smooth_sheets/src/model.dart:226)
I/flutter ( 4546): #1      _LazySheetModelView.setModel (package:smooth_sheets/src/viewport.dart:912)
I/flutter ( 4546): #2      SheetViewportState.setModel (package:smooth_sheets/src/viewport.dart:281)
I/flutter ( 4546): #3      SheetModelOwnerState.dispose (package:smooth_sheets/src/model_owner.dart:78)
I/flutter ( 4546): #4      StatefulElement.unmount (package:flutter/src/widgets/framework.dart:5940)
```

This PR fixes the issue by making the `setModel` method aware of the `hasMetrics` flag.