### PR TITLE
feat(pkg): Velocity-based spring animation for modal sheet swipe gestures

### DIFF
--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -46,10 +46,23 @@ class _SettleSpringSimulation extends Simulation {
     SpringDescription spring,
     double start,
     this.end,
-    double velocity,
-  ) : _spring = SpringSimulation(spring, start, end, velocity);
+    double velocity, {
+    double settleDistance = _kSettleDistanceTolerance,
+  }) : _settleDistance = settleDistance,
+       _spring = SpringSimulation(spring, start, end, velocity);
 
   final double end;
+
+  /// The distance from [end], in transition controller units, at which the
+  /// motion is considered finished.
+  ///
+  /// For a restore this is [_kSettleDistanceTolerance] (just the imperceptible
+  /// tail). For a dismiss it is the transition value at which the sheet has
+  /// fully left the screen — a non-fullscreen sheet exits before the value
+  /// reaches zero, so continuing to zero would only leave a non-interactive,
+  /// off-screen sheet blocking the screen.
+  final double _settleDistance;
+
   final SpringSimulation _spring;
 
   @override
@@ -59,8 +72,7 @@ class _SettleSpringSimulation extends Simulation {
   double dx(double time) => isDone(time) ? 0.0 : _spring.dx(time);
 
   @override
-  bool isDone(double time) =>
-      (end - _spring.x(time)).abs() < _kSettleDistanceTolerance;
+  bool isDone(double time) => (end - _spring.x(time)).abs() < _settleDistance;
 }
 
 /// {@template modal_sheet_barrier_builder}
@@ -276,18 +288,32 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   /// velocity-seeded spring. It is `null` for any non-gesture pop.
   double? _swipeDismissVelocity;
 
+  /// The transition value at which the sheet has fully left the screen during
+  /// a swipe-to-dismiss, expressed as a distance from the fully-closed value
+  /// (`0.0`).
+  ///
+  /// A non-fullscreen sheet exits the viewport before the transition reaches
+  /// zero (e.g. a sheet occupying half the screen disappears at value `0.5`),
+  /// so the pop spring is terminated here to avoid leaving a non-interactive,
+  /// off-screen sheet blocking the screen. Set together with
+  /// [_swipeDismissVelocity] and consumed once by [createSimulation].
+  double _swipeDismissSettleDistance = _kSettleDistanceTolerance;
+
   @override
   Simulation? createSimulation({required bool forward}) {
     final velocity = _swipeDismissVelocity;
     if (!forward && velocity != null) {
-      // Consume the velocity so subsequent pops fall back to the default
-      // reverse transition.
+      // Consume the stashed gesture state so subsequent pops fall back to the
+      // default reverse transition.
+      final settleDistance = _swipeDismissSettleDistance;
       _swipeDismissVelocity = null;
+      _swipeDismissSettleDistance = _kSettleDistanceTolerance;
       return _SettleSpringSimulation(
         _kModalTransitionSpring,
         _controller.value,
         0.0,
         velocity,
+        settleDistance: settleDistance,
       );
     }
     return super.createSimulation(forward: forward);
@@ -619,9 +645,12 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final didPop = invokePop && _canPopByGesture;
 
     if (didPop) {
-      // Stash the release velocity so the route's createSimulation drives the
-      // pop transition with a velocity-seeded spring.
+      // Stash the release velocity and the value at which the sheet fully
+      // leaves the screen so the route's createSimulation drives the pop
+      // transition with a velocity-seeded spring that terminates as soon as the
+      // sheet is off-screen.
       _route._swipeDismissVelocity = effectiveVelocity;
+      _route._swipeDismissSettleDistance = _resolveDismissSettleDistance();
       _route.navigator!.pop();
     } else if (!_transitionController.isCompleted) {
       // The route won't be popped, so spring the transition back to the origin,
@@ -682,6 +711,36 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     }
 
     return true;
+  }
+
+  /// The transition value distance from fully-closed (`0.0`) at which the sheet
+  /// has completely left the screen.
+  ///
+  /// The pop transition slides the whole viewport down, so a sheet whose
+  /// visible height is `model.offset` pixels leaves the screen once the
+  /// viewport has been slid down by that many pixels — that is, at transition
+  /// value `1 - offset / viewportHeight`. Falls back to
+  /// [_kSettleDistanceTolerance] (fullscreen behavior) when the sheet metrics
+  /// are unavailable.
+  double _resolveDismissSettleDistance() {
+    final model = SheetViewportState.of(context)?.model;
+    if (model == null) {
+      return _kSettleDistanceTolerance;
+    }
+
+    final viewportHeight = model.viewportSize.height;
+    if (viewportHeight <= 0) {
+      return _kSettleDistanceTolerance;
+    }
+
+    final exitDistance = 1 - (model.offset / viewportHeight);
+    if (exitDistance < _kSettleDistanceTolerance) {
+      return _kSettleDistanceTolerance;
+    }
+    if (exitDistance > 1.0) {
+      return 1.0;
+    }
+    return exitDistance;
   }
 
   @override

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -20,6 +20,49 @@ final _kModalTransitionSpring = SpringDescription.withDampingRatio(
   ratio: 1.1,
 );
 
