### PR TITLE
feat(pkg): Add SheetVisibilityNotifier to observe how much of a modal sheet is visible

### DIFF
--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -228,8 +228,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
       ? Curves.linear
       : transitionCurve;
 
-  /// A notifier for the sheet's visibility in terms of a fraction between 0
-  /// and 1 inclusively.
+  /// Reports how much of a modal sheet is currently visible on the viewport.
   late final SheetVisibilityNotifier sheetVisibility;
 
   @override
@@ -836,7 +835,47 @@ class _SheetPopScopeState<T> extends State<SheetPopScope<T>> {
   }
 }
 
+/// Reports how much of a modal sheet is currently visible on the viewport.
+///
+/// The [value] is the fraction (from 0 to 1, inclusively) of the sheet's
+/// height that lies within the viewport, for example:
+///
+/// - `0`: the sheet is entirely outside the viewport.
+/// - `0.5`: the upper half is visible; the rest is below the viewport.
+/// - `1`: the entire sheet is within the viewport.
+///
+/// It reflects both the route's transition animation (the push and
+/// pop animations, and the swipe-to-dismiss gesture) and the sheet's own
+/// position within the viewport (for example, dragging between snap points).
+///
+/// This object is an [Animation], so it can drive transition widgets directly.
+/// A typical use is to tie the modal barrier built by
+/// [ModalSheetRoute.barrierBuilder] to the sheet, so that the barrier fades
+/// out as the user drags the sheet down:
+///
+/// ```dart
+/// ModalSheetRoute<void>(
+///   builder: (context) => Sheet(child: ...),
+///   barrierBuilder: (route, onDismiss) {
+///     final visibility =
+///         (route as ModalSheetRouteMixin<void>).sheetVisibility;
+///     return AnimatedModalBarrier(
+///       onDismiss: onDismiss,
+///       color: visibility.drive(
+///         ColorTween(begin: Colors.transparent, end: Colors.black54),
+///       ),
+///     );
+///   },
+/// );
+/// ```
+///
+/// Listeners may be notified during the layout phase, since the sheet's
+/// position can change while the sheet is being laid out. Avoid calling
+/// [State.setState] from a listener; prefer rebuilding with an
+/// [AnimatedBuilder] or a transition widget instead.
 class SheetVisibilityNotifier extends Animation<double> with ChangeNotifier {
+  /// The fraction of the sheet's height that is visible in the viewport,
+  /// ranging from 0 (entirely hidden) to 1 (entirely visible).
   @override
   double get value => _visibility;
   double _visibility = 0;
@@ -848,6 +887,8 @@ class SheetVisibilityNotifier extends Animation<double> with ChangeNotifier {
     }
   }
 
+  /// Always [AnimationStatus.forward], regardless of the direction in which
+  /// the [value] is changing.
   @override
   AnimationStatus get status => AnimationStatus.forward;
 

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -228,6 +228,22 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
       ? Curves.linear
       : transitionCurve;
 
+  /// A notifier for the sheet's visibility in terms of a fraction between 0
+  /// and 1 inclusively.
+  late final SheetVisibilityNotifier sheetVisibility;
+
+  @override
+  void install() {
+    super.install();
+    sheetVisibility = SheetVisibilityNotifier();
+  }
+
+  @override
+  void dispose() {
+    sheetVisibility.dispose();
+    super.dispose();
+  }
+
   Widget buildSheet(BuildContext context);
 
   Widget buildViewport(BuildContext context, Widget child) {
@@ -242,10 +258,13 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   ) {
     return buildViewport(
       context,
-      _SheetDismissible(
-        enabled: swipeDismissible,
-        sensitivity: swipeDismissSensitivity,
-        child: buildSheet(context),
+      _SheetVisibilityObserver(
+        notifier: sheetVisibility,
+        child: _SheetDismissible(
+          enabled: swipeDismissible,
+          sensitivity: swipeDismissSensitivity,
+          child: buildSheet(context),
+        ),
       ),
     );
   }
@@ -814,5 +833,50 @@ class _SheetPopScopeState<T> extends State<SheetPopScope<T>> {
       onPopInvokedWithResult: widget.onPopInvokedWithResult,
       child: widget.child,
     );
+  }
+}
+
+class SheetVisibilityNotifier extends Animation<double> with ChangeNotifier {
+  @override
+  double get value => _visibility;
+  double _visibility = 0;
+
+  void _updateVisibility(double visibility) {
+    if (visibility != _visibility) {
+      _visibility = visibility;
+      notifyListeners();
+    }
+  }
+
+  @override
+  AnimationStatus get status => AnimationStatus.forward;
+
+  @override
+  void addStatusListener(AnimationStatusListener listener) {
+    // status will never change.
+  }
+
+  @override
+  void removeStatusListener(AnimationStatusListener listener) {
+    // status will never change.
+  }
+}
+
+class _SheetVisibilityObserver extends StatefulWidget {
+  const _SheetVisibilityObserver({required this.notifier, required this.child});
+
+  final SheetVisibilityNotifier notifier;
+  final Widget child;
+
+  @override
+  State<_SheetVisibilityObserver> createState() =>
+      _SheetVisibilityObserverState();
+}
+
+// TODO: observe route's animation value and inherited sheet model's offset, and update the visibility value
+class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
   }
 }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'drag.dart';
 import 'gesture_proxy.dart';
 import 'internal/float_comp.dart';
