### PR TITLE
fix(pkg): Avoid crash when a SheetModel is detached during layout

### DIFF
--- a/lib/src/model_owner.dart
+++ b/lib/src/model_owner.dart
@@ -73,7 +73,12 @@ class SheetModelOwnerState<C extends SheetModelConfig>
   @override
   void dispose() {
     widget.controller?.detach(model);
-    _viewport?.setModel(null);
+    // Use unsetModel instead of setModel(null) so that disposing this owner
+    // does not detach a model that another owner attached to the same
+    // viewport after this owner was deactivated (e.g. when a sheet is
+    // rebuilt within the same frame). Otherwise the viewport may be laid
+    // out without any model attached.
+    _viewport?.unsetModel(model);
     model.dispose();
     _viewport = null;
     _model = null;
@@ -92,7 +97,7 @@ class SheetModelOwnerState<C extends SheetModelConfig>
     _devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     final viewport = SheetViewportState.of(context);
     if (viewport != _viewport) {
-      _viewport?.setModel(null);
+      _viewport?.unsetModel(model);
       _viewport = viewport?..setModel(model);
     }
   }

--- a/lib/src/viewport.dart
+++ b/lib/src/viewport.dart
@@ -261,6 +261,15 @@ class SheetViewportState extends State<SheetViewport> {
     _modelView.setModel(model);
   }
 