+/// The distance, in transition controller units (fraction of the viewport
+/// height), within which [_SettleSpringSimulation] considers the spring to have
+/// reached its resting position and terminates.
+///
+/// An overdamped spring approaches its target asymptotically, so the last
+/// fraction of the motion is imperceptibly slow. Cutting it off at 1% of the
+/// viewport height keeps the visible motion intact while roughly halving how
+/// long the animation — and thus the pointer-input lock — lingers.
+const _kSettleDistanceTolerance = 0.01;
+
+/// A [Simulation] that drives an overdamped [SpringSimulation] but terminates
+/// as soon as the spring reaches its [end] position, rather than waiting for
+/// the spring's velocity to also settle within tolerance.
+///
+/// An overdamped spring approaches its resting position asymptotically, so
+/// [SpringSimulation.isDone] can stay `false` for up to a second after the
+/// motion is visually complete. When such a spring drives a modal route's
+/// transition, that keeps the animation running — and pointer input disabled —
+/// long after the sheet has settled. This wrapper reports completion the moment
+/// the position is within [_kSettleDistanceTolerance] of [end], so the
+/// perceived motion is unchanged but the gesture lock is released promptly.
+class _SettleSpringSimulation extends Simulation {
+  _SettleSpringSimulation(
+    SpringDescription spring,
+    double start,
+    this.end,
+    double velocity,
+  ) : _spring = SpringSimulation(spring, start, end, velocity);
+
+  final double end;
+  final SpringSimulation _spring;
+
+  @override
+  double x(double time) => isDone(time) ? end : _spring.x(time);
+
+  @override
+  double dx(double time) => isDone(time) ? 0.0 : _spring.dx(time);
+
+  @override
+  bool isDone(double time) =>
+      (end - _spring.x(time)).abs() < _kSettleDistanceTolerance;
+}
+
 /// {@template modal_sheet_barrier_builder}
 /// A builder for creating a custom modal barrier.
 ///
@@ -240,7 +283,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
       // Consume the velocity so subsequent pops fall back to the default
       // reverse transition.
       _swipeDismissVelocity = null;