-import 'model.dart' show SheetOffset;
+import 'model.dart' show SheetModelView, SheetOffset;
 import 'viewport.dart';
 
 const _minReleasedPageForwardAnimationTime = 300; // Milliseconds.
@@ -259,7 +259,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     return buildViewport(
       context,
       _SheetVisibilityObserver(
-        notifier: sheetVisibility,
+        route: this,
         child: _SheetDismissible(
           enabled: swipeDismissible,
           sensitivity: swipeDismissSensitivity,
@@ -863,9 +863,9 @@ class SheetVisibilityNotifier extends Animation<double> with ChangeNotifier {
 }
 
 class _SheetVisibilityObserver extends StatefulWidget {
-  const _SheetVisibilityObserver({required this.notifier, required this.child});
+  const _SheetVisibilityObserver({required this.route, required this.child});
 
-  final SheetVisibilityNotifier notifier;
+  final ModalSheetRouteMixin<dynamic> route;
   final Widget child;
 
   @override
@@ -873,8 +873,57 @@ class _SheetVisibilityObserver extends StatefulWidget {
       _SheetVisibilityObserverState();
 }
 
-// TODO: observe route's animation value and inherited sheet model's offset, and update the visibility value
 class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
+  Animation<double> get _transition => widget.route.animation!;
+
+  SheetModelView? _model;
+
+  @override
+  void initState() {
+    super.initState();
+    _transition.addListener(_updateVisibility);
+  }
+
+  @override
+  void dispose() {
+    _transition.removeListener(_updateVisibility);
+    _model?.removeListener(_updateVisibility);
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final model = SheetViewportState.of(context)!.model;
+    _model?.removeListener(_updateVisibility);
+    _model = model..addListener(_updateVisibility);
+    _updateVisibility();
+  }
+
+  void _updateVisibility() {
+    final model = _model;
+    if (model == null || !model.hasMetrics || widget.route.offstage) {
+      return;
+    }
+    final sheetHeight = model.size.height;
+    if (sheetHeight <= 0) {
+      widget.route.sheetVisibility._updateVisibility(0);
+      return;
+    }
+
+    // The route transition slides the entire viewport, and thus the sheet,
+    // downward by this amount. See ModalSheetRouteMixin.buildTransitions.
+    final viewportHeight = model.viewportSize.height;
+    final transitionProgress = widget.route.effectiveCurve.transform(
+      _transition.value,
+    );
+    final translation = (1 - transitionProgress) * viewportHeight;
+    final sheetTop = (viewportHeight - model.offset) + translation;
+    widget.route.sheetVisibility._updateVisibility(
+      ((viewportHeight - sheetTop) / sheetHeight).clamp(0.0, 1.0),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return widget.child;

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -1196,7 +1196,7 @@ void main() {
         expect(
           tester.getRect(find.byId('sheet')),
           Rect.fromLTWH(0, 600, 800, 500),
-          reason: 'sheet should be fully outside viewport',
+          reason: 'entire sheet should be outside viewport',
         );
         expect(route.sheetVisibility.value, 0.0);
       });
@@ -1239,37 +1239,58 @@ void main() {
           await tester.tap(find.text('Open modal'));
           await tester.pumpAndSettle();
 
-          final notifiedValues = [route.sheetVisibility.value];
-          route.sheetVisibility.addListener(() {
-            notifiedValues.add(route.sheetVisibility.value);
-          });
           final gesture = await tester.startDrag(
             tester.getCenter(find.byId('sheet')),
             AxisDirection.down,
           );
-          for (var i = 0; i < 8; i++) {
-            await gesture.moveDownwardBy(50);
-            await tester.pump();
-          }
+          await gesture.moveDownwardBy(50 - kDragSlopDefault);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.9));
 
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.8));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.7));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.6));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.5));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.4));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.3));
+
+          await gesture.moveDownwardBy(50);
+          await tester.pump();
+          expect(route.sheetVisibility.value, moreOrLessEquals(0.2));
           expect(
             tester.getTopLeft(find.byId('sheet')).dy,
-            greaterThan(450),
+            moreOrLessEquals(500),
             reason: 'sheet should exceed dismissal offset',
           );
