### PR TITLE
fix(pkg): Modal barrier fade too subtle for small sheets

### DIFF
--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,7 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/draggable.dart' show SheetDragConfiguration;
 export 'src/keyboard_dismissible.dart';
-export 'src/modal.dart';
+export 'src/modal.dart' hide kDefaultModalBarrierCurve;
 export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide

--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -10,7 +10,7 @@ export 'src/decorations.dart';
 export 'src/drag.dart' hide SheetDragController, SheetDragControllerTarget;
 export 'src/draggable.dart' show SheetDragConfiguration;
 export 'src/keyboard_dismissible.dart';
-export 'src/modal.dart' hide kDefaultModalBarrierCurve;
+export 'src/modal.dart';
 export 'src/modal_utils.dart';
 export 'src/model.dart'
     hide

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -304,7 +304,13 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
         dismissible: barrierDismissible,
         semanticsLabel: barrierLabel,
         barrierSemanticsDismissible: semanticsDismissible,
-        color: _DefaultModalBarrierColorAnimation(route: this),
+        color: _DefaultModalBarrierColorAnimation(
+          transitionProgress: animation!,
+          userGestureInProgress: () => navigator!.userGestureInProgress,
+          sheetVisibility: sheetVisibility,
+          curve: barrierCurve,
+          color: barrierColor,
+        ),
       );
     } else {
       return ModalBarrier(
@@ -977,109 +983,53 @@ class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
   }
 }
 