-      return SpringSimulation(
+      return _SettleSpringSimulation(
         _kModalTransitionSpring,
         _controller.value,
         0.0,
@@ -585,7 +628,7 @@ class _SheetDismissibleState extends State<_SheetDismissible>
       // continuing the motion from the gesture's release velocity.
       const completedAnimationValue = 1.0;
       _transitionController.animateWith(
-        SpringSimulation(
+        _SettleSpringSimulation(
           _kModalTransitionSpring,
           _transitionController.value,
           completedAnimationValue,

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -1,7 +1,5 @@
-import 'dart:async';
-import 'dart:math';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart' show SpringSimulation;
 import 'package:meta/meta.dart';
 
 import 'drag.dart';
@@ -10,8 +8,17 @@ import 'internal/float_comp.dart';
 import 'model.dart' show SheetOffset;
 import 'viewport.dart';
 
-const _minReleasedPageForwardAnimationTime = 300; // Milliseconds.
-const Cubic _releasedPageForwardAnimationCurve = Curves.fastLinearToSlowEaseIn;
+/// The spring used to settle the transition animation after a swipe gesture,
+/// both when restoring the sheet to its neutral position and when dismissing.
+///
+/// This mirrors the default sheet spring in `physics.dart` (an overdamped
+/// spring with a damping ratio of 1.1), so the motion never oscillates past
+/// the fully-open or fully-closed extremes.
+final _kModalTransitionSpring = SpringDescription.withDampingRatio(
+  mass: 0.5,
+  stiffness: 100.0,
+  ratio: 1.1,
+);
 
 /// {@template modal_sheet_barrier_builder}
 /// A builder for creating a custom modal barrier.
@@ -217,6 +224,31 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   // Provides access to the AnimationController of this route that is
   // marked as protected, allowing it to be used by SheetDismissible.
   AnimationController get _controller => controller!;
+
+  /// The release velocity of a swipe-to-dismiss gesture, in transition
+  /// controller units (fraction of the viewport height per second).
+  ///
+  /// Set by [_SheetDismissibleState] right before it pops the route, and
+  /// consumed once by [createSimulation] to drive the pop transition with a
+  /// velocity-seeded spring. It is `null` for any non-gesture pop.
+  double? _swipeDismissVelocity;
+
+  @override
+  Simulation? createSimulation({required bool forward}) {
+    final velocity = _swipeDismissVelocity;
+    if (!forward && velocity != null) {
+      // Consume the velocity so subsequent pops fall back to the default
+      // reverse transition.
+      _swipeDismissVelocity = null;
+      return SpringSimulation(
+        _kModalTransitionSpring,
+        _controller.value,
+        0.0,
+        velocity,
+      );
+    }
+    return super.createSimulation(forward: forward);
+  }
 
   /// The curve used for the transition animation.
   ///
@@ -544,22 +576,20 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final didPop = invokePop && _canPopByGesture;
 
     if (didPop) {
+      // Stash the release velocity so the route's createSimulation drives the
+      // pop transition with a velocity-seeded spring.
+      _route._swipeDismissVelocity = effectiveVelocity;
       _route.navigator!.pop();
     } else if (!_transitionController.isCompleted) {
-      // The route won't be popped, so animate the transition
-      // back to the origin.
-      final fraction = 1.0 - _transitionController.value;
-      final animationTime = max(
-        (_route.transitionDuration.inMilliseconds * fraction).floor(),
-        _minReleasedPageForwardAnimationTime,
-      );
-
+      // The route won't be popped, so spring the transition back to the origin,
+      // continuing the motion from the gesture's release velocity.
       const completedAnimationValue = 1.0;
-      unawaited(
-        _transitionController.animateTo(
+      _transitionController.animateWith(
+        SpringSimulation(
+          _kModalTransitionSpring,
+          _transitionController.value,
           completedAnimationValue,
-          duration: Duration(milliseconds: animationTime),
-          curve: _releasedPageForwardAnimationCurve,
+          effectiveVelocity,
         ),
       );
     }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -46,23 +46,10 @@ class _SettleSpringSimulation extends Simulation {
     SpringDescription spring,
     double start,
     this.end,
-    double velocity, {
-    double settleDistance = _kSettleDistanceTolerance,
-  }) : _settleDistance = settleDistance,
-       _spring = SpringSimulation(spring, start, end, velocity);
+    double velocity,
+  ) : _spring = SpringSimulation(spring, start, end, velocity);
 
   final double end;
-
-  /// The distance from [end], in transition controller units, at which the
-  /// motion is considered finished.
-  ///
-  /// For a restore this is [_kSettleDistanceTolerance] (just the imperceptible
-  /// tail). For a dismiss it is the transition value at which the sheet has
-  /// fully left the screen — a non-fullscreen sheet exits before the value
-  /// reaches zero, so continuing to zero would only leave a non-interactive,
-  /// off-screen sheet blocking the screen.
-  final double _settleDistance;
-
   final SpringSimulation _spring;
 
   @override
@@ -72,7 +59,8 @@ class _SettleSpringSimulation extends Simulation {
   double dx(double time) => isDone(time) ? 0.0 : _spring.dx(time);
 
   @override
-  bool isDone(double time) => (end - _spring.x(time)).abs() < _settleDistance;
+  bool isDone(double time) =>
+      (end - _spring.x(time)).abs() < _kSettleDistanceTolerance;
 }
 
 /// {@template modal_sheet_barrier_builder}
@@ -288,32 +276,18 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   /// velocity-seeded spring. It is `null` for any non-gesture pop.
   double? _swipeDismissVelocity;
 
-  /// The transition value at which the sheet has fully left the screen during
-  /// a swipe-to-dismiss, expressed as a distance from the fully-closed value
-  /// (`0.0`).
-  ///
-  /// A non-fullscreen sheet exits the viewport before the transition reaches
-  /// zero (e.g. a sheet occupying half the screen disappears at value `0.5`),
-  /// so the pop spring is terminated here to avoid leaving a non-interactive,
-  /// off-screen sheet blocking the screen. Set together with
-  /// [_swipeDismissVelocity] and consumed once by [createSimulation].
-  double _swipeDismissSettleDistance = _kSettleDistanceTolerance;
-
   @override
   Simulation? createSimulation({required bool forward}) {
     final velocity = _swipeDismissVelocity;
     if (!forward && velocity != null) {
-      // Consume the stashed gesture state so subsequent pops fall back to the
-      // default reverse transition.
-      final settleDistance = _swipeDismissSettleDistance;
+      // Consume the velocity so subsequent pops fall back to the default
+      // reverse transition.
       _swipeDismissVelocity = null;
-      _swipeDismissSettleDistance = _kSettleDistanceTolerance;
       return _SettleSpringSimulation(
         _kModalTransitionSpring,
         _controller.value,
         0.0,
         velocity,
-        settleDistance: settleDistance,
       );
     }
     return super.createSimulation(forward: forward);
@@ -645,12 +619,9 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final didPop = invokePop && _canPopByGesture;
 
     if (didPop) {
-      // Stash the release velocity and the value at which the sheet fully
-      // leaves the screen so the route's createSimulation drives the pop
-      // transition with a velocity-seeded spring that terminates as soon as the
-      // sheet is off-screen.
+      // Stash the release velocity so the route's createSimulation drives the
+      // pop transition with a velocity-seeded spring.
       _route._swipeDismissVelocity = effectiveVelocity;
-      _route._swipeDismissSettleDistance = _resolveDismissSettleDistance();
       _route.navigator!.pop();
     } else if (!_transitionController.isCompleted) {
       // The route won't be popped, so spring the transition back to the origin,
@@ -711,36 +682,6 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     }
 
     return true;
-  }
-
-  /// The transition value distance from fully-closed (`0.0`) at which the sheet
-  /// has completely left the screen.
-  ///
-  /// The pop transition slides the whole viewport down, so a sheet whose
-  /// visible height is `model.offset` pixels leaves the screen once the
-  /// viewport has been slid down by that many pixels — that is, at transition
-  /// value `1 - offset / viewportHeight`. Falls back to
-  /// [_kSettleDistanceTolerance] (fullscreen behavior) when the sheet metrics
-  /// are unavailable.
-  double _resolveDismissSettleDistance() {
-    final model = SheetViewportState.of(context)?.model;
-    if (model == null) {
-      return _kSettleDistanceTolerance;
-    }
-
-    final viewportHeight = model.viewportSize.height;
-    if (viewportHeight <= 0) {
-      return _kSettleDistanceTolerance;
-    }
-
-    final exitDistance = 1 - (model.offset / viewportHeight);
-    if (exitDistance < _kSettleDistanceTolerance) {
-      return _kSettleDistanceTolerance;
-    }
-    if (exitDistance > 1.0) {
-      return 1.0;
-    }
-    return exitDistance;
   }
 
   @override

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -765,7 +765,6 @@ void main() {
   group('Velocity-seeded spring settle after swipe gesture', () {
     ({Widget testWidget, ModalSheetRoute<dynamic> modalRoute}) boilerplate({
       required SwipeDismissSensitivity sensitivity,
-      double sheetHeight = 600,
     }) {
       final modalRoute = ModalSheetRoute<dynamic>(
         swipeDismissible: true,
@@ -776,7 +775,7 @@ void main() {
               key: const Key('sheet'),
               color: Colors.white,
               width: double.infinity,
-              height: sheetHeight,
+              height: 600,
             ),
           );
         },
@@ -925,48 +924,6 @@ void main() {
 
       await tester.pumpAndSettle();
     });
-
-    testWidgets(
-      'a non-fullscreen sheet pop terminates once the sheet leaves the screen',
-      (tester) async {
-        // The test viewport is 600px tall; a 300px sheet occupies its bottom
-        // half and thus fully exits the screen at transition value 0.5.
-        const sensitivity = SwipeDismissSensitivity(
-          minFlingVelocityRatio: 1.0,
-          dismissalOffset: SheetOffset.absolute(0),
-        );
-        final env = boilerplate(sensitivity: sensitivity, sheetHeight: 300);
-        await tester.pumpWidget(env.testWidget);
-        await tester.tap(find.text('Open modal'));
-        await tester.pumpAndSettle();
-
-        final animation = env.modalRoute.animation!;
-        await tester.fling(
-          find.byKey(const Key('sheet')),
-          const Offset(0, 150),
-          1000,
-        );
-
-        // The lowest transition value seen while the pop is still running.
-        var minValueWhileRunning = animation.value;
-        var frames = 0;
-        while (!animation.isDismissed && frames < 200) {
-          minValueWhileRunning = min(minValueWhileRunning, animation.value);
-          await tester.pump(const Duration(milliseconds: 16));
-          frames++;
-        }
-
-        expect(animation.isDismissed, isTrue);
-        expect(
-          minValueWhileRunning,
-          greaterThan(0.4),
-          reason:
-              'The pop should terminate around value 0.5, where the '
-              'half-height sheet leaves the screen, instead of animating the '
-              'transition all the way down to zero over an empty screen.',
-        );
-      },
-    );
   });
 
   // Regression tests for https://github.com/fujidaiti/smooth_sheets/issues/250

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -765,6 +765,7 @@ void main() {
   group('Velocity-seeded spring settle after swipe gesture', () {
     ({Widget testWidget, ModalSheetRoute<dynamic> modalRoute}) boilerplate({
       required SwipeDismissSensitivity sensitivity,
+      double sheetHeight = 600,
     }) {
       final modalRoute = ModalSheetRoute<dynamic>(
         swipeDismissible: true,
@@ -775,7 +776,7 @@ void main() {
               key: const Key('sheet'),
               color: Colors.white,
               width: double.infinity,
-              height: 600,
+              height: sheetHeight,
             ),
           );
         },
@@ -924,6 +925,48 @@ void main() {
 
       await tester.pumpAndSettle();
     });
+
+    testWidgets(
+      'a non-fullscreen sheet pop terminates once the sheet leaves the screen',
+      (tester) async {
+        // The test viewport is 600px tall; a 300px sheet occupies its bottom
+        // half and thus fully exits the screen at transition value 0.5.
+        const sensitivity = SwipeDismissSensitivity(
+          minFlingVelocityRatio: 1.0,
+          dismissalOffset: SheetOffset.absolute(0),
+        );
+        final env = boilerplate(sensitivity: sensitivity, sheetHeight: 300);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        final animation = env.modalRoute.animation!;
+        await tester.fling(
+          find.byKey(const Key('sheet')),
+          const Offset(0, 150),
+          1000,
+        );
+
+        // The lowest transition value seen while the pop is still running.
+        var minValueWhileRunning = animation.value;
+        var frames = 0;
+        while (!animation.isDismissed && frames < 200) {
+          minValueWhileRunning = min(minValueWhileRunning, animation.value);
+          await tester.pump(const Duration(milliseconds: 16));
+          frames++;
+        }
+
+        expect(animation.isDismissed, isTrue);
+        expect(
+          minValueWhileRunning,
+          greaterThan(0.4),
+          reason:
+              'The pop should terminate around value 0.5, where the '
+              'half-height sheet leaves the screen, instead of animating the '
+              'transition all the way down to zero over an empty screen.',
+        );
+      },
+    );
   });
 
   // Regression tests for https://github.com/fujidaiti/smooth_sheets/issues/250

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -880,6 +880,50 @@ void main() {
             'because the pop spring is seeded with the release velocity.',
       );
     });
+
+    testWidgets('a canceled restore settles promptly, not asymptotically', (
+      tester,
+    ) async {
+      // A short, slow drag that does not dismiss, so the sheet is restored.
+      const sensitivity = SwipeDismissSensitivity(
+        minFlingVelocityRatio: 5.0,
+        dismissalOffset: SheetOffset.absolute(0),
+      );
+      final env = boilerplate(sensitivity: sensitivity);
+      await tester.pumpWidget(env.testWidget);
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      final gesture = await tester.press(find.byKey(const Key('sheet')));
+      await gesture.moveBy(const Offset(0, 120));
+      await gesture.up();
+
+      final animation = env.modalRoute.animation!;
+      expect(animation.isCompleted, isFalse);
+
+      // A raw overdamped spring would keep the animation running for roughly
+      // 900ms; the settle wrapper must terminate it well before that.
+      var elapsed = 0;
+      while (!animation.isCompleted && elapsed < 900) {
+        await tester.pump(const Duration(milliseconds: 16));
+        elapsed += 16;
+      }
+
+      expect(
+        animation.isCompleted,
+        isTrue,
+        reason: 'The restore settle should complete well under 900ms.',
+      );
+      expect(
+        elapsed,
+        lessThan(700),
+        reason:
+            'The settle wrapper should cut off the slow asymptotic tail of '
+            'the overdamped spring instead of running to full rest.',
+      );
+
+      await tester.pumpAndSettle();
+    });
   });
 
   // Regression tests for https://github.com/fujidaiti/smooth_sheets/issues/250

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -757,6 +758,127 @@ void main() {
       await tester.pumpAndSettle();
       expect(env.modalRoute.animation!.isCompleted, isTrue);
       expect(env.modalRoute.effectiveCurve, Curves.easeInOut);
+    });
+  });
+
+  // Regression tests for https://github.com/fujidaiti/smooth_sheets/issues/570
+  group('Velocity-seeded spring settle after swipe gesture', () {
+    ({Widget testWidget, ModalSheetRoute<dynamic> modalRoute}) boilerplate({
+      required SwipeDismissSensitivity sensitivity,
+    }) {
+      final modalRoute = ModalSheetRoute<dynamic>(
+        swipeDismissible: true,
+        swipeDismissSensitivity: sensitivity,
+        builder: (context) {
+          return Sheet(
+            child: Container(
+              key: const Key('sheet'),
+              color: Colors.white,
+              width: double.infinity,
+              height: 600,
+            ),
+          );
+        },
+      );
+      return (
+        testWidget: _Boilerplate(modalRoute: modalRoute),
+        modalRoute: modalRoute,
+      );
+    }
+
+    testWidgets(
+      'a faster downward release dips the restore further before '
+      'springing back to fully-open',
+      (tester) async {
+        // Both flings are too slow/short to dismiss, so the sheet is restored.
+        const sensitivity = SwipeDismissSensitivity(
+          minFlingVelocityRatio: 5.0,
+          dismissalOffset: SheetOffset.absolute(0),
+        );
+
+        Future<double> restoreDip(double flingSpeed) async {
+          // Tear down any previous tree so the imperatively-pushed modal route
+          // does not survive into this run via Navigator element reuse.
+          await tester.pumpWidget(const SizedBox());
+          final env = boilerplate(sensitivity: sensitivity);
+          await tester.pumpWidget(env.testWidget);
+          await tester.tap(find.text('Open modal'));
+          await tester.pumpAndSettle();
+
+          await tester.fling(
+            find.byKey(const Key('sheet')),
+            const Offset(0, 150),
+            flingSpeed,
+          );
+
+          final animation = env.modalRoute.animation!;
+          // The lowest value reached while the sheet springs back up.
+          var minValue = animation.value;
+          var frames = 0;
+          while (!animation.isCompleted && frames < 200) {
+            minValue = min(minValue, animation.value);
+            await tester.pump(const Duration(milliseconds: 16));
+            frames++;
+          }
+          await tester.pumpAndSettle();
+          return minValue;
+        }
+
+        final dipFast = await restoreDip(600);
+        final dipSlow = await restoreDip(100);
+
+        expect(
+          dipFast,
+          lessThan(dipSlow),
+          reason:
+              'A faster downward release should carry the sheet further '
+              'down (a lower minimum value) before the spring restores it.',
+        );
+      },
+    );
+
+    testWidgets('a faster downward fling dismisses the modal sooner', (
+      tester,
+    ) async {
+      // Both flings are fast enough to dismiss the modal.
+      const sensitivity = SwipeDismissSensitivity(
+        minFlingVelocityRatio: 1.0,
+        dismissalOffset: SheetOffset.absolute(0),
+      );
+
+      Future<int> dismissTime(double flingSpeed) async {
+        await tester.pumpWidget(const SizedBox());
+        final env = boilerplate(sensitivity: sensitivity);
+        await tester.pumpWidget(env.testWidget);
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        await tester.fling(
+          find.byKey(const Key('sheet')),
+          const Offset(0, 150),
+          flingSpeed,
+        );
+
+        final sheet = find.byKey(const Key('sheet'));
+        var elapsed = 0;
+        while (sheet.evaluate().isNotEmpty && elapsed < 3200) {
+          await tester.pump(const Duration(milliseconds: 16));
+          elapsed += 16;
+        }
+        await tester.pumpAndSettle();
+        return elapsed;
+      }
+
+      final timeFast = await dismissTime(2400);
+      final timeSlow = await dismissTime(950);
+
+      expect(
+        timeFast,
+        lessThan(timeSlow),
+        reason:
+            'A faster downward fling should close the modal sooner '
+            'because the pop spring is seeded with the release velocity.',
+      );
     });
   });
 