-          expect(notifiedValues.first, 1.0);
-          expect(notifiedValues.last, lessThan(0.3));
-          expect(notifiedValues, isMonotonicallyDecreasing);
 
-          final lastNotifiedValue = notifiedValues.last;
-          notifiedValues.clear();
+          final notifiedValues = <double>[];
+          route.sheetVisibility.addListener(() {
+            notifiedValues.add(route.sheetVisibility.value);
+          });
           await gesture.up();
           // Use a shorter interval than the default so that the intermediate
           // frames of the dismissing animation are captured.
           await tester.pumpAndSettle(const Duration(milliseconds: 16));
 
           expect(find.byId('sheet'), findsNothing);
-          expect(notifiedValues.first, lessThan(lastNotifiedValue));
+          expect(notifiedValues.first, lessThan(0.2));
           expect(notifiedValues.last, 0);
           expect(
             notifiedValues,

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 
 import 'src/flutter_test_x.dart';
+import 'src/matchers.dart';
 import 'src/test_stateful_widget.dart';
 
 class _Boilerplate extends StatelessWidget {
@@ -1111,4 +1112,163 @@ void main() {
       await tester.pumpAndSettle();
     });
   });
+
+  group(
+    'SheetVisibilityNotifier',
+    () {
+      (Widget, ModalSheetRoute<dynamic>) boilerplate({
+        bool dismissible = true,
+        SheetSnapGrid snaps = const SheetSnapGrid.single(
+          snap: SheetOffset(1),
+        ),
+      }) {
+        final route = ModalSheetRoute<dynamic>(
+          swipeDismissible: dismissible,
+          swipeDismissSensitivity: SwipeDismissSensitivity(
+            dismissalOffset: SheetOffset(0.3),
+          ),
+          builder: (context) {
+            return Sheet(
+              snapGrid: snaps,
+              initialOffset: SheetOffset(1),
+              physics: BouncingSheetPhysics(),
+              child: Container(
+                key: const Key('sheet'),
+                color: Colors.white,
+                width: double.infinity,
+                height: 500,
+              ),
+            );
+          },
+        );
+
+        return (_Boilerplate(modalRoute: route), route);
+      }
+
+      testWidgets('should update visibility along with sheet position', (
+        tester,
+      ) async {
+        final (testWidget, route) = boilerplate(
+          dismissible: false,
+          snaps: SheetSnapGrid(
+            snaps: [SheetOffset(0), SheetOffset(0.5), SheetOffset(1)],
+          ),
+        );
+
+        await tester.pumpWidget(testWidget);
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getRect(find.byId('sheet')),
+          Rect.fromLTWH(0, 100, 800, 600),
+          reason: 'sheet should be fully visible',
+        );
+        expect(route.sheetVisibility.value, 1);
+
+        await tester.dragUpward(find.byId('sheet'), deltaY: 50);
+        await tester.pump();
+
+        expect(tester.getTopLeft(find.byId('sheet')), lessThan(100));
+        expect(
+          route.sheetVisibility.value,
+          1,
+          reason: 'visibility should never exceeds 1',
+        );
+
+        await tester.fling(find.byId('sheet'), Offset(0, 60), 1000);
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getRect(find.byId('sheet')),
+          Rect.fromLTWH(0, 350, 800, 600),
+          reason: 'sheet should rest at mid-snap point',
+        );
+        expect(route.sheetVisibility.value, 0.5);
+
+        await tester.fling(find.byId('sheet'), Offset(0, 60), 1000);
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getRect(find.byId('sheet')),
+          Rect.fromLTWH(0, 600, 800, 600),
+          reason: 'sheet should be fully outside viewport',
+        );
+        expect(route.sheetVisibility.value, 0.0);
+      });
+
+      testWidgets(
+        'should notify listeners of visibility during push/pop animations',
+        (tester) async {
+          final (testWidget, route) = boilerplate();
+          final notifiedValues = <double>[];
+          route.sheetVisibility.addListener(() {
+            notifiedValues.add(route.sheetVisibility.value);
+          });
+
+          await tester.pumpWidget(testWidget);
+          await tester.tap(find.text('Open modal'));
+          await tester.pumpAndSettle();
+
+          expect(notifiedValues.first, 0);
+          expect(notifiedValues.last, 1);
+          expect(notifiedValues, isMonotonicallyIncreasing);
+
+          notifiedValues.clear();
+          route.navigator!.pop();
+          await tester.pumpAndSettle();
+
+          expect(notifiedValues.first, greaterThan(0.98));
+          expect(notifiedValues.last, 0);
+          expect(notifiedValues, isMonotonicallyDecreasing);
+        },
+      );
+
+      testWidgets(
+        'should notify listeners of visibility during swipe-to-dismiss gesture',
+        (tester) async {
+          final (testWidget, route) = boilerplate();
+          final notifiedValues = <double>[];
+          route.sheetVisibility.addListener(() {
+            notifiedValues.add(route.sheetVisibility.value);
+          });
+
+          await tester.pumpWidget(testWidget);
+          await tester.tap(find.text('Open modal'));
+          await tester.pumpAndSettle();
+          final gesture = await tester.startDrag(
+            tester.getCenter(find.byId('sheet')),
+            AxisDirection.down,
+          );
+          notifiedValues.clear();
+          for (var i = 0; i < 8; i++) {
+            await gesture.moveDownwardBy(50);
+            await tester.pump();
+          }
+
+          expect(
+            tester.getTopLeft(find.byId('sheet')).dy,
+            500,
+            reason: 'sheet should exceed dismissal offset',
+          );
+          expect(notifiedValues.first, greaterThan(0.98));
+          expect(notifiedValues.last, 0.1);
+          expect(notifiedValues, isMonotonicallyDecreasing);
+
+          notifiedValues.clear();
+          await gesture.up();
+          await tester.pumpAndSettle();
+
+          expect(find.byId('sheet'), findsNothing);
+          expect(notifiedValues.first, lessThan(0.1));
+          expect(notifiedValues.last, 0);
+          expect(
+            notifiedValues,
+            isMonotonicallyDecreasing,
+            reason: 'visibility should keep being updated after the release',
+          );
+        },
+      );
+    },
+  );
 }

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -1161,7 +1161,7 @@ void main() {
 
         expect(
           tester.getRect(find.byId('sheet')),
-          Rect.fromLTWH(0, 100, 800, 600),
+          Rect.fromLTWH(0, 100, 800, 500),
           reason: 'sheet should be fully visible',
         );
         expect(route.sheetVisibility.value, 1);
@@ -1169,7 +1169,7 @@ void main() {
         await tester.dragUpward(find.byId('sheet'), deltaY: 50);
         await tester.pump();
 
-        expect(tester.getTopLeft(find.byId('sheet')), lessThan(100));
+        expect(tester.getTopLeft(find.byId('sheet')).dy, lessThan(100));
         expect(
           route.sheetVisibility.value,
           1,
@@ -1181,17 +1181,21 @@ void main() {
 
         expect(
           tester.getRect(find.byId('sheet')),
-          Rect.fromLTWH(0, 350, 800, 600),
+          Rect.fromLTWH(0, 350, 800, 500),
           reason: 'sheet should rest at mid-snap point',
         );
         expect(route.sheetVisibility.value, 0.5);
 
-        await tester.fling(find.byId('sheet'), Offset(0, 60), 1000);
+        await tester.flingFrom(
+          tester.getRect(find.byId('sheet')).topCenter + Offset(0, 50),
+          Offset(0, 60),
+          1000,
+        );
         await tester.pumpAndSettle();
 
         expect(
           tester.getRect(find.byId('sheet')),
-          Rect.fromLTWH(0, 600, 800, 600),
+          Rect.fromLTWH(0, 600, 800, 500),
           reason: 'sheet should be fully outside viewport',
         );
         expect(route.sheetVisibility.value, 0.0);
@@ -1236,11 +1240,11 @@ void main() {
           await tester.pumpWidget(testWidget);
           await tester.tap(find.text('Open modal'));
           await tester.pumpAndSettle();
+          notifiedValues.clear();
           final gesture = await tester.startDrag(
             tester.getCenter(find.byId('sheet')),
             AxisDirection.down,
           );
-          notifiedValues.clear();
           for (var i = 0; i < 8; i++) {
             await gesture.moveDownwardBy(50);
             await tester.pump();
@@ -1248,19 +1252,22 @@ void main() {
 
           expect(
             tester.getTopLeft(find.byId('sheet')).dy,
-            500,
+            greaterThan(450),
             reason: 'sheet should exceed dismissal offset',
           );
-          expect(notifiedValues.first, greaterThan(0.98));
-          expect(notifiedValues.last, 0.1);
+          expect(notifiedValues.first, greaterThan(0.95));
+          expect(notifiedValues.last, lessThan(0.3));
           expect(notifiedValues, isMonotonicallyDecreasing);
 
+          final lastNotifiedValue = notifiedValues.last;
           notifiedValues.clear();
           await gesture.up();
-          await tester.pumpAndSettle();
+          // Use a shorter interval than the default so that the intermediate
+          // frames of the dismissing animation are captured.
+          await tester.pumpAndSettle(const Duration(milliseconds: 16));
 
           expect(find.byId('sheet'), findsNothing);
-          expect(notifiedValues.first, lessThan(0.1));
+          expect(notifiedValues.first, lessThan(lastNotifiedValue));
           expect(notifiedValues.last, 0);
           expect(
             notifiedValues,

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -1205,14 +1205,16 @@ void main() {
         'should notify listeners of visibility during push/pop animations',
         (tester) async {
           final (testWidget, route) = boilerplate();
-          final notifiedValues = <double>[];
-          route.sheetVisibility.addListener(() {
-            notifiedValues.add(route.sheetVisibility.value);
-          });
 
           await tester.pumpWidget(testWidget);
           await tester.tap(find.text('Open modal'));
-          await tester.pumpAndSettle();
+          await tester.pump();
+
+          final notifiedValues = [route.sheetVisibility.value];
+          route.sheetVisibility.addListener(() {
+            notifiedValues.add(route.sheetVisibility.value);
+          });
+          await tester.pumpAndSettle(Duration(milliseconds: 16));
 
           expect(notifiedValues.first, 0);
           expect(notifiedValues.last, 1);
@@ -1232,15 +1234,15 @@ void main() {
         'should notify listeners of visibility during swipe-to-dismiss gesture',
         (tester) async {
           final (testWidget, route) = boilerplate();
-          final notifiedValues = <double>[];
-          route.sheetVisibility.addListener(() {
-            notifiedValues.add(route.sheetVisibility.value);
-          });
 
           await tester.pumpWidget(testWidget);
           await tester.tap(find.text('Open modal'));
           await tester.pumpAndSettle();
-          notifiedValues.clear();
+
+          final notifiedValues = [route.sheetVisibility.value];
+          route.sheetVisibility.addListener(() {
+            notifiedValues.add(route.sheetVisibility.value);
+          });
           final gesture = await tester.startDrag(
             tester.getCenter(find.byId('sheet')),
             AxisDirection.down,
@@ -1255,7 +1257,7 @@ void main() {
             greaterThan(450),
             reason: 'sheet should exceed dismissal offset',
           );
-          expect(notifiedValues.first, greaterThan(0.95));
+          expect(notifiedValues.first, 1.0);
           expect(notifiedValues.last, lessThan(0.3));
           expect(notifiedValues, isMonotonicallyDecreasing);
 


### PR DESCRIPTION
Add `SheetVisibilityNotifier`, exposed as `ModalSheetRouteMixin.sheetVisibility`.

It reports a single fraction from 0 to 1 — how much of the sheet's height currently lies within the viewport — by combining the two sources that move the sheet:

- the route transition, which slides the whole viewport down, and
- the sheet's own offset within the viewport, which changes as the user drags or snaps.

Because it folds both in, one value covers the push and pop animations, the swipe-to-dismiss gesture, and plain dragging between snap points.

The intended use is `ModalSheetRoute.barrierBuilder`, where driving the barrier color from visibility instead of from `ModalRoute.animation` makes the barrier fade out as the sheet is dragged away.