-class _DefaultModalBarrier extends StatefulWidget {
-  const _DefaultModalBarrier({
-    required this.route,
-    required this.color,
-  });
-
-  final ModalSheetRouteMixin<dynamic> route;
-  final Color color;
-
-  @override
-  State<_DefaultModalBarrier> createState() => _DefaultModalBarrierState();
-}
-
-class _DefaultModalBarrierState extends State<_DefaultModalBarrier> {
-  double _opacity = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    widget.route.animation!.addListener(_invalidateOpacity);
-  }
-
-  @override
-  void dispose() {
-    widget.route.animation!.removeListener(_invalidateOpacity);
-    super.dispose();
-  }
-
-  void _invalidateOpacity() {
-    var opacity = widget.route.sheetVisibility.value;
-    if (widget.route.sheetVisibility.swipeToDismissThreshold
-        case final threshold when threshold > 0) {
-      opacity = (opacity / threshold).clamp(0.0, 1.0);
-    }
-    if (!Navigator.of(context).userGestureInProgress) {
-      opacity = widget.route.barrierCurve.transform(opacity);
-    }
-    if (opacity != _opacity) {
-      setState(() => _opacity = opacity);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final lerpedColor = Color.lerp(
-      const Color(0x00000000),
-      widget.color,
-      _opacity,
-    );
-    return ModalBarrier(
-      color: lerpedColor,
-      semanticsLabel: 'test-barrier',
-    );
-  }
-}
-
-@internal
-@visibleForTesting
-const Curve kDefaultModalBarrierCurve = Curves.ease;
-
 class _DefaultModalBarrierColorAnimation extends Animation<Color> {
-  _DefaultModalBarrierColorAnimation({required this.route});
+  _DefaultModalBarrierColorAnimation({
+    required this.transitionProgress,
+    required this.userGestureInProgress,
+    required this.sheetVisibility,
+    required this.curve,
+    required this.color,
+  }) : _transparentColor = color.withAlpha(0);
 
-  final ModalSheetRouteMixin<dynamic> route;
+  final Animation<double> transitionProgress;
+  final ValueGetter<bool> userGestureInProgress;
+  final SheetVisibilityNotifier sheetVisibility;
+  final Curve curve;
+  final Color color;
+  final Color _transparentColor;
 
   @override
   void addListener(VoidCallback listener) =>
-      route.animation!.addListener(listener);
+      transitionProgress.addListener(listener);
 
   @override
   void removeListener(VoidCallback listener) =>
-      route.animation!.removeListener(listener);
+      transitionProgress.removeListener(listener);
 
   @override
   void addStatusListener(AnimationStatusListener listener) =>
-      route.animation!.addStatusListener(listener);
+      transitionProgress.addStatusListener(listener);
 
   @override
   void removeStatusListener(AnimationStatusListener listener) =>
-      route.animation!.removeStatusListener(listener);
+      transitionProgress.removeStatusListener(listener);
 
   @override
-  AnimationStatus get status => route.animation!.status;
+  AnimationStatus get status => transitionProgress.status;
 
   @override
   Color get value {
-    if (!route.navigator!.userGestureInProgress) {
-      return Color.lerp(
-        route.barrierColor!.withAlpha(0),
-        route.barrierColor,
-        kDefaultModalBarrierCurve.transform(route.animation!.value),
-      )!;
+    double opacity;
+    if (userGestureInProgress()) {
+      opacity = sheetVisibility.value;
+      if (sheetVisibility.swipeToDismissThreshold case final t when t > 0) {
+        opacity = (opacity / t).clamp(0.0, 1.0);
+      }
+    } else {
+      opacity = curve.transform(transitionProgress.value);
     }
 
-    var opacity = route.sheetVisibility.value;
-    if (route.sheetVisibility.swipeToDismissThreshold case final threshold
-        when threshold > 0) {
-      opacity = (opacity / threshold).clamp(0.0, 1.0);
-    }
-    return Color.lerp(
-      route.barrierColor!.withAlpha(0),
-      route.barrierColor,
-      opacity,
-    )!;
+    return Color.lerp(_transparentColor, color, opacity)!;
   }
 }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -304,7 +304,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
         dismissible: barrierDismissible,
         semanticsLabel: barrierLabel,
         barrierSemanticsDismissible: semanticsDismissible,
-        color: animation!.drive(_DefaultModalBarrierColorTween(route: this)),
+        color: _DefaultModalBarrierColorAnimation(route: this),
       );
     } else {
       return ModalBarrier(
@@ -1033,21 +1033,53 @@ class _DefaultModalBarrierState extends State<_DefaultModalBarrier> {
   }
 }
 
-class _DefaultModalBarrierColorTween extends Animatable<Color> {
-  _DefaultModalBarrierColorTween({required this.route});
+@internal
+@visibleForTesting
+const Curve kDefaultModalBarrierCurve = Curves.ease;
+
+class _DefaultModalBarrierColorAnimation extends Animation<Color> {
+  _DefaultModalBarrierColorAnimation({required this.route});
 
   final ModalSheetRouteMixin<dynamic> route;
 
   @override
-  Color transform(double t) {
+  void addListener(VoidCallback listener) =>
+      route.animation!.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) =>
+      route.animation!.removeListener(listener);
+
+  @override
+  void addStatusListener(AnimationStatusListener listener) =>
+      route.animation!.addStatusListener(listener);
+
+  @override
+  void removeStatusListener(AnimationStatusListener listener) =>
+      route.animation!.removeStatusListener(listener);
+
+  @override
+  AnimationStatus get status => route.animation!.status;
+
+  @override
+  Color get value {
+    if (!route.navigator!.userGestureInProgress) {
+      return Color.lerp(
+        route.barrierColor!.withAlpha(0),
+        route.barrierColor,
+        kDefaultModalBarrierCurve.transform(route.animation!.value),
+      )!;
+    }
+
     var opacity = route.sheetVisibility.value;
     if (route.sheetVisibility.swipeToDismissThreshold case final threshold
         when threshold > 0) {
       opacity = (opacity / threshold).clamp(0.0, 1.0);
     }
-    if (!route.navigator!.userGestureInProgress) {
-      opacity = route.barrierCurve.transform(opacity);
-    }
-    return Color.lerp(const Color(0x00000000), route.barrierColor, opacity)!;
+    return Color.lerp(
+      route.barrierColor!.withAlpha(0),
+      route.barrierColor,
+      opacity,
+    )!;
   }
 }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'drag.dart';
 import 'gesture_proxy.dart';
 import 'internal/float_comp.dart';
-import 'model.dart' show SheetModelView, SheetOffset;
+import 'model.dart' show SheetMetrics, SheetModelView, SheetOffset;
 import 'viewport.dart';
 
 const _minReleasedPageForwardAnimationTime = 300; // Milliseconds.
@@ -880,11 +880,36 @@ class SheetVisibilityNotifier extends Animation<double> with ChangeNotifier {
   double get value => _visibility;
   double _visibility = 0;
 
+  /// Visibility threshold under which the swipe-to-dismiss action is triggered.
+  double get swipeToDismissThreshold => _threshold;
+  double _threshold = 1;
+
   void _updateVisibility(double visibility) {
     if (visibility != _visibility) {
       _visibility = visibility;
       notifyListeners();
     }
+  }
+
+  void didChangeVisualSheetPosition(
+    SheetMetrics metrics,
+    double transitionProgress,
+  ) {
+    final sheetHeight = metrics.size.height;
+    if (sheetHeight <= 0) {
+      _threshold = 1;
+      _updateVisibility(0);
+      return;
+    }
+    // The route transition slides the entire viewport, and thus the sheet,
+    // downward by this amount.
+    final viewportHeight = metrics.viewportSize.height;
+    final translation = (1 - transitionProgress) * viewportHeight;
+    final sheetTop = (viewportHeight - metrics.offset) + translation;
+    _threshold = (metrics.minOffset / sheetHeight).clamp(0.0, 1.0);
+    _updateVisibility(
+      ((viewportHeight - sheetTop) / sheetHeight).clamp(0.0, 1.0),
+    );
   }
 
   /// Always [AnimationStatus.forward], regardless of the direction in which
@@ -922,13 +947,13 @@ class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
   @override
   void initState() {
     super.initState();
-    _transition.addListener(_updateVisibility);
+    _transition.addListener(_invalidateVisibility);
   }
 
   @override
   void dispose() {
-    _transition.removeListener(_updateVisibility);
-    _model?.removeListener(_updateVisibility);
+    _transition.removeListener(_invalidateVisibility);
+    _model?.removeListener(_invalidateVisibility);
     super.dispose();
   }
 
@@ -936,33 +961,26 @@ class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final model = SheetViewportState.of(context)!.model;
-    _model?.removeListener(_updateVisibility);
-    _model = model..addListener(_updateVisibility);
-    _updateVisibility();
+    _model?.removeListener(_invalidateVisibility);
+    _model = model..addListener(_invalidateVisibility);
+    _invalidateVisibility();
   }
 
-  void _updateVisibility() {
+  void _invalidateVisibility() {
     final model = _model;
-    if (model == null || !model.hasMetrics || widget.route.offstage) {
-      return;
+    if (model != null && model.hasMetrics && !widget.route.offstage) {
+      widget.route.sheetVisibility.didChangeVisualSheetPosition(
+        model,
+        widget.route.effectiveCurve.transform(_transition.value),
+      );
     }
-    final sheetHeight = model.size.height;
-    if (sheetHeight <= 0) {
-      widget.route.sheetVisibility._updateVisibility(0);
-      return;
     }
 
-    // The route transition slides the entire viewport, and thus the sheet,
-    // downward by this amount. See ModalSheetRouteMixin.buildTransitions.
-    final viewportHeight = model.viewportSize.height;
-    final transitionProgress = widget.route.effectiveCurve.transform(
-      _transition.value,
-    );
-    final translation = (1 - transitionProgress) * viewportHeight;
-    final sheetTop = (viewportHeight - model.offset) + translation;
-    widget.route.sheetVisibility._updateVisibility(
-      ((viewportHeight - sheetTop) / sheetHeight).clamp(0.0, 1.0),
-    );
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
   }
 
   @override

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -299,17 +299,19 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     final barrierColor = this.barrierColor;
     if (barrierColor != null && barrierColor.a != 0 && !offstage) {
       assert(barrierColor != barrierColor.withValues(alpha: 0));
-      return AnimatedModalBarrier(
-        onDismiss: onDismiss,
-        dismissible: barrierDismissible,
-        semanticsLabel: barrierLabel,
-        barrierSemanticsDismissible: semanticsDismissible,
-        color: animation!.drive(
-          ColorTween(
-            begin: barrierColor.withValues(alpha: 0.0),
-            end: barrierColor,
-          ).chain(CurveTween(curve: barrierCurve)),
-        ),
+      return _DefaultModalBarrier(
+        // onDismiss: onDismiss,
+        // dismissible: barrierDismissible,
+        // semanticsLabel: barrierLabel,
+        // barrierSemanticsDismissible: semanticsDismissible,
+        // color: animation!.drive(
+        //   ColorTween(
+        //     begin: barrierColor.withValues(alpha: 0.0),
+        //     end: barrierColor,
+        //   ).chain(CurveTween(curve: barrierCurve)),
+        // ),
+        color: barrierColor,
+        route: this,
       );
     } else {
       return ModalBarrier(
@@ -974,17 +976,66 @@ class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
         widget.route.effectiveCurve.transform(_transition.value),
       );
     }
-    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return widget.child;
   }
 }
+
+class _DefaultModalBarrier extends StatefulWidget {
+  const _DefaultModalBarrier({
+    required this.route,
+    required this.color,
+  });
+
+  final ModalSheetRouteMixin<dynamic> route;
+  final Color color;
+
+  @override
+  State<_DefaultModalBarrier> createState() => _DefaultModalBarrierState();
+}
+
+class _DefaultModalBarrierState extends State<_DefaultModalBarrier> {
+  double _opacity = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.route.animation!.addListener(_invalidateOpacity);
+  }
+
+  @override
+  void dispose() {
+    widget.route.animation!.removeListener(_invalidateOpacity);
+    super.dispose();
+  }
+
+  void _invalidateOpacity() {
+    var opacity = widget.route.sheetVisibility.value;
+    if (widget.route.sheetVisibility.swipeToDismissThreshold
+        case final threshold when threshold > 0) {
+      opacity = (opacity / threshold).clamp(0.0, 1.0);
+    }
+    if (!Navigator.of(context).userGestureInProgress) {
+      opacity = widget.route.barrierCurve.transform(opacity);
+    }
+    if (opacity != _opacity) {
+      setState(() => _opacity = opacity);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return widget.child;
+    final lerpedColor = Color.lerp(
+      const Color(0x00000000),
+      widget.color,
+      _opacity,
+    );
+    return ModalBarrier(
+      color: lerpedColor,
+      semanticsLabel: 'test-barrier',
+    );
   }
 }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -299,19 +299,12 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
     final barrierColor = this.barrierColor;
     if (barrierColor != null && barrierColor.a != 0 && !offstage) {
       assert(barrierColor != barrierColor.withValues(alpha: 0));
-      return _DefaultModalBarrier(
-        // onDismiss: onDismiss,
-        // dismissible: barrierDismissible,
-        // semanticsLabel: barrierLabel,
-        // barrierSemanticsDismissible: semanticsDismissible,
-        // color: animation!.drive(
-        //   ColorTween(
-        //     begin: barrierColor.withValues(alpha: 0.0),
-        //     end: barrierColor,
-        //   ).chain(CurveTween(curve: barrierCurve)),
-        // ),
-        color: barrierColor,
-        route: this,
+      return AnimatedModalBarrier(
+        onDismiss: onDismiss,
+        dismissible: barrierDismissible,
+        semanticsLabel: barrierLabel,
+        barrierSemanticsDismissible: semanticsDismissible,
+        color: animation!.drive(_DefaultModalBarrierColorTween(route: this)),
       );
     } else {
       return ModalBarrier(
@@ -1037,5 +1030,24 @@ class _DefaultModalBarrierState extends State<_DefaultModalBarrier> {
       color: lerpedColor,
       semanticsLabel: 'test-barrier',
     );
+  }
+}
+
+class _DefaultModalBarrierColorTween extends Animatable<Color> {
+  _DefaultModalBarrierColorTween({required this.route});
+
+  final ModalSheetRouteMixin<dynamic> route;
+
+  @override
+  Color transform(double t) {
+    var opacity = route.sheetVisibility.value;
+    if (route.sheetVisibility.swipeToDismissThreshold case final threshold
+        when threshold > 0) {
+      opacity = (opacity / threshold).clamp(0.0, 1.0);
+    }
+    if (!route.navigator!.userGestureInProgress) {
+      opacity = route.barrierCurve.transform(opacity);
+    }
+    return Color.lerp(const Color(0x00000000), route.barrierColor, opacity)!;
   }
 }

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'drag.dart';
 import 'gesture_proxy.dart';
 import 'internal/float_comp.dart';
-import 'model.dart' show SheetMetrics, SheetModelView, SheetOffset;
+import 'model.dart';
 import 'viewport.dart';
 
 const _minReleasedPageForwardAnimationTime = 300; // Milliseconds.

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
-import 'package:smooth_sheets/src/modal.dart';
 
 import 'src/flutter_test_x.dart';
 import 'src/matchers.dart';
@@ -427,7 +426,7 @@ void main() {
           final alpha = captureCurrentAlpha(tester);
           final expectedProgres = i / 10;
           expect(route.animation!.value, moreOrLessEquals(expectedProgres));
-          expect(alpha, kDefaultModalBarrierCurve.transform(expectedProgres));
+          expect(alpha, route.barrierCurve.transform(expectedProgres));
         }
 
         await tester.pumpAndSettle();
@@ -442,7 +441,7 @@ void main() {
           final alpha = captureCurrentAlpha(tester);
           final expectedProgress = i / 10;
           expect(route.animation!.value, moreOrLessEquals(expectedProgress));
-          expect(alpha, kDefaultModalBarrierCurve.transform(expectedProgress));
+          expect(alpha, route.barrierCurve.transform(expectedProgress));
         }
 
         await tester.pumpAndSettle();

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -367,6 +367,107 @@ void main() {
     });
   });
 
+  testWidgets(
+    'Default modal barrier should fades in/out as sheet appears/disappears',
+    (tester) async {
+      const barrierLabel = 'test-barrier';
+      final capturedAlphas = <double>[];
+
+      void captureCurrentAlpha() {
+        final barrier = tester
+            .widgetList<ModalBarrier>(
+              find.byWidgetPredicate(
+                (w) => w is ModalBarrier && w.semanticsLabel == barrierLabel,
+              ),
+            )
+            .firstOrNull;
+        if (barrier?.color?.a case final a?) {
+          capturedAlphas.add(a);
+        }
+      }
+
+      final route = ModalSheetRoute<dynamic>(
+        barrierLabel: barrierLabel,
+        barrierColor: Color(0xFF000000), // alpha = 1.0
+        swipeDismissible: true,
+        swipeDismissSensitivity: SwipeDismissSensitivity(
+          dismissalOffset: SheetOffset(0.4),
+        ),
+        builder: (_) {
+          return Sheet(
+            snapGrid: SheetSnapGrid(
+              snaps: [SheetOffset(0.5), SheetOffset(1)],
+            ),
+            child: Container(
+              key: const Key('sheet'),
+              color: Colors.white,
+              width: double.infinity,
+              height: 600,
+            ),
+          );
+        },
+      );
+
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      do {
+        await tester.pump(Duration(milliseconds: 16));
+        captureCurrentAlpha();
+      } while (tester.binding.hasScheduledFrame);
+
+      expect(capturedAlphas.first, moreOrLessEquals(0, epsilon: 1e-1));
+      expect(capturedAlphas.last, 1);
+      expect(capturedAlphas, isMonotonicallyIncreasing);
+
+      capturedAlphas.clear();
+      final gesture = await tester.startDrag(
+        tester.getCenter(find.byId('sheet')),
+        AxisDirection.down,
+      );
+      await gesture.moveDownwardBy(50 - kDragSlopDefault);
+      captureCurrentAlpha();
+      for (var i = 0; i < 5; ++i) {
+        await gesture.moveDownwardBy(50);
+        captureCurrentAlpha();
+      }
+
+      expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+      expect(
+        capturedAlphas,
+        everyElement(1),
+        reason: 'alpha should not change before transition starts',
+      );
+
+      // Drag the sheet down further, enough to dismiss it.
+      capturedAlphas.clear();
+      for (var i = 0; i < 5; ++i) {
+        await gesture.moveDownwardBy(20);
+        captureCurrentAlpha();
+      }
+
+      expect(route.animation!.value, lessThan(1));
+      expect(capturedAlphas.first, lessThan(1));
+      expect(capturedAlphas.last, moreOrLessEquals(1 / 3));
+      expect(
+        capturedAlphas,
+        isMonotonicallyDecreasing,
+        reason: 'alpha should start decreasing along with transition',
+      );
+
+      capturedAlphas.clear();
+      await gesture.up();
+      do {
+        await tester.pump(Duration(milliseconds: 16));
+        captureCurrentAlpha();
+      } while (tester.binding.hasScheduledFrame);
+
+      expect(find.byKey(const Key('sheet')), findsNothing);
+      expect(capturedAlphas.first, lessThan(1 / 3));
+      expect(capturedAlphas.last, moreOrLessEquals(0, epsilon: 1e-1));
+      expect(capturedAlphas, isMonotonicallyDecreasing);
+    },
+  );
+
   // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/233
   group('PopScope test', () {
     late bool isOnPopInvokedCalled;

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -442,12 +442,13 @@ void main() {
       capturedAlphas.clear();
       for (var i = 0; i < 5; ++i) {
         await gesture.moveDownwardBy(20);
+        await tester.pump();
         captureCurrentAlpha();
       }
 
       expect(route.animation!.value, lessThan(1));
       expect(capturedAlphas.first, lessThan(1));
-      expect(capturedAlphas.last, moreOrLessEquals(1 / 3));
+      expect(capturedAlphas.last, moreOrLessEquals(2 / 3));
       expect(
         capturedAlphas,
         isMonotonicallyDecreasing,
@@ -461,8 +462,8 @@ void main() {
         captureCurrentAlpha();
       } while (tester.binding.hasScheduledFrame);
 
-      expect(find.byKey(const Key('sheet')), findsNothing);
-      expect(capturedAlphas.first, lessThan(1 / 3));
+      expect(find.byId('sheet'), findsNothing);
+      expect(capturedAlphas.first, 2 / 3);
       expect(capturedAlphas.last, moreOrLessEquals(0, epsilon: 1e-1));
       expect(capturedAlphas, isMonotonicallyDecreasing);
     },

--- a/test/modal_test.dart
+++ b/test/modal_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
+import 'package:smooth_sheets/src/modal.dart';
 
 import 'src/flutter_test_x.dart';
 import 'src/matchers.dart';
@@ -367,28 +368,17 @@ void main() {
     });
   });
 
-  testWidgets(
-    'Default modal barrier should fades in/out as sheet appears/disappears',
-    (tester) async {
-      const barrierLabel = 'test-barrier';
-      final capturedAlphas = <double>[];
+  group('Default modal barrier', () {
+    const barrierLabel = 'test-barrier';
+    late List<double> capturedAlphas;
+    late ModalSheetRoute<dynamic> route;
 
-      void captureCurrentAlpha() {
-        final barrier = tester
-            .widgetList<ModalBarrier>(
-              find.byWidgetPredicate(
-                (w) => w is ModalBarrier && w.semanticsLabel == barrierLabel,
-              ),
-            )
-            .firstOrNull;
-        if (barrier?.color?.a case final a?) {
-          capturedAlphas.add(a);
-        }
-      }
-
-      final route = ModalSheetRoute<dynamic>(
+    setUp(() {
+      capturedAlphas = [];
+      route = ModalSheetRoute<dynamic>(
         barrierLabel: barrierLabel,
         barrierColor: Color(0xFF000000), // alpha = 1.0
+        transitionDuration: Duration(milliseconds: 300),
         swipeDismissible: true,
         swipeDismissSensitivity: SwipeDismissSensitivity(
           dismissalOffset: SheetOffset(0.4),
@@ -407,67 +397,129 @@ void main() {
           );
         },
       );
+    });
 
-      await tester.pumpWidget(_Boilerplate(modalRoute: route));
-      await tester.tap(find.text('Open modal'));
-      do {
-        await tester.pump(Duration(milliseconds: 16));
-        captureCurrentAlpha();
-      } while (tester.binding.hasScheduledFrame);
+    double? captureCurrentAlpha(WidgetTester tester) {
+      final barrier = tester
+          .widgetList<ModalBarrier>(
+            find.byWidgetPredicate(
+              (w) => w is ModalBarrier && w.semanticsLabel == barrierLabel,
+            ),
+          )
+          .firstOrNull;
 
-      expect(capturedAlphas.first, moreOrLessEquals(0, epsilon: 1e-1));
-      expect(capturedAlphas.last, 1);
-      expect(capturedAlphas, isMonotonicallyIncreasing);
-
-      capturedAlphas.clear();
-      final gesture = await tester.startDrag(
-        tester.getCenter(find.byId('sheet')),
-        AxisDirection.down,
-      );
-      await gesture.moveDownwardBy(50 - kDragSlopDefault);
-      captureCurrentAlpha();
-      for (var i = 0; i < 5; ++i) {
-        await gesture.moveDownwardBy(50);
-        captureCurrentAlpha();
+      final alpha = barrier?.color?.a;
+      if (alpha != null) {
+        capturedAlphas.add(alpha);
       }
+      return alpha;
+    }
 
-      expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
-      expect(
-        capturedAlphas,
-        everyElement(1),
-        reason: 'alpha should not change before transition starts',
-      );
-
-      // Drag the sheet down further, enough to dismiss it.
-      capturedAlphas.clear();
-      for (var i = 0; i < 5; ++i) {
-        await gesture.moveDownwardBy(20);
+    testWidgets(
+      'should fade in/out along with push/pop animation',
+      (tester) async {
+        await tester.pumpWidget(_Boilerplate(modalRoute: route));
+        await tester.tap(find.text('Open modal'));
         await tester.pump();
-        captureCurrentAlpha();
-      }
 
-      expect(route.animation!.value, lessThan(1));
-      expect(capturedAlphas.first, lessThan(1));
-      expect(capturedAlphas.last, moreOrLessEquals(2 / 3));
-      expect(
-        capturedAlphas,
-        isMonotonicallyDecreasing,
-        reason: 'alpha should start decreasing along with transition',
-      );
+        for (var i = 1; i <= 10; ++i) {
+          await tester.pump(Duration(milliseconds: 30));
+          final alpha = captureCurrentAlpha(tester);
+          final expectedProgres = i / 10;
+          expect(route.animation!.value, moreOrLessEquals(expectedProgres));
+          expect(alpha, kDefaultModalBarrierCurve.transform(expectedProgres));
+        }
 
-      capturedAlphas.clear();
-      await gesture.up();
-      do {
-        await tester.pump(Duration(milliseconds: 16));
-        captureCurrentAlpha();
-      } while (tester.binding.hasScheduledFrame);
+        await tester.pumpAndSettle();
+        expect(capturedAlphas.last, 1);
+        expect(capturedAlphas, isMonotonicallyIncreasing);
 
-      expect(find.byId('sheet'), findsNothing);
-      expect(capturedAlphas.first, 2 / 3);
-      expect(capturedAlphas.last, moreOrLessEquals(0, epsilon: 1e-1));
-      expect(capturedAlphas, isMonotonicallyDecreasing);
-    },
-  );
+        capturedAlphas.clear();
+        route.navigator!.pop();
+
+        for (var i = 10; i >= 0; --i) {
+          await tester.pump(Duration(milliseconds: 30));
+          final alpha = captureCurrentAlpha(tester);
+          final expectedProgress = i / 10;
+          expect(route.animation!.value, moreOrLessEquals(expectedProgress));
+          expect(alpha, kDefaultModalBarrierCurve.transform(expectedProgress));
+        }
+
+        await tester.pumpAndSettle();
+        expect(capturedAlphas.last, 0);
+        expect(capturedAlphas, isMonotonicallyDecreasing);
+      },
+    );
+
+    testWidgets(
+      'should start fading out after swipe-to-dismiss action is triggered',
+      (tester) async {
+        await tester.pumpWidget(_Boilerplate(modalRoute: route));
+        await tester.tap(find.text('Open modal'));
+        await tester.pumpAndSettle();
+
+        capturedAlphas.clear();
+        final gesture = await tester.startDrag(
+          tester.getCenter(find.byId('sheet')),
+          AxisDirection.down,
+        );
+        await gesture.moveDownwardBy(50 - kDragSlopDefault);
+        captureCurrentAlpha(tester);
+        for (var i = 0; i < 5; ++i) {
+          await gesture.moveDownwardBy(50);
+          captureCurrentAlpha(tester);
+        }
+
+        expect(tester.getTopLeft(find.byId('sheet')).dy, 300);
+        expect(
+          capturedAlphas,
+          everyElement(1),
+          reason: 'alpha should not change before transition starts',
+        );
+
+        // Drag the sheet down further, enough to dismiss it.
+        capturedAlphas.clear();
+        for (var i = 0; i < 5; ++i) {
+          await gesture.moveDownwardBy(20);
+          await tester.pump();
+          captureCurrentAlpha(tester);
+        }
+
+        // We've dragged the minimized sheet down by 100px,
+        // which is 1/6 of the screen height.
+        expect(route.animation!.value, moreOrLessEquals(5 / 6));
+        expect(capturedAlphas.first, lessThan(1));
+        // At this point the visual sheet offset is 200px,
+        // which is 2/3 of the minimized sheet height.
+        expect(capturedAlphas.last, moreOrLessEquals(2 / 3));
+        expect(
+          capturedAlphas,
+          isMonotonicallyDecreasing,
+          reason: 'alpha should start decreasing along with transition',
+        );
+
+        capturedAlphas.clear();
+        await gesture.up();
+        await tester.pump();
+        for (var i = 1; i <= 5; ++i) {
+          await tester.pump(Duration(milliseconds: 20));
+          captureCurrentAlpha(tester);
+        }
+
+        // Although it's still in the middle of the transition,
+        // the sheet is no longer visible, and neither is the barrier.
+        expect(route.animation!.value, moreOrLessEquals(0.5));
+        expect(capturedAlphas.last, moreOrLessEquals(0));
+
+        await tester.pumpAndSettle();
+
+        expect(find.byId('sheet'), findsNothing);
+        expect(capturedAlphas.first, lessThan(2 / 3));
+        expect(capturedAlphas.last, moreOrLessEquals(0));
+        expect(capturedAlphas, isMonotonicallyDecreasing);
+      },
+    );
+  });
 
   // Regression test for https://github.com/fujidaiti/smooth_sheets/issues/233
   group('PopScope test', () {


### PR DESCRIPTION
Fixes #78, where dragging a modal sheet down to dismiss it causes the backdrop barrier faded only slightly, instead of fully fading away. This was especially noticeable for small sheets: dragging one all the way off-screen left the barrier still mostly opaque.

The barrier's fade was driven by the route's transition progress, which is scaled to the full screen height so the sheet can track the drag gesture 1:1 as the whole viewport slides. For a sheet much smaller than the screen, dragging it fully off-screen only moves that progress value by a small fraction (`sheetHeight / screenHeight`), so the barrier only faded by that same small fraction, even though the sheet had already disappeared.

To fix the issue, the barrier's fade during the swipe-to-dismiss gesture is now driven by `ModalSheetRouteMixin.sheetVisibility`: it starts fading when the gesture is triggered and becomes transparent when the entire sheet goes outside the screen.