### PR DESCRIPTION
## Problem / Issue

Closes #570

When a modal sheet is swipe-dragged, releasing the drag triggers one of two fixed, velocity-agnostic animations that feel clunky:

- **Cancel / restore** (the drag isn't far or fast enough to dismiss): the sheet settles back to fully-open over a fixed duration with a fixed easing curve, ignoring how fast the finger was moving at release.
- **Dismiss / close**: the sheet closes with the route's default reverse transition, also ignoring the fling speed.

Because neither motion is tied to the release velocity, the sheet doesn't carry the momentum of the gesture — a fast swipe and a slow drag settle at the same pace, which reads as unnatural.

## Solution

Both settle animations are now driven by a `SpringSimulation` seeded with the gesture's release velocity, so the motion continues smoothly from where the finger left off (a fast fling settles quickly and carries momentum; a slow release settles gently).

- The transition controller's value already represents the visible fraction of the sheet, and the drag handler already computes the release velocity in those same units, so a single spring drives both cases — targeting fully-open for a canceled restore, and fully-closed for a dismiss.
- The dismiss animation is wired through the framework's `TransitionRoute.createSimulation` hook, which the navigator uses to drive the pop transition. This is scoped strictly to gesture-driven dismissals; programmatic pops (a button, the system back gesture, tapping the barrier) keep the existing default transition.
- An overdamped spring (mirroring the default sheet spring) is used so the sheet never oscillates past the fully-open or fully-closed extremes.

Existing swipe-dismiss thresholds, keyboard-open handling, and the linear-curve-during-gesture behavior are all preserved. Regression tests cover the new velocity sensitivity: a faster downward release carries the restore further before springing back, and a faster downward fling dismisses the modal sooner.