+  /// Detaches [model] from this viewport only if it is currently attached.
+  ///
+  /// Unlike `setModel(null)`, this does not detach a different model that
+  /// may have been attached after [model], e.g. by a new sheet that is
+  /// created in the same frame in which the owner of [model] is disposed.
+  void unsetModel(SheetModel model) {
+    _modelView.unsetModel(model);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -907,7 +916,27 @@ class _RenderSheetSkelton extends RenderShiftedBox {
     (child.parentData! as BoxParentData).offset =
         _layoutSpec.contentMargin.topLeft;
 
-    assert(_model._inner != null);
+    final maxRect = _layoutSpec.maxSheetRect;
+    final maxSize = maxRect.size;
+    final paddedChildSize = _layoutSpec.contentMargin.inflateSize(child.size);
+
+    final model = _model._inner;
+    if (model == null) {
+      // No model is attached to the viewport at the moment, e.g. when this
+      // render object is laid out in the same frame in which the owner of
+      // the previously attached model was disposed. Fall back to a
+      // best-effort size instead of crashing; the layout pass that runs
+      // after a model is (re)attached will apply the proper layout.
+      size = BoxConstraints(
+        minWidth: maxSize.width,
+        maxWidth: maxSize.width,
+        minHeight: paddedChildSize.height,
+        maxHeight: maxSize.height,
+      ).constrain(Size.fromHeight(_preferredExtent ?? paddedChildSize.height));
+      _isPerformingLayout = false;
+      return;
+    }
+
     final viewportLayout = ImmutableViewportLayout(
       contentSize: Size.copy(child.size),
       viewportSize: _layoutSpec.viewportSize,
@@ -916,11 +945,8 @@ class _RenderSheetSkelton extends RenderShiftedBox {
           _layoutSpec.viewportSize.height - _layoutSpec.maxContentRect.bottom,
       contentMargin: _layoutSpec.contentMargin,
     );
-    final newOffset = _model._inner!.dryApplyNewLayout(viewportLayout);
+    final newOffset = model.dryApplyNewLayout(viewportLayout);
     _preferredExtent = _getPreferredExtent(newOffset, viewportLayout);
-    final maxRect = _layoutSpec.maxSheetRect;
-    final maxSize = maxRect.size;
-    final paddedChildSize = _layoutSpec.contentMargin.inflateSize(child.size);
     size = BoxConstraints(
       minWidth: maxSize.width,
       maxWidth: maxSize.width,
@@ -932,8 +958,8 @@ class _RenderSheetSkelton extends RenderShiftedBox {
       viewportLayout: viewportLayout,
       size: Size.copy(size),
     );
-    _model._inner!.applyNewLayout(newLayout);
-    assert(_model._inner!.hasMetrics);
+    model.applyNewLayout(newLayout);
+    assert(model.hasMetrics);
     layoutNotifier.value = newLayout;
 
     _isPerformingLayout = false;
@@ -992,6 +1018,12 @@ class _LazySheetModelView extends SheetModelView with ChangeNotifier {
     }
     if (newModel.rect != oldRect) {
       _rectNotifier.notifyListeners();
+    }
+  }
+
+  void unsetModel(SheetModel model) {
+    if (_inner == model) {
+      setModel(null);
     }
   }
 

--- a/test/regression_test.dart
+++ b/test/regression_test.dart
@@ -210,4 +210,55 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  // Rebuilding the sheet subtree with a new key reuses the enclosing
+  // SheetViewport, so the new sheet's owner attaches its model in the build
+  // phase while the old owner is only unmounted in the finalization phase,
+  // after the layout pass. SheetModelOwnerState.dispose() used to detach
+  // whatever model was attached at that point via setModel(null), including
+  // the model it never owned, leaving the viewport with no model at all.
+  group('Swapping the sheet within the same viewport', () {
+    final viewportKey = GlobalKey<SheetViewportState>();
+
+    Widget buildApp(String sheetKey, {double contentHeight = 400}) {
+      return MaterialApp(
+        home: SheetViewport(
+          key: viewportKey,
+          child: Sheet(
+            key: ValueKey(sheetKey),
+            child: SizedBox(height: contentHeight),
+          ),
+        ),
+      );
+    }
+
+    testWidgets("should keep the new sheet's model attached", (tester) async {
+      await tester.pumpWidget(buildApp('old'));
+      await tester.pumpWidget(buildApp('new'));
+
+      expect(
+        viewportKey.currentState!.model.hasMetrics,
+        isTrue,
+        reason:
+            'Disposing the old owner should not detach the model that the '
+            'new owner attached to the same viewport',
+      );
+    });
+
+    testWidgets('should not crash when laid out on a later frame', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp('old'));
+      await tester.pumpWidget(buildApp('new'));
+
+      // The detached model is never reattached, so the next layout pass of the
+      // surviving sheet used to hit 'assert(_model._inner != null)' in
+      // _RenderSheetSkelton.performLayout, and a null check error on the
+      // subsequent _model._inner! dereference in release builds.
+      await tester.pumpWidget(buildApp('new', contentHeight: 300));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Problem / Issue

Closes #581

`_RenderSheetSkelton.performLayout` can be reached with no model attached to the
`SheetViewport`. That trips `assert(_model._inner != null)` in debug builds, and
throws `Null check operator used on a null value` on the following
`_model._inner!` dereference in release builds, aborting the frame's layout pass.

`SheetModelOwnerState.dispose()` detaches with `_viewport?.setModel(null)`
unconditionally, without checking that the attached model is still its own. When
the sheet subtree is rebuilt against a reused `SheetViewport` (a new key, or a
replaced route), the new owner attaches its model during the build phase, but the
old owner is only unmounted in `finalizeTree()` — after `flushLayout()`. Its
`dispose()` then detaches the model the new owner just attached.

The crashing frame is therefore not the frame that clobbers: the viewport is left
permanently detached, because the surviving owner's `didChangeDependencies()`
never runs again. Every subsequent layout pass of that sheet hits the null model.

This is distinct from #349 / #571, which fixed a null check on the *outgoing*
model's metrics inside `_LazySheetModelView.setModel`. Neither
`SheetModelOwnerState.dispose()` nor `performLayout` was changed there, so this
path is unaffected by that fix and still reproduces on `v1.1.0`.

## Solution

Two parts — the first removes the cause, the second stops a null model from being
fatal:

1. **Scope detachment to the owning model.** Add
   `SheetViewportState.unsetModel(SheetModel model)` →
   `_LazySheetModelView.unsetModel(model)`, which clears `_inner` only when
   `_inner == model`, and call it from `SheetModelOwnerState.dispose()` and
   `didChangeDependencies()` instead of `setModel(null)`. An owner can no longer
   detach a model it does not own.

2. **Tolerate a transiently null model in `performLayout`.** Even with (1), the
   viewport can legitimately be laid out with no model attached — the last sheet
   is being removed while the `LayoutBuilder` in `_BareSheetState.build` forces a
   layout in the same frame. Size the skeleton from the existing constraints and
   the last `_preferredExtent`, and return without calling
   `dryApplyNewLayout`/`applyNewLayout`. With a model attached the path is
   unchanged apart from replacing the `!` unwraps with a promoted local.

Two regression tests are added, both failing without this patch: one asserts the
new sheet's model stays attached across the swap (the root cause, no crash
needed), the other reproduces the layout crash on a later frame.

`flutter test` passes 356/356 on Flutter 3.44.5.

This supersedes #569, which was closed in favour of #571. That PR only carried
the `hasMetrics` guard for #349 — I did not have the reproduction above at the
time, which is why it looked like #571 covered this too.
