### PR TITLE
feat(pkg): Add SheetMotion to drive sheet transitions and animations with a spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,20 @@ A sheet can be displayed as a modal sheet using `ModalSheetRoute` for imperative
 
 Furthermore, [the modal sheets in the style of iOS 15](https://medium.com/surf-dev/bottomsheet-in-ios-15-uisheetpresentationcontroller-and-its-capabilities-5e913661c9f) are also supported. For imperative navigation, use `CupertinoModalSheetRoute`, and for declarative navigation, use `CupertinoModalSheetPage`, respectively.
 
+By default, the open and close transitions are interpolated along a curve over a fixed duration. Pass a `SpringSheetMotion` as the `transitionMotion` to drive them with a spring simulation instead, the way iOS does. A spring is velocity aware, so the speed at which the user releases a swipe-to-dismiss gesture carries over into the animation that follows it, which a curve cannot do.
+
+```dart
+ModalSheetRoute<void>(
+  swipeDismissible: true,
+  transitionMotion: const SpringSheetMotion(),
+  builder: (context) => Sheet(child: ...),
+);
+```
+
 See also:
 
 - [SwipeDismissSensitivity](https://pub.dev/documentation/smooth_sheets/latest/smooth_sheets/SwipeDismissSensitivity-class.html), which can be used to tweak the sensitivity of the swipe-to-dismiss action.
+- [sheet_motion.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/sheet_motion.dart), which compares the curve driven transition with each of the iOS spring presets.
 - [declarative_modal_sheet.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/declarative_modal_sheet.dart), a tutorial of integration with declarative navigation using [go_router](https://pub.dev/packages/go_router) package.
 - [imperative_modal_sheet.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/imperative_modal_sheet.dart), a tutorial of integration with imperative Navigator API.
 - [cupertino_modal_sheet.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/cupertino_modal_sheet.dart), a tutorial of iOS style modal sheets.
@@ -195,6 +206,20 @@ See also:
 
 <br/>
 
+### SheetMotion
+
+A `SheetMotion` describes how a sheet travels from where it is to where it is going, and the same type configures both a modal sheet route's open and close transitions and `SheetController.animateTo`.
+
+`CurvedSheetMotion` interpolates along a `Curve` over a fixed `Duration`, which is the default. `SpringSheetMotion` hands the trajectory to a spring simulation instead, the way iOS does: because a spring is velocity aware, the speed at which the user releases a swipe carries over into the animation that follows it, which a curve cannot do. Presets mirroring the four `duration`/`bounce` pairs iOS itself uses are provided as `smooth`, `snappy`, `bouncy` and `interactive`.
+
+A motion always describes a normalized progress running from 0 to 1 rather than pixels, so it behaves identically over a 20 pixel move and a 600 pixel one.
+
+See also:
+
+- [sheet_motion.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/sheet_motion.dart), which compares the curve driven motion with each of the spring presets.
+
+<br/>
+
 ### SheetController
 
 <div align="center">
@@ -203,9 +228,19 @@ See also:
 
 Like [ScrollController](https://api.flutter.dev/flutter/widgets/ScrollController-class.html) for scrollable widget, the SheetController can be used to animate or observe the offset (position) of a sheet.
 
+`SheetController.animateTo` takes the same `SheetMotion` that a modal sheet route uses for its transition, so an imperative move can be driven by a spring as well:
+
+```dart
+controller.animateTo(
+  const SheetOffset(0.5),
+  motion: SpringSheetMotion.snappy(),
+);
+```
+
 See also:
 
 - [sheet_controller.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/sheet_controller.dart) for basic usage.
+- [sheet_motion.dart](https://github.com/fujidaiti/smooth_sheets/blob/main/example/lib/tutorial/sheet_motion.dart), which compares the available motions.
 
 <br/>
 

--- a/example/lib/showcase/airbnb_mobile_app.dart
+++ b/example/lib/showcase/airbnb_mobile_app.dart
@@ -80,7 +80,7 @@ class _MapButton extends StatelessWidget {
         // Collapse the sheet to reveal the map behind.
         sheetController.animateTo(
           SheetOffset.absolute(it.minOffset),
-          curve: Curves.fastOutSlowIn,
+          motion: const CurvedSheetMotion(curve: Curves.fastOutSlowIn),
         );
       }
     }

--- a/example/lib/tutorial/sheet_motion.dart
+++ b/example/lib/tutorial/sheet_motion.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+void main() {
+  runApp(const _SheetMotionExample());
+}
+
+class _SheetMotionExample extends StatelessWidget {
+  const _SheetMotionExample();
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: _ExampleHome());
+  }
+}
+
+/// The motions this example lets you compare.
+///
+/// [SheetMotion] describes how a sheet travels from where it is to where it
+/// is going. It comes in two kinds:
+///
+/// - [CurvedSheetMotion] interpolates along a [Curve] over a fixed [Duration].
+///   Since a curve is a pure function of elapsed time, the trajectory is
+///   always the same, no matter how fast the user was moving their finger.
+/// - [SpringSheetMotion] hands the movement to a spring simulation, the way
+///   iOS does. A spring is velocity aware, so the speed of a swipe carries
+///   over into the animation that follows it.
+enum _MotionKind {
+  curve('Curve', 'The default. Not velocity aware.'),
+  iosSpring('Spring · iOS', 'The spring iOS uses for its own sheets.'),
+  smooth('Spring · smooth', 'SwiftUI .smooth — 500ms, no bounce.'),
+  snappy('Spring · snappy', 'SwiftUI .snappy — a little bounce.'),
+  bouncy('Spring · bouncy', 'SwiftUI .bouncy — overshoots by about 5%.'),
+  interactive(
+    'Spring · interactive',
+    'SwiftUI .interactiveSpring — a much shorter response.',
+  );
+
+  const _MotionKind(this.label, this.description);
+
+  final String label;
+  final String description;
+
+  SheetMotion get motion => switch (this) {
+    _MotionKind.curve => const CurvedSheetMotion(),
+    _MotionKind.iosSpring => const SpringSheetMotion(),
+    _MotionKind.smooth => SpringSheetMotion.smooth(),
+    _MotionKind.snappy => SpringSheetMotion.snappy(),
+    _MotionKind.bouncy => SpringSheetMotion.bouncy(),
+    _MotionKind.interactive => SpringSheetMotion.interactive(),
+  };
+}
+
+class _ExampleHome extends StatefulWidget {
+  const _ExampleHome();
+
+  @override
+  State<_ExampleHome> createState() => _ExampleHomeState();
+}
+
+class _ExampleHomeState extends State<_ExampleHome> {
+  var _selectedMotion = _MotionKind.iosSpring;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sheet Motion')),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: RadioGroup<_MotionKind>(
+              groupValue: _selectedMotion,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedMotion = value);
+                }
+              },
+              child: ListView(
+                children: [
+                  for (final kind in _MotionKind.values)
+                    RadioListTile(
+                      value: kind,
+                      title: Text(kind.label),
+                      subtitle: Text(kind.description),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              spacing: 8,
+              children: [
+                FilledButton(
+                  onPressed: () => _showModalSheet(context, _selectedMotion),
+                  child: const Text('Open a modal sheet'),
+                ),
+                Text(
+                  'Swipe the sheet down and let go at different speeds. '
+                  'A spring carries your release velocity into the animation; '
+                  'a curve throws it away.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void _showModalSheet(BuildContext context, _MotionKind kind) {
+  Navigator.push(
+    context,
+    ModalSheetRoute<void>(
+      // The same SheetMotion drives the open transition, the close
+      // transition, and the animation that either dismisses the sheet or
+      // settles it back after a swipe.
+      transitionMotion: kind.motion,
+      swipeDismissible: true,
+      builder: (context) => _MySheet(kind: kind),
+    ),
+  );
+}
+
+class _MySheet extends StatefulWidget {
+  const _MySheet({required this.kind});
+
+  final _MotionKind kind;
+
+  @override
+  State<_MySheet> createState() => _MySheetState();
+}
+
+class _MySheetState extends State<_MySheet> {
+  late final SheetController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = SheetController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Sheet(
+      controller: _controller,
+      snapGrid: const SheetSnapGrid(snaps: [SheetOffset(0.5), SheetOffset(1)]),
+      // SheetSize.stretch keeps the background covering the visible part of
+      // the sheet at every offset, rather than only the height of the
+      // content.
+      decoration: MaterialSheetDecoration(
+        size: SheetSize.stretch,
+        color: Theme.of(context).colorScheme.surfaceContainer,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        clipBehavior: Clip.antiAlias,
+      ),
+      // Filling the viewport makes the sheet's own height the viewport
+      // height, so SheetOffset(1) is a full page and SheetOffset(0.5) is
+      // half of one.
+      child: SizedBox.expand(
+        child: SafeArea(
+          bottom: false,
+          // Keep the content near the top so that it stays visible at the
+          // lower snap too.
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 12,
+              children: [
+                Text(
+                  widget.kind.label,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                // SheetController.animateTo takes the very same SheetMotion,
+                // so an imperative move can use a spring too.
+                FilledButton.tonal(
+                  onPressed: () => _controller.animateTo(
+                    const SheetOffset(0.5),
+                    motion: widget.kind.motion,
+                  ),
+                  child: const Text('Animate to the lower snap'),
+                ),
+                FilledButton.tonal(
+                  onPressed: () => _controller.animateTo(
+                    const SheetOffset(1),
+                    motion: widget.kind.motion,
+                  ),
+                  child: const Text('Animate to the upper snap'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/smooth_sheets.dart
+++ b/lib/smooth_sheets.dart
@@ -21,6 +21,7 @@ export 'src/model.dart'
         SheetModel,
         SheetModelConfig,
         SheetModelView;
+export 'src/motion.dart';
 export 'src/notification.dart';
 export 'src/offset_driven_animation.dart';
 export 'src/paged_sheet.dart';

--- a/lib/src/activity.dart
+++ b/lib/src/activity.dart
@@ -217,9 +217,12 @@ class AnimatedSheetActivity extends SheetActivity
 
   @override
   void onAnimationTick() {
-    final progress = curve.transform(controller.value);
+    // AnimationController.animateTo() drives the controller with an
+    // interpolation simulation that has already applied the curve, so
+    // controller.value is the curved progress. Applying the curve again
+    // here would compose it with itself.
     owner
-      ..offset = lerpDouble(_startOffset, _endOffset, progress)!
+      ..offset = lerpDouble(_startOffset, _endOffset, controller.value)!
       ..didUpdateMetrics();
   }
 

--- a/lib/src/activity.dart
+++ b/lib/src/activity.dart
@@ -7,7 +7,10 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 import 'drag.dart';
+import 'internal/animation_behavior.dart';
+import 'internal/float_comp.dart';
 import 'model.dart';
+import 'motion.dart';
 import 'physics.dart';
 
 @internal
@@ -169,8 +172,7 @@ class InitialSheetActivity<T extends SheetModel> extends SheetActivity<T> {
 }
 
 /// An activity that animates the [SheetModel]'s `offset` to a destination
-/// position determined by [destination], using the specified [curve] and
-/// [duration].
+/// position determined by [destination], following [motion].
 ///
 /// This activity accepts the destination position as an [SheetOffset], allowing
 /// the concrete end position (in offset) to be updated during the animation
@@ -179,30 +181,50 @@ class InitialSheetActivity<T extends SheetModel> extends SheetActivity<T> {
 ///
 /// When the bottom viewport inset changes, typically due to the appearance
 /// or disappearance of the on-screen keyboard, this activity updates the
-/// sheet position to maintain its visual position unchanged. If the
-/// end position changes, it starts a [SettlingSheetActivity] for the
-/// remaining duration to ensure the animation duration remains consistent.
+/// sheet position to maintain its visual position unchanged. If the end
+/// position changes, a [CurvedSheetMotion] hands the remaining duration to a
+/// [SettlingSheetActivity] so that the total duration stays consistent, while
+/// a [SpringSheetMotion] re-aims at the new destination, carrying its current
+/// velocity across.
 @internal
 class AnimatedSheetActivity extends SheetActivity
     with ControlledSheetActivityMixin {
   AnimatedSheetActivity({
     required this.destination,
-    required this.duration,
-    required this.curve,
-  }) : assert(duration > Duration.zero);
+    required this.motion,
+    this.initialVelocity = 0,
+  }) : assert(
+         motion is! CurvedSheetMotion || motion.duration > Duration.zero,
+         'A curve driven motion needs a positive duration.',
+       );
 
   final SheetOffset destination;
-  final Duration duration;
-  final Curve curve;
+
+  /// How the sheet travels from its current offset to [destination].
+  final SheetMotion motion;
+
+  /// The speed the sheet is already moving at, in pixels per second, with
+  /// positive values meaning the offset is increasing.
+  ///
+  /// Only a [SpringSheetMotion] can carry this over into the animation; a
+  /// [CurvedSheetMotion] always starts from rest.
+  final double initialVelocity;
 
   late final double _startOffset;
   late final double _endOffset;
 
+  /// The distance the animation covers, which is also the factor that
+  /// converts between the normalized progress a [SheetMotion] describes and
+  /// the pixels the sheet actually moves.
+  double get _travel => _endOffset - _startOffset;
+
   @override
   void init(SheetModel owner) {
-    super.init(owner);
+    // Must be resolved before super.init(), which starts the animation, and
+    // a spring needs _travel to normalize its initial velocity.
     _startOffset = owner.offset;
     _endOffset = destination.resolve(owner);
+    super.init(owner);
   }
 
   @override
@@ -212,8 +234,30 @@ class AnimatedSheetActivity extends SheetActivity
 
   @override
   TickerFuture onAnimationStart() {
-    return controller.animateTo(1.0, duration: duration, curve: curve);
+    final simulation = motion.createSimulation(
+      start: 0,
+      end: 1,
+      // SheetMotion describes a normalized progress, so the velocity has to
+      // be divided by the distance that progress spans. _travel is never
+      // zero: SheetModel.animateTo() returns early when the sheet is already
+      // at the destination.
+      velocity: initialVelocity / _travel,
+    );
+    return simulation == null
+        ? controller.animateTo(
+            1,
+            duration: motion.duration,
+            curve: motion.curve,
+          )
+        : controller.animateWith(applyAnimationBehaviorTo(simulation));
   }
+
+  /// The speed of the sheet in pixels per second.
+  ///
+  /// [controller] runs in normalized progress, so its own velocity is in
+  /// progress per second and has to be scaled back up.
+  @override
+  double get velocity => controller.velocity * _travel;
 
   @override
   void onAnimationTick() {
@@ -235,10 +279,28 @@ class AnimatedSheetActivity extends SheetActivity
   void applyNewLayout(ViewportLayout? oldLayout) {
     if (oldLayout == null) return;
     final newEndOffset = destination.resolve(owner);
-    if (newEndOffset != _endOffset) {
+    if (FloatComp.distance(
+      owner.devicePixelRatio,
+    ).isApprox(newEndOffset, _endOffset)) {
+      return;
+    }
+
+    if (motion.createSimulation(start: 0, end: 1, velocity: 0) == null) {
       final remainingDuration =
-          duration - (controller.lastElapsedDuration ?? Duration.zero);
+          motion.duration - (controller.lastElapsedDuration ?? Duration.zero);
       owner.settleTo(destination, remainingDuration);
+    } else {
+      // A simulation has no clock left to hand over, so aim it at the new
+      // destination instead, carrying the current speed for continuity.
+      //
+      // This has to begin a whole new activity rather than restart this
+      // one's controller: a canceled TickerFuture never completes, so the
+      // whenComplete(onAnimationEnd) registered by
+      // ControlledSheetActivityMixin.init would never fire, leaving the
+      // caller of animateTo() waiting forever.
+      unawaited(
+        owner.animateTo(destination, motion: motion, velocity: velocity),
+      );
     }
   }
 }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'model.dart';
+import 'motion.dart';
 
 class SheetController extends ChangeNotifier
     implements ValueListenable<double?> {
@@ -64,13 +65,52 @@ class SheetController extends ChangeNotifier
     super.dispose();
   }
 
+  /// Animates the sheet to the given offset.
+  ///
+  /// The returned future completes when the animation ends, whether it
+  /// reached [to] or was interrupted by another activity such as a drag.
+  ///
+  /// [motion] describes how the sheet travels there. It defaults to
+  /// [kDefaultSheetAnimationMotion]; pass a [SpringSheetMotion] to move the
+  /// sheet with a spring simulation instead of a curve:
+  ///
+  /// ```dart
+  /// controller.animateTo(
+  ///   const SheetOffset(0.5),
+  ///   motion: SpringSheetMotion.snappy(),
+  /// );
+  /// ```
+  ///
+  /// [velocity] is the speed the sheet is already moving at, in pixels per
+  /// second, with positive values meaning the offset is increasing. Only a
+  /// [SpringSheetMotion] can carry it over into the animation.
   Future<void> animateTo(
     SheetOffset to, {
-    Duration duration = const Duration(milliseconds: 300),
-    Curve curve = Curves.easeInOut,
+    @Deprecated(
+      'Use motion instead. Note that CurvedSheetMotion defaults to '
+      'Curves.fastEaseInToSlowEaseOut; pass kDefaultSheetAnimationMotion '
+      'to keep the easing animateTo has always used. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Duration? duration,
+    @Deprecated(
+      'Use motion instead. Note that CurvedSheetMotion defaults to '
+      'Curves.fastEaseInToSlowEaseOut; pass kDefaultSheetAnimationMotion '
+      'to keep the easing animateTo has always used. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Curve? curve,
+    SheetMotion? motion,
+    double velocity = 0,
   }) {
     assert(_client != null);
-    return _client!.animateTo(to, duration: duration, curve: curve);
+    return _client!.animateTo(
+      to,
+      duration: duration,
+      curve: curve,
+      motion: motion,
+      velocity: velocity,
+    );
   }
 
   @override

--- a/lib/src/cupertino.dart
+++ b/lib/src/cupertino.dart
@@ -7,6 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'internal/double_utils.dart';
 import 'modal.dart';
 import 'model.dart';
+import 'motion.dart';
 import 'viewport.dart';
 
 const _sheetTopInset = 12.0;
@@ -376,11 +377,15 @@ class _OutgoingTransitionController extends Animation<double>
 
     final oldValue = _value;
     final sheetMetrics = _lastReportedSheetMetrics;
+    // _value is documented to stay within [0, 1], and the incoming route's
+    // animation is unbounded when a simulation that can overshoot drives it,
+    // so the contract is enforced rather than assumed.
+    final transitionProgress = route.secondaryAnimation!.value.clamp(0.0, 1.0);
     if (sheetMetrics == null) {
-      _value = route.secondaryAnimation!.value;
+      _value = transitionProgress;
     } else {
       _value = min(
-        route.secondaryAnimation!.value,
+        transitionProgress,
         sheetMetrics.offset
             .inverseLerp(sheetMetrics.minOffset, sheetMetrics.maxOffset)
             .clamp(0, 1),
@@ -642,8 +647,17 @@ class CupertinoModalSheetPage<T> extends Page<T> {
     this.swipeDismissible = false,
     this.barrierLabel,
     this.barrierColor = _barrierColor,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
     this.transitionDuration = _transitionDuration,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
     this.transitionCurve = _incomingTransitionCurve,
+    this.transitionMotion,
     this.swipeDismissSensitivity = const SwipeDismissSensitivity(),
     this.overlayColor,
     this.viewportBuilder,
@@ -666,9 +680,25 @@ class CupertinoModalSheetPage<T> extends Page<T> {
 
   final String? barrierLabel;
 
+  /// {@macro modal_sheet_legacy_transition_duration}
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   final Duration transitionDuration;
 
+  /// {@macro modal_sheet_legacy_transition_curve}
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   final Curve transitionCurve;
+
+  /// {@macro modal_sheet_transition_motion}
+  ///
+  /// If null, a [CurvedSheetMotion] is built from the deprecated
+  /// [transitionDuration] and [transitionCurve].
+  final SheetMotion? transitionMotion;
 
   final SwipeDismissSensitivity swipeDismissSensitivity;
 
@@ -707,10 +737,12 @@ class _PageBasedCupertinoModalSheetRoute<T>
   bool get swipeDismissible => _page.swipeDismissible;
 
   @override
-  Curve get transitionCurve => _page.transitionCurve;
-
-  @override
-  Duration get transitionDuration => _page.transitionDuration;
+  SheetMotion get transitionMotion =>
+      _page.transitionMotion ??
+      CurvedSheetMotion(
+        duration: _page.transitionDuration,
+        curve: _page.transitionCurve,
+      );
 
   @override
   SwipeDismissSensitivity get swipeDismissSensitivity =>
@@ -749,12 +781,26 @@ class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
     this.swipeDismissible = false,
     this.barrierLabel,
     this.barrierColor = _barrierColor,
-    this.transitionDuration = _transitionDuration,
-    this.transitionCurve = _incomingTransitionCurve,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Duration transitionDuration = _transitionDuration,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Curve transitionCurve = _incomingTransitionCurve,
+    SheetMotion? transitionMotion,
     this.swipeDismissSensitivity = const SwipeDismissSensitivity(),
     this.overlayColor,
     this.barrierBuilder,
-  });
+  }) : transitionMotion =
+           transitionMotion ??
+           CurvedSheetMotion(
+             duration: transitionDuration,
+             curve: transitionCurve,
+           );
 
   final WidgetBuilder builder;
 
@@ -775,11 +821,9 @@ class CupertinoModalSheetRoute<T> extends _BaseCupertinoModalSheetRoute<T> {
   @override
   final bool maintainState;
 
+  /// {@macro modal_sheet_transition_motion}
   @override
-  final Duration transitionDuration;
-
-  @override
-  final Curve transitionCurve;
+  final SheetMotion transitionMotion;
 
   @override
   final SwipeDismissSensitivity swipeDismissSensitivity;

--- a/lib/src/internal/animation_behavior.dart
+++ b/lib/src/internal/animation_behavior.dart
@@ -1,0 +1,43 @@
+/// @docImport 'package:flutter/animation.dart';
+library;
+
+import 'package:flutter/physics.dart';
+import 'package:flutter/semantics.dart';
+
+/// How much faster a simulation runs when the platform asks for animations
+/// to be disabled.
+///
+/// [AnimationController] shortens a duration driven animation to 5% of its
+/// length in that case, so speeding a simulation up by the reciprocal keeps
+/// the two consistent.
+const _disabledAnimationSpeedUp = 20.0;
+
+/// Returns [simulation], sped up if the platform asks for animations to be
+/// disabled.
+///
+/// [AnimationController.animateWith] and [AnimationController.animateBackWith]
+/// do not apply the accessibility scaling that [AnimationController.animateTo],
+/// [AnimationController.forward] and [AnimationController.reverse] do, so a
+/// simulation driven animation would otherwise ignore the setting entirely.
+Simulation applyAnimationBehaviorTo(Simulation simulation) {
+  return SemanticsBinding.instance.disableAnimations
+      ? _SpedUpSimulation(simulation, _disabledAnimationSpeedUp)
+      : simulation;
+}
+
+/// Runs [_inner] [_scale] times faster than it would run on its own.
+class _SpedUpSimulation extends Simulation {
+  _SpedUpSimulation(this._inner, this._scale);
+
+  final Simulation _inner;
+  final double _scale;
+
+  @override
+  double x(double time) => _inner.x(time * _scale);
+
+  @override
+  double dx(double time) => _inner.dx(time * _scale) * _scale;
+
+  @override
+  bool isDone(double time) => _inner.isDone(time * _scale);
+}

--- a/lib/src/modal.dart
+++ b/lib/src/modal.dart
@@ -6,11 +6,14 @@ import 'package:meta/meta.dart';
 
 import 'drag.dart';
 import 'gesture_proxy.dart';
+import 'internal/animation_behavior.dart';
 import 'internal/float_comp.dart';
 import 'model.dart';
+import 'motion.dart';
 import 'viewport.dart';
 
 const _minReleasedPageForwardAnimationTime = 300; // Milliseconds.
+
 const Cubic _releasedPageForwardAnimationCurve = Curves.fastLinearToSlowEaseIn;
 
 /// {@template modal_sheet_barrier_builder}
@@ -47,8 +50,17 @@ class ModalSheetPage<T> extends Page<T> {
     this.fullscreenDialog = false,
     this.barrierLabel,
     this.barrierColor = Colors.black54,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
     this.transitionDuration = const Duration(milliseconds: 300),
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
     this.transitionCurve = Curves.fastEaseInToSlowEaseOut,
+    this.transitionMotion,
     this.swipeDismissSensitivity = const SwipeDismissSensitivity(),
     this.viewportBuilder,
     this.barrierBuilder,
@@ -73,9 +85,37 @@ class ModalSheetPage<T> extends Page<T> {
 
   final bool swipeDismissible;
 
+  /// {@template modal_sheet_legacy_transition_duration}
+  /// How long the open and close transitions take.
+  ///
+  /// Superseded by [transitionMotion]; pass
+  /// `CurvedSheetMotion(duration: ...)` instead. Ignored entirely
+  /// when [transitionMotion] is non-null.
+  /// {@endtemplate}
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   final Duration transitionDuration;
 
+  /// {@template modal_sheet_legacy_transition_curve}
+  /// The curve along which the open and close transitions are interpolated.
+  ///
+  /// Superseded by [transitionMotion]; pass
+  /// `CurvedSheetMotion(curve: ...)` instead. Ignored entirely when
+  /// [transitionMotion] is non-null.
+  /// {@endtemplate}
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   final Curve transitionCurve;
+
+  /// {@macro modal_sheet_transition_motion}
+  ///
+  /// If null, a [CurvedSheetMotion] is built from the deprecated
+  /// [transitionDuration] and [transitionCurve].
+  final SheetMotion? transitionMotion;
 
   final SwipeDismissSensitivity swipeDismissSensitivity;
 
@@ -116,10 +156,12 @@ class _PageBasedModalSheetRoute<T> extends PageRoute<T>
   bool get swipeDismissible => _page.swipeDismissible;
 
   @override
-  Curve get transitionCurve => _page.transitionCurve;
-
-  @override
-  Duration get transitionDuration => _page.transitionDuration;
+  SheetMotion get transitionMotion =>
+      _page.transitionMotion ??
+      CurvedSheetMotion(
+        duration: _page.transitionDuration,
+        curve: _page.transitionCurve,
+      );
 
   @override
   SwipeDismissSensitivity get swipeDismissSensitivity =>
@@ -152,11 +194,25 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
     this.barrierLabel,
     this.barrierColor = Colors.black54,
     this.swipeDismissible = false,
-    this.transitionDuration = const Duration(milliseconds: 300),
-    this.transitionCurve = Curves.fastEaseInToSlowEaseOut,
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Duration transitionDuration = const Duration(milliseconds: 300),
+    @Deprecated(
+      'Use transitionMotion with a CurvedSheetMotion instead. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+    SheetMotion? transitionMotion,
     this.swipeDismissSensitivity = const SwipeDismissSensitivity(),
     this.barrierBuilder,
-  });
+  }) : transitionMotion =
+           transitionMotion ??
+           CurvedSheetMotion(
+             duration: transitionDuration,
+             curve: transitionCurve,
+           );
 
   final WidgetBuilder builder;
 
@@ -177,11 +233,9 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
   @override
   final bool maintainState;
 
+  /// {@macro modal_sheet_transition_motion}
   @override
-  final Duration transitionDuration;
-
-  @override
-  final Curve transitionCurve;
+  final SheetMotion transitionMotion;
 
   @override
   final SwipeDismissSensitivity swipeDismissSensitivity;
@@ -204,7 +258,47 @@ class ModalSheetRoute<T> extends PageRoute<T> with ModalSheetRouteMixin<T> {
 mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   bool get swipeDismissible;
 
-  Curve get transitionCurve;
+  /// {@template modal_sheet_transition_motion}
+  /// Describes how the route's open and close transitions are animated.
+  ///
+  /// Defaults to a [CurvedSheetMotion], which interpolates the
+  /// transition along a [Curve] over a fixed [Duration].
+  ///
+  /// Set this to a [SpringSheetMotion] to drive the transition with
+  /// a spring simulation instead, the way iOS does. A spring is velocity
+  /// aware, so the speed at which the user releases a swipe-to-dismiss
+  /// gesture carries over into the animation:
+  ///
+  /// ```dart
+  /// ModalSheetRoute<void>(
+  ///   swipeDismissible: true,
+  ///   transitionMotion: const SheetMotion.spring(),
+  ///   builder: (context) => Sheet(child: ...),
+  /// );
+  /// ```
+  ///
+  /// The motion is captured when the route is installed. Changing it on a live
+  /// [Page] afterwards has no effect on the route that page already created,
+  /// because the shape of the animation controller — bounded for a curve,
+  /// unbounded for a simulation that can overshoot — is fixed at that point.
+  /// {@endtemplate}
+  SheetMotion get transitionMotion => const CurvedSheetMotion();
+
+  /// [transitionMotion] as it was when this route was installed.
+  ///
+  /// Everything that drives the transition reads this rather than
+  /// [transitionMotion], so that the motion cannot change out from under the
+  /// animation controller that was built for it. Falls back to the live value
+  /// before [install] has run.
+  SheetMotion get _motion => _installedMotion ?? transitionMotion;
+  SheetMotion? _installedMotion;
+
+  /// The curve of [transitionMotion], or [Curves.linear] if it is driven by
+  /// a simulation rather than a curve.
+  Curve get transitionCurve => _motion.curve;
+
+  @override
+  Duration get transitionDuration => _motion.duration;
 
   SwipeDismissSensitivity get swipeDismissSensitivity;
 
@@ -222,11 +316,80 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   ///
   /// In the middle of a dismiss gesture drag,
   /// this returns [Curves.linear] to match the finger motion.
+  ///
+  /// If [transitionMotion] is a [SpringSheetMotion], this always
+  /// returns [Curves.linear], because the simulation already describes the
+  /// entire trajectory and reshaping it with a curve would distort it.
   @nonVirtual
   @visibleForTesting
   Curve get effectiveCurve => (navigator?.userGestureInProgress ?? false)
       ? Curves.linear
-      : transitionCurve;
+      : _motion.curve;
+
+  /// The velocity at which the user released the most recent
+  /// swipe-to-dismiss gesture, in transition progress per second.
+  ///
+  /// Stashed by [_SheetDismissible] right before it pops the route, so that
+  /// [createSimulation] can hand it to the pop animation. Consumed, and thus
+  /// reset to null, by the next [createSimulation] call.
+  double? _dragEndVelocity;
+
+  @override
+  AnimationController createAnimationController() {
+    if (_motion.isBounded) {
+      return super.createAnimationController();
+    }
+
+    // A spring with bounce leaves the [0, 1] range before settling back onto
+    // its destination. A bounded controller would clamp those values, pinning
+    // the sheet against the boundary until the simulation comes back into
+    // range, so the overshoot has to be allowed through instead.
+    assert(
+      !debugTransitionCompleted(),
+      'Cannot reuse a $runtimeType after disposing it.',
+    );
+    return AnimationController.unbounded(
+      duration: transitionDuration,
+      reverseDuration: reverseTransitionDuration,
+      debugLabel: debugLabel,
+      vsync: navigator!,
+    );
+  }
+
+  @override
+  Animation<double> createAnimation() {
+    if (_motion.isBounded) {
+      return super.createAnimation();
+    }
+    return _springTransitionAnimation = _SpringTransitionAnimation(
+      _controller,
+    );
+  }
+
+  _SpringTransitionAnimation? _springTransitionAnimation;
+
+  @override
+  void didAdd() {
+    super.didAdd();
+    if (!_controller.value.isFinite) {
+      // TransitionRoute.didAdd() jumps the controller to its upper bound,
+      // which is infinite for the unbounded controller used by a spring.
+      _controller.value = 1;
+    }
+  }
+
+  @override
+  Simulation? createSimulation({required bool forward}) {
+    final velocity = _dragEndVelocity;
+    _dragEndVelocity = null;
+
+    final simulation = _motion.createSimulation(
+      start: controller!.value,
+      end: forward ? 1.0 : 0.0,
+      velocity: velocity ?? 0.0,
+    );
+    return simulation == null ? null : applyAnimationBehaviorTo(simulation);
+  }
 
   /// Reports how much of a modal sheet is currently visible on the viewport.
   ///
@@ -265,6 +428,9 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
 
   @override
   void install() {
+    // Must happen before super.install(), which calls
+    // createAnimationController() and therefore needs the captured motion.
+    _installedMotion = transitionMotion;
     super.install();
     _sheetVisibility = _SheetVisibilityNotifier();
   }
@@ -272,6 +438,7 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   @override
   void dispose() {
     _sheetVisibility.dispose();
+    _springTransitionAnimation?.dispose();
     super.dispose();
   }
 
@@ -309,9 +476,14 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   ) {
     final transitionTween = Tween(begin: const Offset(0, 1), end: Offset.zero);
     return SlideTransition(
-      position: animation.drive(
-        transitionTween.chain(CurveTween(curve: effectiveCurve)),
-      ),
+      // Curve.transform() rejects values outside [0, 1], which an
+      // unbounded motion produces, and its simulation already describes
+      // the whole trajectory anyway.
+      position: _motion.isBounded
+          ? animation.drive(
+              transitionTween.chain(CurveTween(curve: effectiveCurve)),
+            )
+          : animation.drive(transitionTween),
       child: child,
     );
   }
@@ -355,6 +527,72 @@ mixin ModalSheetRouteMixin<T> on ModalRoute<T> {
   }
 }
 
+/// The view of the unbounded [AnimationController] that drives a spring
+/// driven route.
+///
+/// An [AnimationController] derives [AnimationStatus.completed] and
+/// [AnimationStatus.dismissed] from whether its value equals its bounds, and
+/// the bounds of an unbounded controller are infinite. Assigning a value
+/// directly — as [TransitionRoute.didAdd] and [TransitionRoute.didReplace] do
+/// for routes that appear without a transition — would therefore leave the
+/// route reporting [AnimationStatus.forward] forever, which in turn disables
+/// barrier taps and confuses the swipe-to-dismiss gesture.
+///
+/// This restores the missing statuses by reading them off the resting value
+/// instead. While the controller is animating, its own status is used, so the
+/// overshoot of a bouncy spring is still reported as an ongoing transition.
+class _SpringTransitionAnimation extends Animation<double>
+    with
+        AnimationEagerListenerMixin,
+        AnimationLocalListenersMixin,
+        AnimationLocalStatusListenersMixin {
+  _SpringTransitionAnimation(this._controller) {
+    _status = _computeStatus();
+    _controller
+      ..addListener(_onValueChanged)
+      ..addStatusListener(_onStatusChanged);
+  }
+
+  final AnimationController _controller;
+
+  @override
+  double get value => _controller.value;
+
+  @override
+  AnimationStatus get status => _status;
+  late AnimationStatus _status;
+
+  AnimationStatus _computeStatus() {
+    if (!_controller.isAnimating) {
+      if (_controller.value >= 1) return AnimationStatus.completed;
+      if (_controller.value <= 0) return AnimationStatus.dismissed;
+    }
+    return _controller.status;
+  }
+
+  void _onValueChanged() {
+    notifyListeners();
+    _invalidateStatus();
+  }
+
+  void _onStatusChanged(AnimationStatus _) => _invalidateStatus();
+
+  void _invalidateStatus() {
+    if (_computeStatus() case final newStatus when newStatus != _status) {
+      _status = newStatus;
+      notifyStatusListeners(newStatus);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_onValueChanged)
+      ..removeStatusListener(_onStatusChanged);
+    super.dispose();
+  }
+}
+
 /// Enables swipe-to-dismiss functionality for a modal sheet route.
 ///
 /// Must be used as the content of a route that implements
@@ -385,6 +623,14 @@ class _SheetDismissibleState extends State<_SheetDismissible>
   late ModalSheetRouteMixin<dynamic> _route;
 
   AnimationController get _transitionController => _route._controller;
+
+  /// The status of the route transition.
+  ///
+  /// Read through [ModalRoute.animation] rather than off
+  /// [_transitionController] directly: a spring driven route uses an unbounded
+  /// controller, which cannot derive `completed`/`dismissed` from its own
+  /// infinite bounds. Only the animation restores them.
+  Animation<double> get _transition => _route.animation!;
 
   bool get _isUserGestureInProgress => _route.navigator!.userGestureInProgress;
 
@@ -483,7 +729,7 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final minPDC = minPotentialDeltaConsumption.dy;
     assert(details.delta.dy * minPDC >= 0);
     final double effectiveDragDelta;
-    if (!_transitionController.isCompleted) {
+    if (!_transition.isCompleted) {
       // Dominantly use the full pixels if it is in the middle of a transition.
       effectiveDragDelta = dragDelta;
     } else if (dragDelta < 0 &&
@@ -504,7 +750,10 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     }
 
     final viewport = _navigatorSize.height;
-    final visibleViewport = viewport * _transitionController.value;
+    // The controller is unbounded when a spring drives the transition, so the
+    // value may briefly sit outside [0, 1] while the spring overshoots.
+    final visibleViewport =
+        viewport * _transitionController.value.clamp(0.0, 1.0);
     assert(0 <= visibleViewport && visibleViewport <= viewport);
     final newVisibleViewport = (visibleViewport + effectiveDragDelta).clamp(
       0,
@@ -595,24 +844,41 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     final didPop = invokePop && _canPopByGesture;
 
     if (didPop) {
+      // Hand the release velocity to the pop animation, which
+      // ModalSheetRouteMixin.createSimulation is about to build.
+      _route._dragEndVelocity = effectiveVelocity;
       _route.navigator!.pop();
-    } else if (!_transitionController.isCompleted) {
+    } else if (!_transition.isCompleted) {
       // The route won't be popped, so animate the transition
       // back to the origin.
-      final fraction = 1.0 - _transitionController.value;
-      final animationTime = max(
-        (_route.transitionDuration.inMilliseconds * fraction).floor(),
-        _minReleasedPageForwardAnimationTime,
+      const completedAnimationValue = 1.0;
+      final simulation = _route._motion.createSimulation(
+        start: _transitionController.value,
+        end: completedAnimationValue,
+        velocity: effectiveVelocity,
       );
 
-      const completedAnimationValue = 1.0;
-      unawaited(
-        _transitionController.animateTo(
-          completedAnimationValue,
-          duration: Duration(milliseconds: animationTime),
-          curve: _releasedPageForwardAnimationCurve,
-        ),
-      );
+      if (simulation != null) {
+        unawaited(
+          _transitionController.animateWith(
+            applyAnimationBehaviorTo(simulation),
+          ),
+        );
+      } else {
+        final fraction = 1.0 - _transitionController.value;
+        final animationTime = max(
+          (_route.transitionDuration.inMilliseconds * fraction).floor(),
+          _minReleasedPageForwardAnimationTime,
+        );
+
+        unawaited(
+          _transitionController.animateTo(
+            completedAnimationValue,
+            duration: Duration(milliseconds: animationTime),
+            curve: _releasedPageForwardAnimationCurve,
+          ),
+        );
+      }
     }
 
     // Reset the transition animation curve back to the default from linear
@@ -640,8 +906,7 @@ class _SheetDismissibleState extends State<_SheetDismissible>
     // 3. The modal route is removed from the Navigator's subtree.
     // 4. Route.didPop() is called, initiating the pop transition animation
     //    by calling AnimationController.reverse().
-    if (_transitionController.isCompleted ||
-        _transitionController.isDismissed) {
+    if (_transition.isCompleted || _transition.isDismissed) {
       _isUserGestureInProgress = false;
     } else {
       late final AnimationStatusListener animationStatusCallback;
@@ -966,7 +1231,9 @@ class _SheetVisibilityObserverState extends State<_SheetVisibilityObserver> {
     if (model != null && model.hasMetrics && !widget.route.offstage) {
       widget.route._sheetVisibility.didChangeVisualSheetPosition(
         model,
-        widget.route.effectiveCurve.transform(_transition.value),
+        widget.route.effectiveCurve.transform(
+          _transition.value.clamp(0.0, 1.0),
+        ),
       );
     }
   }
@@ -1021,7 +1288,7 @@ class _DefaultModalBarrierColorAnimation extends Animation<Color> {
         opacity = (opacity / t).clamp(0.0, 1.0);
       }
     } else {
-      opacity = curve.transform(transitionProgress.value);
+      opacity = curve.transform(transitionProgress.value.clamp(0.0, 1.0));
     }
 
     return Color.lerp(_transparentColor, color, opacity)!;

--- a/lib/src/modal_utils.dart
+++ b/lib/src/modal_utils.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'cupertino.dart';
 import 'modal.dart';
+import 'motion.dart';
 import 'viewport.dart';
 
 /// Pushes a platform-appropriate modal sheet onto the navigator's stack.
@@ -31,8 +32,19 @@ Future<T?> showAdaptiveModalSheet<T>({
   bool swipeDismissible = false,
   String? barrierLabel,
   Color? barrierColor,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Duration? transitionDuration,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Curve? transitionCurve,
+
+  /// {@macro modal_sheet_transition_motion}
+  SheetMotion? transitionMotion,
   SwipeDismissSensitivity swipeDismissSensitivity =
       const SwipeDismissSensitivity(),
   RouteSettings? routeSettings,
@@ -51,6 +63,7 @@ Future<T?> showAdaptiveModalSheet<T>({
         barrierColor: barrierColor,
         transitionDuration: transitionDuration,
         transitionCurve: transitionCurve,
+        transitionMotion: transitionMotion,
         swipeDismissSensitivity: swipeDismissSensitivity,
         routeSettings: routeSettings,
       );
@@ -68,6 +81,7 @@ Future<T?> showAdaptiveModalSheet<T>({
         barrierColor: barrierColor,
         transitionDuration: transitionDuration,
         transitionCurve: transitionCurve,
+        transitionMotion: transitionMotion,
         swipeDismissSensitivity: swipeDismissSensitivity,
         routeSettings: routeSettings,
       );
@@ -97,8 +111,19 @@ Future<T?> showModalSheet<T>({
   bool fullscreenDialog = false,
   String? barrierLabel,
   Color? barrierColor,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Duration? transitionDuration,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Curve? transitionCurve,
+
+  /// {@macro modal_sheet_transition_motion}
+  SheetMotion? transitionMotion,
   SwipeDismissSensitivity swipeDismissSensitivity =
       const SwipeDismissSensitivity(),
   EdgeInsets viewportPadding = EdgeInsets.zero,
@@ -115,6 +140,7 @@ Future<T?> showModalSheet<T>({
     swipeDismissible: swipeDismissible,
     transitionDuration: transitionDuration ?? const Duration(milliseconds: 300),
     transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+    transitionMotion: transitionMotion,
     swipeDismissSensitivity: swipeDismissSensitivity,
     viewportBuilder: (context, child) {
       return SheetViewport(padding: viewportPadding, child: child);
@@ -146,8 +172,19 @@ Future<T?> showCupertinoModalSheet<T>({
   bool swipeDismissible = false,
   String? barrierLabel,
   Color? barrierColor,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Duration? transitionDuration,
+  @Deprecated(
+    'Use transitionMotion with a CurvedSheetMotion instead. '
+    'This feature was deprecated after v1.1.0.',
+  )
   Curve? transitionCurve,
+
+  /// {@macro modal_sheet_transition_motion}
+  SheetMotion? transitionMotion,
   SwipeDismissSensitivity swipeDismissSensitivity =
       const SwipeDismissSensitivity(),
   RouteSettings? routeSettings,
@@ -162,6 +199,7 @@ Future<T?> showCupertinoModalSheet<T>({
     swipeDismissible: swipeDismissible,
     transitionDuration: transitionDuration ?? const Duration(milliseconds: 300),
     transitionCurve: transitionCurve ?? Curves.fastEaseInToSlowEaseOut,
+    transitionMotion: transitionMotion,
     swipeDismissSensitivity: swipeDismissSensitivity,
   );
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -11,6 +11,7 @@ import 'activity.dart';
 import 'drag.dart';
 import 'gesture_proxy.dart';
 import 'model_owner.dart';
+import 'motion.dart';
 import 'notification.dart';
 import 'physics.dart';
 import 'snap_grid.dart';
@@ -477,16 +478,35 @@ abstract class SheetModel<C extends SheetModelConfig> extends SheetModelView
   /// interrupted prematurely.
   Future<void> animateTo(
     SheetOffset newPosition, {
-    Curve curve = Curves.easeInOut,
-    Duration duration = const Duration(milliseconds: 300),
+    @Deprecated(
+      'Use motion instead. Note that CurvedSheetMotion defaults to '
+      'Curves.fastEaseInToSlowEaseOut; pass kDefaultSheetAnimationMotion '
+      'to keep the easing animateTo has always used. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Curve? curve,
+    @Deprecated(
+      'Use motion instead. Note that CurvedSheetMotion defaults to '
+      'Curves.fastEaseInToSlowEaseOut; pass kDefaultSheetAnimationMotion '
+      'to keep the easing animateTo has always used. '
+      'This feature was deprecated after v1.1.0.',
+    )
+    Duration? duration,
+    SheetMotion? motion,
+    double velocity = 0,
   }) {
     if (offset == newPosition.resolve(this)) {
       return Future.value();
     } else {
       final activity = AnimatedSheetActivity(
         destination: newPosition,
-        duration: duration,
-        curve: curve,
+        motion:
+            motion ??
+            CurvedSheetMotion(
+              duration: duration ?? kDefaultSheetAnimationMotion.duration,
+              curve: curve ?? kDefaultSheetAnimationMotion.curve,
+            ),
+        initialVelocity: velocity,
       );
 
       beginActivity(activity);

--- a/lib/src/motion.dart
+++ b/lib/src/motion.dart
@@ -1,0 +1,338 @@
+/// @docImport 'package:flutter/cupertino.dart';
+/// @docImport 'package:flutter/widgets.dart';
+///
+/// @docImport 'controller.dart';
+/// @docImport 'cupertino.dart';
+/// @docImport 'modal.dart';
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
+
+/// The spring used by [SpringSheetMotion] by default.
+///
+/// This is the very spring that Flutter uses to drive the transitions of
+/// [CupertinoModalPopupRoute] and [CupertinoDialogRoute]. Its stiffness was
+/// read from the `CASpringAnimation` that iOS itself uses, and the damping is
+/// derived from it as `2 * sqrt(mass * stiffness)`, which makes the spring
+/// critically damped (a damping ratio of exactly 1). A critically damped
+/// spring settles at its destination as fast as possible without ever
+/// overshooting it.
+const kDefaultSheetMotionSpring = SpringDescription(
+  mass: 1,
+  stiffness: 522.35,
+  damping: 45.7099552,
+);
+
+/// The motion used by [SheetController.animateTo] by default.
+///
+/// This preserves the curve and duration that `animateTo` used before it
+/// accepted a [SheetMotion], which differ from [CurvedSheetMotion]'s own
+/// defaults.
+const kDefaultSheetAnimationMotion = CurvedSheetMotion(
+  duration: Duration(milliseconds: 300),
+  curve: Curves.easeInOut,
+);
+
+/// The tolerance used by [SpringSheetMotion] by default.
+///
+/// The iOS spring animation is considered finished after 0.404 seconds. At
+/// that point, the position is already within the default distance tolerance
+/// of 1e-3, but the velocity is still around 0.02. The velocity tolerance is
+/// therefore relaxed to 0.03, so that the transition does not keep running
+/// noticeably longer than its iOS counterpart.
+const kDefaultSheetMotionTolerance = Tolerance(velocity: 0.03);
+
+/// Describes how the open and close transitions of a modal sheet route
+/// are animated.
+///
+/// See also:
+/// - [CurvedSheetMotion], which interpolates the transition along a
+///   [Curve] over a fixed [Duration]. This is the default.
+/// - [SpringSheetMotion], which drives the transition with a spring
+///   simulation and carries the swipe-to-dismiss release velocity over into
+///   the animation.
+abstract class SheetMotion {
+  /// Creates a description of how a sheet moves.
+  const SheetMotion();
+
+  /// Creates a [CurvedSheetMotion].
+  const factory SheetMotion.curved({
+    Duration duration,
+    Curve curve,
+  }) = CurvedSheetMotion;
+
+  /// Creates a [SpringSheetMotion].
+  const factory SheetMotion.spring({
+    SpringDescription spring,
+    Tolerance tolerance,
+  }) = SpringSheetMotion;
+
+  /// {@template sheet_motion_duration}
+  /// How long the motion takes.
+  ///
+  /// A motion driven by a simulation has no duration of its own — it ends
+  /// when the simulation runs out of energy — and reports only a nominal
+  /// value, for the sake of the APIs that insist on one, such as
+  /// [ModalRoute.transitionDuration].
+  /// {@endtemplate}
+  Duration get duration;
+
+  /// The curve along which the progress is interpolated.
+  ///
+  /// Only consulted when [createSimulation] returns null; a simulation
+  /// already describes the whole trajectory.
+  Curve get curve;
+
+  /// Whether the progress this motion produces always stays within `[0, 1]`.
+  ///
+  /// A motion that can overshoot its destination must return false, so that
+  /// consumers driving an [AnimationController] give it an unbounded one
+  /// instead of clamping the overshoot away.
+  bool get isBounded => true;
+
+  /// The simulation that carries the progress from [start] to [end],
+  /// departing at [velocity], or null to interpolate along [curve] over
+  /// [duration] instead.
+  ///
+  /// {@template sheet_motion_normalized_progress}
+  /// All three values are expressed as a **normalized progress** running from
+  /// 0 to 1, whatever quantity the consumer maps that progress onto — the
+  /// visibility of a modal sheet route, or the offset of a sheet moved by
+  /// [SheetController.animateTo]. [velocity] is therefore in units of
+  /// progress per second rather than pixels per second, and any [Tolerance]
+  /// is in progress units too. That is what lets one motion behave
+  /// identically over a 20 pixel move and a 600 pixel one.
+  /// {@endtemplate}
+  Simulation? createSimulation({
+    required double start,
+    required double end,
+    required double velocity,
+  });
+}
+
+/// A [SheetMotion] that interpolates the transition progress along
+/// [curve] over a fixed [duration].
+///
+/// This is the default motion of every modal sheet route.
+///
+/// Because the trajectory of a curve is a pure function of elapsed time, this
+/// motion cannot take the velocity of a swipe-to-dismiss gesture into account:
+/// a flick and a slow release from the same position produce exactly the same
+/// animation. Use [SpringSheetMotion] if that matters.
+class CurvedSheetMotion extends SheetMotion {
+  /// Creates a curve driven modal sheet route transition.
+  const CurvedSheetMotion({
+    this.duration = const Duration(milliseconds: 300),
+    this.curve = Curves.fastEaseInToSlowEaseOut,
+  });
+
+  /// {@macro sheet_motion_duration}
+  @override
+  final Duration duration;
+
+  /// The curve along which the transition progress is interpolated.
+  @override
+  final Curve curve;
+
+  /// Always null: this motion interpolates along [curve] over [duration]
+  /// rather than simulating anything.
+  @override
+  Simulation? createSimulation({
+    required double start,
+    required double end,
+    required double velocity,
+  }) => null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CurvedSheetMotion &&
+          other.duration == duration &&
+          other.curve == curve;
+
+  @override
+  int get hashCode => Object.hash(duration, curve);
+
+  @override
+  String toString() => 'CurvedSheetMotion(duration: $duration, curve: $curve)';
+}
+
+/// A [SheetMotion] that drives the transition with a
+/// [SpringSimulation], the way iOS drives the same interaction.
+///
+/// Unlike [CurvedSheetMotion], a spring is velocity aware. When the
+/// user releases a swipe-to-dismiss gesture, the velocity of their finger is
+/// handed to the simulation as its initial velocity, so a flick and a slow
+/// release produce different trajectories, and the motion stays continuous
+/// across the gesture-to-animation handoff.
+///
+/// A [spring] with a damping ratio below 1 overshoots its destination before
+/// settling onto it, which briefly carries the sheet past the top of its
+/// resting position. Routes driven by this motion use an unbounded animation
+/// controller so that the overshoot plays out instead of being clamped away.
+/// The default [kDefaultSheetMotionSpring] never overshoots.
+class SpringSheetMotion extends SheetMotion {
+  /// Creates a spring driven modal sheet route transition.
+  const SpringSheetMotion({
+    this.spring = kDefaultSheetMotionSpring,
+    this.tolerance = kDefaultSheetMotionTolerance,
+  });
+
+  /// Creates a spring driven transition from the perceptual [duration] and
+  /// [bounce] pair used by SwiftUI's `spring(duration:bounce:)`.
+  ///
+  /// [bounce] is `0` for a critically damped spring that never overshoots its
+  /// destination, positive (up to `1`) for a springier one that does, and
+  /// negative (down to but excluding `-1`) for an increasingly sluggish,
+  /// overdamped one.
+  ///
+  /// See also [SpringSheetMotion.smooth],
+  /// [SpringSheetMotion.snappy],
+  /// [SpringSheetMotion.bouncy] and
+  /// [SpringSheetMotion.interactive], which are the four
+  /// `duration`/`bounce` pairs that iOS itself uses.
+  factory SpringSheetMotion.withBounce({
+    Duration duration = const Duration(milliseconds: 500),
+    double bounce = 0,
+    Tolerance tolerance = kDefaultSheetMotionTolerance,
+  }) {
+    assert(duration > Duration.zero);
+    // bounce == 1 would give a damping ratio of 0 — an undamped spring that
+    // oscillates forever, so a transition using it would never finish.
+    assert(bounce > -1 && bounce < 1);
+    const mass = 1.0;
+    final seconds = duration.inMicroseconds / Duration.microsecondsPerSecond;
+    final stiffness = 4 * math.pi * math.pi * mass / (seconds * seconds);
+    final dampingRatio = bounce > 0 ? 1 - bounce : 1 / (bounce + 1);
+    return SpringSheetMotion(
+      spring: SpringDescription(
+        mass: mass,
+        stiffness: stiffness,
+        damping: dampingRatio * 2 * math.sqrt(mass * stiffness),
+      ),
+      tolerance: tolerance,
+    );
+  }
+
+  /// The iOS `smooth` spring: no bounce at all.
+  ///
+  /// [extraBounce] is added on top of the preset's own bounce.
+  factory SpringSheetMotion.smooth({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0,
+    Tolerance tolerance = kDefaultSheetMotionTolerance,
+  }) => SpringSheetMotion.withBounce(
+    duration: duration,
+    bounce: extraBounce,
+    tolerance: tolerance,
+  );
+
+  /// The iOS `snappy` spring: a small amount of bounce that reads as
+  /// responsive rather than playful.
+  ///
+  /// [extraBounce] is added on top of the preset's own bounce.
+  factory SpringSheetMotion.snappy({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0,
+    Tolerance tolerance = kDefaultSheetMotionTolerance,
+  }) => SpringSheetMotion.withBounce(
+    duration: duration,
+    bounce: 0.15 + extraBounce,
+    tolerance: tolerance,
+  );
+
+  /// The iOS `bouncy` spring: overshoots its destination by about 5% before
+  /// settling back onto it.
+  ///
+  /// [extraBounce] is added on top of the preset's own bounce.
+  factory SpringSheetMotion.bouncy({
+    Duration duration = const Duration(milliseconds: 500),
+    double extraBounce = 0,
+    Tolerance tolerance = kDefaultSheetMotionTolerance,
+  }) => SpringSheetMotion.withBounce(
+    duration: duration,
+    bounce: 0.3 + extraBounce,
+    tolerance: tolerance,
+  );
+
+  /// The iOS `interactiveSpring`: a much shorter response, meant for motion
+  /// that follows the user's finger.
+  ///
+  /// [extraBounce] is added on top of the preset's own bounce.
+  factory SpringSheetMotion.interactive({
+    Duration duration = const Duration(milliseconds: 150),
+    double extraBounce = 0,
+    Tolerance tolerance = kDefaultSheetMotionTolerance,
+  }) => SpringSheetMotion.withBounce(
+    duration: duration,
+    bounce: 0.14 + extraBounce,
+    tolerance: tolerance,
+  );
+
+  /// {@macro sheet_motion_duration}
+  ///
+  /// A spring settles when it runs out of energy rather than when a clock
+  /// runs out, so this is only the value reported to APIs that demand a
+  /// duration. It never drives the animation; [spring] does.
+  @override
+  Duration get duration => const Duration(milliseconds: 300);
+
+  /// Always [Curves.linear]: the simulation already describes the whole
+  /// trajectory, and reshaping it with a curve would distort it.
+  @override
+  Curve get curve => Curves.linear;
+
+  /// Always false: a spring can carry the progress past its destination
+  /// before settling back onto it.
+  @override
+  bool get isBounded => false;
+
+  /// The spring that drives the transition.
+  ///
+  /// {@macro sheet_motion_normalized_progress}
+  final SpringDescription spring;
+
+  /// How close to its destination the [spring] must be, and how slowly it
+  /// must be moving, for the motion to be considered finished.
+  ///
+  /// Measured in normalized progress, not pixels — see [spring].
+  final Tolerance tolerance;
+
+  /// {@macro sheet_motion_normalized_progress}
+  @override
+  Simulation createSimulation({
+    required double start,
+    required double end,
+    required double velocity,
+  }) {
+    return SpringSimulation(
+      spring,
+      start,
+      end,
+      velocity,
+      tolerance: tolerance,
+      // Guarantees that the animation lands exactly on `end`, since a spring
+      // only approaches its destination asymptotically.
+      snapToEnd: true,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SpringSheetMotion &&
+          other.spring.mass == spring.mass &&
+          other.spring.stiffness == spring.stiffness &&
+          other.spring.damping == spring.damping &&
+          other.tolerance == tolerance;
+
+  @override
+  int get hashCode =>
+      Object.hash(spring.mass, spring.stiffness, spring.damping, tolerance);
+
+  @override
+  String toString() => 'SpringSheetMotion(spring: $spring)';
+}

--- a/test/activity_test.dart
+++ b/test/activity_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mockito/mockito.dart';
@@ -12,8 +14,8 @@ class _TestAnimatedSheetActivity extends AnimatedSheetActivity {
   _TestAnimatedSheetActivity({
     required AnimationController controller,
     required super.destination,
-    required super.duration,
-    required super.curve,
+    required super.motion,
+    super.initialVelocity,
   }) : _controller = controller;
 
   final AnimationController _controller;
@@ -53,8 +55,10 @@ void main() {
       final activity = _TestAnimatedSheetActivity(
         controller: controller,
         destination: const SheetOffset.absolute(700),
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.linear,
+        motion: CurvedSheetMotion(
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.linear,
+        ),
       )..init(owner);
 
       verify(
@@ -97,8 +101,10 @@ void main() {
       final activity = _TestAnimatedSheetActivity(
         controller: controller,
         destination: const SheetOffset.absolute(700),
-        duration: const Duration(milliseconds: 400),
-        curve: Curves.easeInOut,
+        motion: CurvedSheetMotion(
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.easeInOut,
+        ),
       )..init(owner);
 
       // What the controller reports a quarter of the way through the
@@ -119,6 +125,127 @@ void main() {
       );
     });
 
+    ({MockSheetModel owner, _TestAnimatedSheetActivity activity})
+    springActivity({
+      required double from,
+      required double to,
+      double velocity = 0,
+    }) {
+      final (_, owner) = createMockSheetModel(
+        offset: from,
+        snapGrid: SheetSnapGrid.stepless(
+          minOffset: SheetOffset.absolute(min(from, to)),
+        ),
+        contentSize: const Size(400, 700),
+        viewportSize: const Size(400, 900),
+        devicePixelRatio: 1,
+      );
+      when(controller.animateWith(any)).thenAnswer((_) => MockTickerFuture());
+
+      final activity = _TestAnimatedSheetActivity(
+        controller: controller,
+        destination: SheetOffset.absolute(to),
+        motion: const SpringSheetMotion(),
+        initialVelocity: velocity,
+      )..init(owner);
+
+      return (owner: owner, activity: activity);
+    }
+
+    Simulation capturedSimulation() =>
+        verify(controller.animateWith(captureAny)).captured.single
+            as Simulation;
+
+    test('should drive a spring motion with a simulation', () {
+      springActivity(from: 300, to: 700);
+      final simulation = capturedSimulation();
+
+      expect(simulation.x(0), moreOrLessEquals(0));
+      expect(simulation.dx(0), moreOrLessEquals(0));
+      expect(
+        simulation.x(5),
+        moreOrLessEquals(1),
+        reason: 'The simulation runs in normalized progress, not in pixels.',
+      );
+    });
+
+    test('should convert the initial velocity into progress per second', () {
+      // 400 pixels of travel, so 800 px/s is 2 progress units per second.
+      springActivity(from: 300, to: 700, velocity: 800);
+      expect(capturedSimulation().dx(0), moreOrLessEquals(2));
+    });
+
+    test('should keep the velocity sign when animating downwards', () {
+      // Travelling -400 px, already moving down at -800 px/s: still 2/s
+      // towards the destination.
+      springActivity(from: 700, to: 300, velocity: -800);
+      expect(capturedSimulation().dx(0), moreOrLessEquals(2));
+    });
+
+    test('should report its velocity in pixels per second', () {
+      final env = springActivity(from: 300, to: 700);
+      when(controller.velocity).thenReturn(2);
+      expect(
+        env.activity.velocity,
+        moreOrLessEquals(800),
+        reason:
+            'The controller runs in progress per second; the sheet moves in '
+            'pixels per second.',
+      );
+    });
+
+    // The curved counterpart of this is 'should absorb viewport changes'
+    // below, which hands the remaining duration to a SettlingSheetActivity.
+    // A spring has no remaining duration, so it re-aims instead.
+    test('should re-aim a spring motion when the destination moves', () {
+      final (ownerMetrics, owner) = createMockSheetModel(
+        offset: 250,
+        snapGrid: SheetSnapGrid.stepless(
+          minOffset: const SheetOffset.absolute(250),
+        ),
+        contentSize: const Size(400, 850),
+        viewportSize: const Size(400, 900),
+        devicePixelRatio: 1,
+      );
+      when(controller.animateWith(any)).thenAnswer((_) => MockTickerFuture());
+
+      final activity = _TestAnimatedSheetActivity(
+        controller: controller,
+        destination: const SheetOffset(1),
+        motion: const SpringSheetMotion(),
+      )..init(owner);
+
+      when(controller.value).thenReturn(0.25);
+      when(controller.velocity).thenReturn(0.5);
+      activity.onAnimationTick();
+
+      // The on-screen keyboard appears and pushes the content up, moving the
+      // resolved destination.
+      final oldMeasurements = ownerMetrics.copyWith();
+      ownerMetrics
+        ..contentSize = const Size(400, 850)
+        ..contentMargin = EdgeInsets.only(bottom: 50)
+        ..contentBaseline = 50;
+
+      activity.applyNewLayout(oldMeasurements);
+
+      verifyNever(owner.settleTo(any, any));
+      final captured =
+          verify(
+                owner.animateTo(
+                  const SheetOffset(1),
+                  motion: anyNamed('motion'),
+                  velocity: captureAnyNamed('velocity'),
+                ),
+              ).captured.single
+              as double;
+      expect(
+        captured,
+        greaterThan(0),
+        reason: 'The current speed should carry across the re-aim.',
+      );
+    });
+
     test('should absorb viewport changes', () {
       final (ownerMetrics, owner) = createMockSheetModel(
         offset: 250,
@@ -134,8 +261,10 @@ void main() {
       final activity = _TestAnimatedSheetActivity(
         controller: controller,
         destination: const SheetOffset(1),
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.linear,
+        motion: CurvedSheetMotion(
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.linear,
+        ),
       )..init(owner);
 
       when(controller.value).thenReturn(0.0);

--- a/test/activity_test.dart
+++ b/test/activity_test.dart
@@ -78,6 +78,47 @@ void main() {
       expect(ownerMetrics.offset, 700);
     });
 
+    // Regression test: the curve was applied twice, once by
+    // AnimationController.animateTo() and once again in onAnimationTick(),
+    // so the sheet followed `curve o curve` instead of `curve`. It went
+    // unnoticed because the other tests here use the idempotent
+    // Curves.linear.
+    test('should not apply the curve on top of the controller value', () {
+      final (ownerMetrics, owner) = createMockSheetModel(
+        offset: 300,
+        snapGrid: SheetSnapGrid.stepless(
+          minOffset: const SheetOffset.absolute(300),
+        ),
+        contentSize: const Size(400, 700),
+        viewportSize: const Size(400, 900),
+        devicePixelRatio: 1,
+      );
+
+      final activity = _TestAnimatedSheetActivity(
+        controller: controller,
+        destination: const SheetOffset.absolute(700),
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      )..init(owner);
+
+      // What the controller reports a quarter of the way through the
+      // animation: the curve has already been applied to it.
+      final quarterWay = Curves.easeInOut.transform(0.25);
+      expect(quarterWay, moreOrLessEquals(0.1287, epsilon: 1e-4));
+
+      when(controller.value).thenReturn(quarterWay);
+      activity.onAnimationTick();
+
+      expect(
+        ownerMetrics.offset,
+        moreOrLessEquals(300 + 400 * quarterWay, epsilon: 1e-6),
+        reason:
+            'The offset should follow the curve once. Applying it twice '
+            'would put the sheet at '
+            '${300 + 400 * Curves.easeInOut.transform(quarterWay)}.',
+      );
+    });
+
     test('should absorb viewport changes', () {
       final (ownerMetrics, owner) = createMockSheetModel(
         offset: 250,

--- a/test/motion_test.dart
+++ b/test/motion_test.dart
@@ -1,0 +1,1347 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+import 'src/flutter_test_x.dart';
+import 'src/matchers.dart';
+
+/// A motion the package does not ship, to prove [SheetMotion] is extensible.
+class _GravityMotion extends SheetMotion {
+  const _GravityMotion();
+
+  @override
+  Duration get duration => const Duration(milliseconds: 400);
+
+  @override
+  Curve get curve => Curves.linear;
+
+  @override
+  Simulation createSimulation({
+    required double start,
+    required double end,
+    required double velocity,
+  }) => GravitySimulation(9.8 * (end - start).sign, start, end, velocity);
+}
+
+class _Boilerplate extends StatelessWidget {
+  const _Boilerplate({required this.modalRoute});
+
+  final ModalSheetRoute<dynamic> modalRoute;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => Navigator.push(context, modalRoute),
+                child: const Text('Open modal'),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+ModalSheetRoute<dynamic> _createModalRoute({
+  required SheetMotion transitionMotion,
+  Duration transitionDuration = const Duration(milliseconds: 300),
+  Curve transitionCurve = Curves.fastEaseInToSlowEaseOut,
+  SwipeDismissSensitivity sensitivity = const SwipeDismissSensitivity(),
+}) {
+  return ModalSheetRoute<dynamic>(
+    swipeDismissible: true,
+    transitionMotion: transitionMotion,
+    transitionDuration: transitionDuration,
+    transitionCurve: transitionCurve,
+    swipeDismissSensitivity: sensitivity,
+    builder: (context) => Sheet(
+      child: Container(
+        key: const Key('sheet'),
+        color: Colors.white,
+        width: double.infinity,
+        height: 600,
+      ),
+    ),
+  );
+}
+
+/// Samples the transition progress of [route] once per [interval],
+/// [sampleCount] times, without letting the animation settle in between.
+Future<List<double>> _sampleTransition(
+  WidgetTesterX tester,
+  ModalSheetRoute<dynamic> route, {
+  required int sampleCount,
+  Duration interval = const Duration(milliseconds: 16),
+}) async {
+  final samples = <double>[];
+  for (var i = 0; i < sampleCount; i++) {
+    await tester.pump(interval);
+    samples.add(route.animation!.value);
+  }
+  return samples;
+}
+
+void main() {
+  group('$SpringSheetMotion', () {
+    test('creates a simulation departing from start at the given velocity', () {
+      const motion = SpringSheetMotion();
+      final simulation = motion.createSimulation(
+        start: 0.6,
+        end: 1,
+        velocity: -2.5,
+      );
+
+      expect(simulation.x(0), moreOrLessEquals(0.6));
+      expect(simulation.dx(0), moreOrLessEquals(-2.5));
+    });
+
+    test('lands exactly on the end value once it is done', () {
+      const motion = SpringSheetMotion();
+      final simulation = motion.createSimulation(start: 0, end: 1, velocity: 0);
+
+      var time = 0.0;
+      while (!simulation.isDone(time) && time < 5) {
+        time += 1 / 1000;
+      }
+
+      expect(
+        time,
+        lessThan(1),
+        reason: 'The default spring should settle well within a second.',
+      );
+      expect(
+        simulation.x(time),
+        1.0,
+        reason:
+            'snapToEnd should place the animation exactly on the end value, '
+            'since a spring only approaches it asymptotically.',
+      );
+      expect(simulation.dx(time), 0.0);
+    });
+
+    test('the default spring never overshoots either end', () {
+      const motion = SpringSheetMotion();
+      for (final velocity in [0.0, 2.5, 6.0]) {
+        final opening = motion.createSimulation(
+          start: 0,
+          end: 1,
+          velocity: velocity,
+        );
+        final closing = motion.createSimulation(
+          start: 1,
+          end: 0,
+          velocity: -velocity,
+        );
+        for (var ms = 0; ms <= 1000; ms++) {
+          expect(opening.x(ms / 1000), lessThanOrEqualTo(1.0));
+          expect(closing.x(ms / 1000), greaterThanOrEqualTo(0.0));
+        }
+      }
+    });
+
+    test('the release velocity changes the trajectory', () {
+      const motion = SpringSheetMotion();
+      double positionAt100ms(double velocity) => motion
+          .createSimulation(start: 0.6, end: 1, velocity: velocity)
+          .x(0.1);
+
+      final positions = [0.0, 2.5, 6.0].map(positionAt100ms).toList();
+
+      expect(positions.toSet(), hasLength(3));
+      expect(positions, isMonotonicallyIncreasing);
+    });
+  });
+
+  group('$SpringSheetMotion iOS presets', () {
+    // The natural frequency and damping ratio fully characterise a spring, and
+    // SwiftUI's spring(duration:bounce:) is defined as a spring whose natural
+    // period is `duration` and whose damping ratio is `1 - bounce`.
+    double naturalPeriodOf(SpringDescription spring) =>
+        2 * pi / sqrt(spring.stiffness / spring.mass);
+
+    double dampingRatioOf(SpringDescription spring) =>
+        spring.damping / (2 * sqrt(spring.mass * spring.stiffness));
+
+    ({double peak, int settleMs}) simulate(
+      SpringSheetMotion motion,
+    ) {
+      final simulation = motion.createSimulation(
+        start: 0,
+        end: 1,
+        velocity: 0,
+      );
+      var peak = 0.0;
+      var settleMs = 0;
+      for (var ms = 0; ms <= 3000; ms++) {
+        peak = max(peak, simulation.x(ms / 1000));
+        if (settleMs == 0 && simulation.isDone(ms / 1000)) settleMs = ms;
+      }
+      return (peak: peak, settleMs: settleMs);
+    }
+
+    final presets =
+        <String, ({SpringSheetMotion motion, int ms, double bounce})>{
+          'smooth': (
+            motion: SpringSheetMotion.smooth(),
+            ms: 500,
+            bounce: 0,
+          ),
+          'snappy': (
+            motion: SpringSheetMotion.snappy(),
+            ms: 500,
+            bounce: 0.15,
+          ),
+          'bouncy': (
+            motion: SpringSheetMotion.bouncy(),
+            ms: 500,
+            bounce: 0.3,
+          ),
+          'interactive': (
+            motion: SpringSheetMotion.interactive(),
+            ms: 150,
+            bounce: 0.14,
+          ),
+        };
+
+    presets.forEach((name, preset) {
+      test('$name matches the iOS duration/bounce pair', () {
+        final spring = preset.motion.spring;
+        expect(
+          naturalPeriodOf(spring),
+          moreOrLessEquals(preset.ms / 1000, epsilon: 1e-9),
+          reason: 'The natural period should equal the perceptual duration.',
+        );
+        expect(
+          dampingRatioOf(spring),
+          moreOrLessEquals(1 - preset.bounce, epsilon: 1e-9),
+          reason: 'The damping ratio should equal 1 - bounce.',
+        );
+      });
+    });
+
+    test('only the bouncy presets overshoot', () {
+      expect(simulate(presets['smooth']!.motion).peak, lessThanOrEqualTo(1.0));
+      expect(simulate(presets['snappy']!.motion).peak, greaterThan(1.0));
+      expect(simulate(presets['bouncy']!.motion).peak, greaterThan(1.0));
+      expect(
+        simulate(presets['bouncy']!.motion).peak,
+        greaterThan(simulate(presets['snappy']!.motion).peak),
+        reason: 'bouncy has more bounce than snappy, by definition.',
+      );
+    });
+
+    test('interactive is much shorter than the others', () {
+      expect(
+        simulate(presets['interactive']!.motion).settleMs,
+        lessThan(simulate(presets['smooth']!.motion).settleMs ~/ 2),
+      );
+    });
+
+    test('extraBounce adds to the preset bounce', () {
+      expect(
+        dampingRatioOf(
+          SpringSheetMotion.snappy(extraBounce: 0.15).spring,
+        ),
+        moreOrLessEquals(1 - 0.3, epsilon: 1e-9),
+      );
+    });
+  });
+
+  group('Deprecated transitionDuration and transitionCurve', () {
+    test('still configure the motion of $ModalSheetRoute', () {
+      final route = ModalSheetRoute<dynamic>(
+        transitionDuration: const Duration(milliseconds: 450),
+        transitionCurve: Curves.easeInOut,
+        builder: (context) => const Sheet(child: SizedBox()),
+      );
+
+      expect(
+        route.transitionMotion,
+        isA<CurvedSheetMotion>()
+            .having(
+              (it) => it.duration,
+              'duration',
+              const Duration(milliseconds: 450),
+            )
+            .having((it) => it.curve, 'curve', Curves.easeInOut),
+      );
+      expect(route.transitionDuration, const Duration(milliseconds: 450));
+      expect(route.transitionCurve, Curves.easeInOut);
+    });
+
+    test('still configure the motion of $CupertinoModalSheetRoute', () {
+      final route = CupertinoModalSheetRoute<dynamic>(
+        transitionDuration: const Duration(milliseconds: 450),
+        transitionCurve: Curves.easeInOut,
+        builder: (context) => const Sheet(child: SizedBox()),
+      );
+
+      expect(route.transitionDuration, const Duration(milliseconds: 450));
+      expect(route.transitionCurve, Curves.easeInOut);
+    });
+
+    test('are superseded by an explicit transitionMotion', () {
+      final route = ModalSheetRoute<dynamic>(
+        transitionDuration: const Duration(milliseconds: 450),
+        transitionCurve: Curves.easeInOut,
+        transitionMotion: const CurvedSheetMotion(
+          duration: Duration(milliseconds: 800),
+          curve: Curves.bounceIn,
+        ),
+        builder: (context) => const Sheet(child: SizedBox()),
+      );
+
+      expect(route.transitionDuration, const Duration(milliseconds: 800));
+      expect(route.transitionCurve, Curves.bounceIn);
+    });
+
+    test('report a nominal duration for a spring motion', () {
+      final route = ModalSheetRoute<dynamic>(
+        transitionDuration: const Duration(milliseconds: 450),
+        transitionMotion: const SpringSheetMotion(),
+        builder: (context) => const Sheet(child: SizedBox()),
+      );
+
+      expect(
+        route.transitionDuration,
+        const Duration(milliseconds: 300),
+        reason:
+            'A spring has no duration of its own, but ModalRoute demands one. '
+            'It is never used to drive the animation.',
+      );
+      expect(route.transitionCurve, Curves.linear);
+    });
+  });
+
+  group('$SheetMotion on a modal sheet route', () {
+    testWidgets('defaults to $CurvedSheetMotion', (tester) async {
+      final route = ModalSheetRoute<dynamic>(
+        transitionCurve: Curves.easeInOut,
+        builder: (context) => const Sheet(child: SizedBox(height: 100)),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      expect(route.transitionMotion, isA<CurvedSheetMotion>());
+      expect(route.effectiveCurve, Curves.easeInOut);
+      expect(
+        route.createSimulation(forward: true),
+        isNull,
+        reason:
+            'A curve driven route must keep using the default, duration based '
+            'animation of TransitionRoute.',
+      );
+    });
+
+    testWidgets('reports a linear effective curve when driven by a spring', (
+      tester,
+    ) async {
+      final route = _createModalRoute(
+        transitionCurve: Curves.easeInOut,
+        transitionMotion: const SheetMotion.spring(),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      expect(
+        route.effectiveCurve,
+        Curves.linear,
+        reason:
+            'The simulation already describes the whole trajectory, so it must '
+            'not be reshaped by transitionCurve.',
+      );
+    });
+
+    testWidgets('the open transition follows the spring, '
+        'not transitionDuration', (tester) async {
+      const motion = SpringSheetMotion();
+      final route = _createModalRoute(
+        transitionMotion: motion,
+        // Deliberately absurd: a spring settles when it runs out of energy,
+        // so this must have no effect at all.
+        transitionDuration: const Duration(seconds: 10),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pump();
+      expect(route.animation!.value, 0.0);
+
+      final expected = motion.createSimulation(start: 0, end: 1, velocity: 0);
+      for (var frame = 1; frame <= 6; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(
+          route.animation!.value,
+          moreOrLessEquals(expected.x(frame * 16 / 1000), epsilon: 1e-6),
+        );
+      }
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(route.animation!.isCompleted, isTrue);
+      expect(route.animation!.value, 1.0);
+    });
+
+    testWidgets('is forwarded from $ModalSheetPage to its route', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Navigator(
+            pages: const [
+              MaterialPage<dynamic>(key: ValueKey('home'), child: SizedBox()),
+              ModalSheetPage<dynamic>(
+                key: ValueKey('modal'),
+                transitionCurve: Curves.easeInOut,
+                transitionMotion: SheetMotion.spring(),
+                child: Sheet(child: SizedBox(key: Key('sheet'), height: 100)),
+              ),
+            ],
+            onDidRemovePage: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final route =
+          ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+              as ModalSheetRouteMixin<dynamic>;
+      expect(route.transitionMotion, isA<SpringSheetMotion>());
+      expect(route.effectiveCurve, Curves.linear);
+    });
+
+    testWidgets('drives a $CupertinoModalSheetRoute as well', (tester) async {
+      const motion = SpringSheetMotion();
+      final route = CupertinoModalSheetRoute<dynamic>(
+        transitionMotion: motion,
+        transitionDuration: const Duration(seconds: 10),
+        builder: (context) =>
+            const Sheet(child: SizedBox(key: Key('sheet'), height: 300)),
+      );
+
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        CupertinoApp(
+          navigatorKey: navigatorKey,
+          home: const CupertinoPageScaffold(child: SizedBox()),
+        ),
+      );
+      unawaited(navigatorKey.currentState!.push(route));
+      await tester.pump();
+
+      final expected = motion.createSimulation(start: 0, end: 1, velocity: 0);
+      for (var frame = 1; frame <= 6; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(
+          route.animation!.value,
+          moreOrLessEquals(expected.x(frame * 16 / 1000), epsilon: 1e-6),
+        );
+      }
+
+      await tester.pumpAndSettle();
+      expect(route.animation!.value, 1.0);
+    });
+
+    testWidgets('lets a bouncy spring overshoot and settle back', (
+      tester,
+    ) async {
+      final motion = SpringSheetMotion.bouncy();
+      final route = _createModalRoute(transitionMotion: motion);
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pump();
+
+      final samples = await _sampleTransition(
+        tester,
+        route,
+        sampleCount: 60, // ~960ms, past the overshoot.
+      );
+
+      expect(
+        samples.reduce(max),
+        greaterThan(1.0),
+        reason:
+            'A bounded controller would clamp the overshoot away, pinning the '
+            'sheet at the top until the spring came back into range.',
+      );
+      expect(
+        samples.reduce(max),
+        lessThan(1.1),
+        reason: 'The overshoot of the bouncy preset is about 5%.',
+      );
+
+      await tester.pumpAndSettle();
+      expect(route.animation!.value, 1.0);
+      expect(route.animation!.isCompleted, isTrue);
+    });
+
+    testWidgets('settles a page that is added without a transition', (
+      tester,
+    ) async {
+      // TransitionRoute.didAdd() jumps the controller to its upper bound and
+      // relies on that to report AnimationStatus.completed. The upper bound of
+      // the unbounded controller a spring needs is infinite, so both the value
+      // and the status have to be restored by hand.
+      var popped = false;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Navigator(
+            pages: const [
+              MaterialPage<dynamic>(key: ValueKey('home'), child: SizedBox()),
+              ModalSheetPage<dynamic>(
+                key: ValueKey('modal'),
+                transitionMotion: SheetMotion.spring(),
+                child: Sheet(child: SizedBox(key: Key('sheet'), height: 100)),
+              ),
+            ],
+            onDidRemovePage: (_) => popped = true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final route =
+          ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+              as ModalSheetRouteMixin<dynamic>;
+      expect(route.animation!.value, 1.0);
+      expect(
+        route.animation!.status,
+        AnimationStatus.completed,
+        reason:
+            'A route that is added rather than pushed must report itself as '
+            'settled, or barrier taps and drag routing both misbehave.',
+      );
+
+      // The barrier only dismisses a route whose animation is completed.
+      await tester.tapAt(const Offset(400, 20));
+      await tester.pumpAndSettle();
+      expect(popped, isTrue);
+    });
+
+    testWidgets('keeps the motion it was installed with', (tester) async {
+      // The controller is bounded for a curve and unbounded for a spring, so
+      // the route must not observe a motion that changes underneath it: a
+      // curve on an unbounded controller reverses towards negative infinity.
+      final motion = ValueNotifier<SheetMotion>(
+        const SheetMotion.spring(),
+      );
+      addTearDown(motion.dispose);
+
+      await tester.pumpWidget(
+        ValueListenableBuilder(
+          valueListenable: motion,
+          builder: (context, value, _) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Navigator(
+              pages: [
+                const MaterialPage<dynamic>(
+                  key: ValueKey('home'),
+                  child: SizedBox(),
+                ),
+                ModalSheetPage<dynamic>(
+                  key: const ValueKey('modal'),
+                  transitionMotion: value,
+                  child: const Sheet(
+                    child: SizedBox(key: Key('sheet'), height: 100),
+                  ),
+                ),
+              ],
+              onDidRemovePage: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final route =
+          ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+              as ModalSheetRouteMixin<dynamic>;
+
+      motion.value = const CurvedSheetMotion();
+      await tester.pumpAndSettle();
+      expect(route.transitionMotion, isA<CurvedSheetMotion>());
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(
+        route.animation!.value,
+        inInclusiveRange(0.0, 1.0),
+        reason:
+            'The pop must keep using the spring the controller was built for.',
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('sheet')), findsNothing);
+    });
+
+    testWidgets('the close transition follows the spring', (tester) async {
+      const motion = SpringSheetMotion();
+      final route = _createModalRoute(transitionMotion: motion);
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.pop();
+      await tester.pump();
+
+      final expected = motion.createSimulation(start: 1, end: 0, velocity: 0);
+      for (var frame = 1; frame <= 6; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(
+          route.animation!.value,
+          moreOrLessEquals(expected.x(frame * 16 / 1000), epsilon: 1e-6),
+        );
+      }
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('sheet')), findsNothing);
+    });
+  });
+
+  group('Swipe-to-dismiss release velocity', () {
+    /// Opens a modal, drags it down by 100px releasing at [flingSpeed],
+    /// and returns the transition progress of each of the next 20 frames.
+    ///
+    /// The sensitivity is configured so that the gesture never dismisses the
+    /// modal, which makes every sample part of the settle-back animation.
+    Future<List<double>> settleBackTrajectory(
+      WidgetTesterX tester, {
+      required SheetMotion motion,
+      required double flingSpeed,
+    }) async {
+      final route = _createModalRoute(
+        transitionMotion: motion,
+        sensitivity: const SwipeDismissSensitivity(
+          minFlingVelocityRatio: 100,
+          dismissalOffset: SheetOffset.absolute(0),
+        ),
+      );
+
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byKey(const Key('sheet')),
+        const Offset(0, 100),
+        flingSpeed,
+      );
+      final samples = await _sampleTransition(tester, route, sampleCount: 20);
+
+      await tester.pumpAndSettle();
+      expect(
+        route.animation!.value,
+        1.0,
+        reason: 'The modal should have settled back to its original position.',
+      );
+      // Tear the tree down so that the next scenario starts from scratch.
+      await tester.pumpWidget(const SizedBox.shrink());
+      return samples;
+    }
+
+    testWidgets('is thrown away by a curve driven transition', (tester) async {
+      const motion = CurvedSheetMotion();
+      final gentle = await settleBackTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 200,
+      );
+      final hard = await settleBackTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 4000,
+      );
+
+      expect(
+        hard,
+        orderedEquals(gentle),
+        reason:
+            'A curve is a pure function of elapsed time, so a flick and a slow '
+            'release produce byte-for-byte identical motion.',
+      );
+    });
+
+    testWidgets('is carried into a spring driven transition', (tester) async {
+      const motion = SpringSheetMotion();
+      final gentle = await settleBackTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 200,
+      );
+      final hard = await settleBackTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 4000,
+      );
+
+      expect(hard, isNot(orderedEquals(gentle)));
+      expect(
+        hard.reduce(min),
+        lessThan(gentle.reduce(min)),
+        reason:
+            'The harder the sheet is flung downwards, the further it keeps '
+            'travelling before the spring pulls it back.',
+      );
+      expect(
+        hard.last,
+        greaterThan(hard.reduce(min)),
+        reason: 'The spring must bring the sheet back up afterwards.',
+      );
+    });
+  });
+
+  group('showModalSheet helpers', () {
+    Future<ModalSheetRouteMixin<dynamic>> open(
+      WidgetTesterX tester,
+      Future<void> Function(BuildContext context) show,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => show(context),
+              child: const Text('Open modal'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+      return ModalRoute.of(tester.element(find.byKey(const Key('sheet'))))!
+          as ModalSheetRouteMixin<dynamic>;
+    }
+
+    const sheet = Sheet(child: SizedBox(key: Key('sheet'), height: 100));
+
+    testWidgets('showModalSheet forwards transitionMotion', (tester) async {
+      final route = await open(
+        tester,
+        (context) => showModalSheet<void>(
+          context: context,
+          transitionMotion: const SheetMotion.spring(),
+          builder: (context) => sheet,
+        ),
+      );
+      expect(route.transitionMotion, isA<SpringSheetMotion>());
+    });
+
+    testWidgets('showCupertinoModalSheet forwards transitionMotion', (
+      tester,
+    ) async {
+      final route = await open(
+        tester,
+        (context) => showCupertinoModalSheet<void>(
+          context: context,
+          transitionMotion: SpringSheetMotion.bouncy(),
+          builder: (context) => sheet,
+        ),
+      );
+      expect(route.transitionMotion, isA<SpringSheetMotion>());
+    });
+
+    testWidgets('showAdaptiveModalSheet forwards transitionMotion', (
+      tester,
+    ) async {
+      final route = await open(
+        tester,
+        (context) => showAdaptiveModalSheet<void>(
+          context: context,
+          transitionMotion: const SheetMotion.spring(),
+          builder: (context) => sheet,
+        ),
+      );
+      expect(route.transitionMotion, isA<SpringSheetMotion>());
+    });
+
+    testWidgets('still honour the deprecated duration and curve', (
+      tester,
+    ) async {
+      final route = await open(
+        tester,
+        (context) => showModalSheet<void>(
+          context: context,
+          transitionDuration: const Duration(milliseconds: 450),
+          transitionCurve: Curves.easeInOut,
+          builder: (context) => sheet,
+        ),
+      );
+      expect(route.transitionDuration, const Duration(milliseconds: 450));
+      expect(route.transitionCurve, Curves.easeInOut);
+    });
+  });
+
+  group('Dismissal fling velocity', () {
+    /// Opens a modal, flings it away at [flingSpeed], and returns the
+    /// transition progress of each of the next 6 frames of the pop animation.
+    Future<List<double>> dismissTrajectory(
+      WidgetTesterX tester, {
+      required SheetMotion motion,
+      required double flingSpeed,
+    }) async {
+      final route = _createModalRoute(
+        transitionMotion: motion,
+        sensitivity: const SwipeDismissSensitivity(
+          minFlingVelocityRatio: 1,
+          dismissalOffset: SheetOffset.absolute(0),
+        ),
+      );
+
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byKey(const Key('sheet')),
+        const Offset(0, 100),
+        flingSpeed,
+      );
+      final samples = await _sampleTransition(tester, route, sampleCount: 6);
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('sheet')), findsNothing);
+      // Tear the tree down so that the next scenario starts from scratch.
+      await tester.pumpWidget(const SizedBox.shrink());
+      return samples;
+    }
+
+    testWidgets('is thrown away by a curve driven pop', (tester) async {
+      const motion = CurvedSheetMotion();
+      final gentle = await dismissTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 1000,
+      );
+      final hard = await dismissTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 6000,
+      );
+
+      expect(hard, orderedEquals(gentle));
+    });
+
+    testWidgets('is carried into a spring driven pop', (tester) async {
+      const motion = SpringSheetMotion();
+      final gentle = await dismissTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 1000,
+      );
+      final hard = await dismissTrajectory(
+        tester,
+        motion: motion,
+        flingSpeed: 6000,
+      );
+
+      for (var i = 0; i < gentle.length; i++) {
+        expect(
+          hard[i],
+          lessThan(gentle[i]),
+          reason:
+              'The release velocity is handed to the pop simulation, so at '
+              'every moment the harder fling must be further on its way out.',
+        );
+      }
+    });
+  });
+
+  group('$SheetController.animateTo', () {
+    ({Widget widget, SheetController controller}) boilerplate() {
+      final controller = SheetController();
+      return (
+        widget: MaterialApp(
+          home: SheetViewport(
+            child: Sheet(
+              controller: controller,
+              snapGrid: const SheetSnapGrid(
+                snaps: [SheetOffset(0.5), SheetOffset(1)],
+              ),
+              child: Container(
+                key: const Key('sheet'),
+                color: const Color(0xFFFFFFFF),
+                height: 600,
+              ),
+            ),
+          ),
+        ),
+        controller: controller,
+      );
+    }
+
+    testWidgets('defaults to the motion animateTo has always used', (
+      tester,
+    ) async {
+      // Migrating `duration:` to `CurvedSheetMotion(duration:)` must not
+      // silently change the easing: animateTo has always used easeInOut,
+      // while CurvedSheetMotion itself defaults to fastEaseInToSlowEaseOut.
+      Future<List<double>> trajectory(SheetMotion? motion) async {
+        final env = boilerplate();
+        addTearDown(env.controller.dispose);
+        await tester.pumpWidget(env.widget);
+        await tester.pumpAndSettle();
+
+        unawaited(
+          env.controller.animateTo(const SheetOffset(0.5), motion: motion),
+        );
+        await tester.pump();
+
+        final samples = <double>[];
+        for (var i = 0; i < 8; i++) {
+          await tester.pump(const Duration(milliseconds: 16));
+          samples.add(env.controller.value!);
+        }
+        await tester.pumpAndSettle();
+        await tester.pumpWidget(const SizedBox.shrink());
+        return samples;
+      }
+
+      final byDefault = await trajectory(null);
+      final explicit = await trajectory(kDefaultSheetAnimationMotion);
+      expect(byDefault, orderedEquals(explicit));
+
+      final differentCurve = await trajectory(const CurvedSheetMotion());
+      expect(
+        differentCurve,
+        isNot(orderedEquals(byDefault)),
+        reason:
+            'CurvedSheetMotion() is NOT the animateTo default. If these ever '
+            'match, the trap this constant exists to document is gone and '
+            'the constant can go too.',
+      );
+    });
+
+    testWidgets('moves the sheet with a spring motion', (tester) async {
+      final env = boilerplate();
+      addTearDown(env.controller.dispose);
+      await tester.pumpWidget(env.widget);
+      await tester.pumpAndSettle();
+
+      final start = env.controller.value!;
+      unawaited(
+        env.controller.animateTo(
+          const SheetOffset(0.5),
+          motion: const SpringSheetMotion(),
+        ),
+      );
+      await tester.pump();
+
+      final samples = <double>[];
+      for (var i = 0; i < 6; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        samples.add(env.controller.value!);
+      }
+      expect(samples, isMonotonicallyDecreasing);
+      expect(samples.last, lessThan(start));
+
+      await tester.pumpAndSettle();
+      expect(env.controller.value, moreOrLessEquals(300, epsilon: 0.5));
+    });
+
+    testWidgets('a bouncy motion overshoots and settles back', (tester) async {
+      final env = boilerplate();
+      addTearDown(env.controller.dispose);
+      await tester.pumpWidget(env.widget);
+      await tester.pumpAndSettle();
+
+      unawaited(
+        env.controller.animateTo(
+          const SheetOffset(0.5),
+          motion: SpringSheetMotion.bouncy(),
+        ),
+      );
+      await tester.pump();
+
+      var lowest = double.infinity;
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        lowest = min(lowest, env.controller.value!);
+      }
+      expect(
+        lowest,
+        lessThan(300),
+        reason: 'A bouncy spring travels past its destination first.',
+      );
+
+      await tester.pumpAndSettle();
+      expect(env.controller.value, moreOrLessEquals(300, epsilon: 0.5));
+    });
+
+    testWidgets('completes its future and comes to rest', (tester) async {
+      final env = boilerplate();
+      addTearDown(env.controller.dispose);
+      await tester.pumpWidget(env.widget);
+      await tester.pumpAndSettle();
+
+      var done = false;
+      unawaited(
+        env.controller
+            .animateTo(
+              const SheetOffset(0.5),
+              motion: const SpringSheetMotion(),
+            )
+            .whenComplete(() => done = true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(done, isTrue);
+      expect(env.controller.value, moreOrLessEquals(300, epsilon: 0.5));
+    });
+  });
+
+  group('SheetMotion is unit agnostic', () {
+    // This is the load-bearing property of reusing one motion type for both
+    // route transitions and animateTo: a SheetMotion always describes a
+    // normalized 0 to 1 progress, so its Tolerance is in progress units and
+    // the motion takes the same time whatever distance it is mapped onto.
+    //
+    // Applying the same spring directly in pixel space would not be: the
+    // tolerance is compared against the remaining distance in the caller's
+    // own units, so the settle time would drift with the distance.
+    int framesToSettle(Simulation simulation) {
+      var frames = 0;
+      while (frames < 600 && !simulation.isDone(frames * 16 / 1000)) {
+        frames++;
+      }
+      return frames;
+    }
+
+    testWidgets('moves any distance in the same time', (tester) async {
+      // The consumer maps the normalized progress onto whatever distance it
+      // needs, so the settle time must not depend on that distance. Measured
+      // end to end rather than on the simulation, since it is the consumer
+      // that does the normalizing.
+      Future<int> framesToArrive(double sheetHeight) async {
+        final controller = SheetController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SheetViewport(
+              child: Sheet(
+                controller: controller,
+                snapGrid: const SheetSnapGrid(
+                  snaps: [SheetOffset(0), SheetOffset(1)],
+                ),
+                child: SizedBox(height: sheetHeight, width: double.infinity),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final future = controller.animateTo(
+          const SheetOffset(0),
+          motion: const SpringSheetMotion(),
+        );
+        await tester.pump();
+
+        var frames = 0;
+        var done = false;
+        unawaited(future.whenComplete(() => done = true));
+        while (frames < 600 && !done) {
+          await tester.pump(const Duration(milliseconds: 16));
+          frames++;
+        }
+        await tester.pumpAndSettle();
+        await tester.pumpWidget(const SizedBox.shrink());
+        return frames;
+      }
+
+      final short = await framesToArrive(120);
+      final long = await framesToArrive(560);
+      expect(
+        long,
+        short,
+        reason:
+            'A SheetMotion describes a normalized 0 to 1 progress, so a '
+            '560px move must take exactly as long as a 120px one. Handing '
+            'the spring pixels instead would make the longer move settle '
+            'later, because Tolerance is measured in the caller units.',
+      );
+    });
+
+    test('a pixel space spring would drift with the distance', () {
+      const motion = SpringSheetMotion();
+      final short = framesToSettle(
+        SpringSimulation(
+          motion.spring,
+          0,
+          100,
+          0,
+          tolerance: motion.tolerance,
+          snapToEnd: true,
+        ),
+      );
+      final long = framesToSettle(
+        SpringSimulation(
+          motion.spring,
+          0,
+          900,
+          0,
+          tolerance: motion.tolerance,
+          snapToEnd: true,
+        ),
+      );
+
+      expect(
+        long,
+        greaterThan(short),
+        reason:
+            'Tolerance.distance is compared against the remaining distance in '
+            'the caller units, so a longer travel takes longer to settle. '
+            'This is why the motion is normalized before it reaches the '
+            'simulation.',
+      );
+    });
+  });
+
+  group('Reduced motion', () {
+    // AnimationController applies its own scaling to duration driven
+    // animations when the platform asks for animations to be disabled, but
+    // not to simulation driven ones, so the spring paths have to do it
+    // themselves.
+    void disableAnimations(WidgetTesterX tester) {
+      tester.platformDispatcher.accessibilityFeaturesTestValue =
+          const FakeAccessibilityFeatures(disableAnimations: true);
+      addTearDown(
+        tester.platformDispatcher.clearAccessibilityFeaturesTestValue,
+      );
+    }
+
+    testWidgets('shortens a spring driven route transition', (tester) async {
+      disableAnimations(tester);
+
+      final route = _createModalRoute(
+        transitionMotion: const SpringSheetMotion(),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pump();
+
+      // The default spring settles in ~405ms, so at 5% of that it must
+      // already be done well inside a couple of frames.
+      await tester.pump(const Duration(milliseconds: 32));
+      expect(
+        route.animation!.value,
+        1.0,
+        reason: 'A disabled animation should be over almost immediately.',
+      );
+      expect(route.animation!.isCompleted, isTrue);
+    });
+
+    testWidgets('shortens a spring driven animateTo', (tester) async {
+      disableAnimations(tester);
+
+      final controller = SheetController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetViewport(
+            child: Sheet(
+              controller: controller,
+              snapGrid: const SheetSnapGrid(
+                snaps: [SheetOffset(0.5), SheetOffset(1)],
+              ),
+              child: Container(
+                key: const Key('sheet'),
+                color: const Color(0xFFFFFFFF),
+                height: 600,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      unawaited(
+        controller.animateTo(
+          const SheetOffset(0.5),
+          motion: const SpringSheetMotion(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 32));
+
+      expect(controller.value, moreOrLessEquals(300, epsilon: 1));
+    });
+  });
+
+  group('Spring driven route with a draggable sheet', () {
+    Widget boilerplate(SheetMotion motion) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: Navigator(
+        pages: [
+          const MaterialPage<dynamic>(key: ValueKey('home'), child: SizedBox()),
+          ModalSheetPage<dynamic>(
+            key: const ValueKey('modal'),
+            swipeDismissible: true,
+            transitionMotion: motion,
+            child: Sheet(
+              initialOffset: const SheetOffset(1),
+              snapGrid: const SheetSnapGrid(
+                snaps: [SheetOffset(0.5), SheetOffset(1)],
+              ),
+              child: Container(
+                key: const Key('sheet'),
+                color: const Color(0xFFFFFFFF),
+                height: 500,
+              ),
+            ),
+          ),
+        ],
+        onDidRemovePage: (_) {},
+      ),
+    );
+
+    // The drag routing in _SheetDismissible asks whether the route transition
+    // has settled. Reading that off the raw controller does not work for a
+    // spring, because an unbounded controller cannot derive completed from
+    // its infinite bounds — so every drag was booked as route dismissal
+    // progress and the sheet could never reach an intermediate snap.
+    for (final entry in {
+      'a curve': const CurvedSheetMotion(),
+      'a spring': const SpringSheetMotion(),
+    }.entries) {
+      testWidgets('lets the sheet settle at its own snap with ${entry.key}', (
+        tester,
+      ) async {
+        await tester.pumpWidget(boilerplate(entry.value));
+        await tester.pumpAndSettle();
+        final top = tester.getRect(find.byKey(const Key('sheet'))).top;
+
+        await tester.drag(find.byKey(const Key('sheet')), const Offset(0, 200));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getRect(find.byKey(const Key('sheet'))).top,
+          greaterThan(top),
+          reason:
+              'The drag belongs to the sheet, which should come to rest at '
+              'its lower snap rather than dragging the whole route.',
+        );
+        expect(find.byKey(const Key('sheet')), findsOneWidget);
+      });
+    }
+
+    testWidgets('survives a drag started during a bouncy overshoot', (
+      tester,
+    ) async {
+      final route = ModalSheetRoute<void>(
+        swipeDismissible: true,
+        transitionMotion: SpringSheetMotion.bouncy(),
+        builder: (context) => Sheet(
+          initialOffset: const SheetOffset(1),
+          snapGrid: const SheetSnapGrid(
+            snaps: [SheetOffset(0.5), SheetOffset(1)],
+          ),
+          child: Container(
+            key: const Key('sheet'),
+            color: const Color(0xFFFFFFFF),
+            height: 500,
+          ),
+        ),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pump();
+
+      // Advance to a frame where the spring is past its destination.
+      var frames = 0;
+      while (frames < 120 && route.animation!.value <= 1.0) {
+        await tester.pump(const Duration(milliseconds: 16));
+        frames++;
+      }
+      expect(
+        route.animation!.value,
+        greaterThan(1.0),
+        reason: 'The test needs to catch the sheet mid-overshoot.',
+      );
+
+      // Grabbing the sheet here used to trip an assertion, because the
+      // transition progress was above 1 and the drag handler assumed it
+      // could not be.
+      final gesture = await tester.press(find.byKey(const Key('sheet')));
+      await gesture.moveBy(const Offset(0, 40));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('A user defined $SheetMotion', () {
+    testWidgets('can drive a route transition', (tester) async {
+      final route = ModalSheetRoute<void>(
+        transitionMotion: const _GravityMotion(),
+        builder: (_) =>
+            const Sheet(child: SizedBox(key: Key('sheet'), height: 200)),
+      );
+      await tester.pumpWidget(_Boilerplate(modalRoute: route));
+      await tester.tap(find.text('Open modal'));
+      await tester.pump();
+
+      final expected = const _GravityMotion().createSimulation(
+        start: 0,
+        end: 1,
+        velocity: 0,
+      );
+      for (var frame = 1; frame <= 6; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(
+          route.animation!.value,
+          moreOrLessEquals(expected.x(frame * 16 / 1000), epsilon: 1e-6),
+        );
+      }
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('sheet')), findsOneWidget);
+    });
+
+    testWidgets('can drive animateTo', (tester) async {
+      final controller = SheetController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SheetViewport(
+            child: Sheet(
+              controller: controller,
+              snapGrid: const SheetSnapGrid(
+                snaps: [SheetOffset(0.5), SheetOffset(1)],
+              ),
+              child: Container(
+                key: const Key('sheet'),
+                color: const Color(0xFFFFFFFF),
+                height: 600,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Must not be awaited before pumping: the future only completes once
+      // frames run.
+      unawaited(
+        controller.animateTo(
+          const SheetOffset(0.5),
+          motion: const _GravityMotion(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(controller.value, moreOrLessEquals(300, epsilon: 0.5));
+    });
+  });
+}

--- a/test/src/stubbing.mocks.dart
+++ b/test/src/stubbing.mocks.dart
@@ -10,12 +10,13 @@ import 'package:flutter/cupertino.dart' as _i3;
 import 'package:flutter/foundation.dart' as _i10;
 import 'package:flutter/gestures.dart' as _i8;
 import 'package:flutter/scheduler.dart' as _i11;
-import 'package:flutter/src/animation/curves.dart' as _i14;
+import 'package:flutter/src/animation/curves.dart' as _i15;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i12;
 import 'package:smooth_sheets/src/activity.dart' as _i7;
-import 'package:smooth_sheets/src/drag.dart' as _i13;
+import 'package:smooth_sheets/src/drag.dart' as _i14;
 import 'package:smooth_sheets/src/model.dart' as _i4;
+import 'package:smooth_sheets/src/motion.dart' as _i13;
 import 'package:smooth_sheets/src/physics.dart' as _i5;
 import 'package:smooth_sheets/src/snap_grid.dart' as _i6;
 
@@ -379,14 +380,21 @@ class MockSheetModel<C extends _i4.SheetModelConfig> extends _i1.Mock
   @override
   _i9.Future<void> animateTo(
     _i4.SheetOffset? newPosition, {
-    _i3.Curve? curve = _i3.Curves.easeInOut,
-    Duration? duration = const Duration(milliseconds: 300),
+    _i3.Curve? curve,
+    Duration? duration,
+    _i13.SheetMotion? motion,
+    double? velocity = 0.0,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
               #animateTo,
               [newPosition],
-              {#curve: curve, #duration: duration},
+              {
+                #curve: curve,
+                #duration: duration,
+                #motion: motion,
+                #velocity: velocity,
+              },
             ),
             returnValue: _i9.Future<void>.value(),
             returnValueForMissingStub: _i9.Future<void>.value(),
@@ -444,19 +452,19 @@ class MockSheetModel<C extends _i4.SheetModelConfig> extends _i1.Mock
   );
 
   @override
-  void didDragStart(_i13.SheetDragStartDetails? details) => super.noSuchMethod(
+  void didDragStart(_i14.SheetDragStartDetails? details) => super.noSuchMethod(
     Invocation.method(#didDragStart, [details]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void didDragEnd(_i13.SheetDragEndDetails? details) => super.noSuchMethod(
+  void didDragEnd(_i14.SheetDragEndDetails? details) => super.noSuchMethod(
     Invocation.method(#didDragEnd, [details]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void didDragUpdateMetrics(_i13.SheetDragUpdateDetails? details) =>
+  void didDragUpdateMetrics(_i14.SheetDragUpdateDetails? details) =>
       super.noSuchMethod(
         Invocation.method(#didDragUpdateMetrics, [details]),
         returnValueForMissingStub: null,
@@ -903,7 +911,7 @@ class MockAnimationController extends _i1.Mock
   _i3.TickerFuture animateTo(
     double? target, {
     Duration? duration,
-    _i3.Curve? curve = _i14.Curves.linear,
+    _i3.Curve? curve = _i15.Curves.linear,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -934,7 +942,7 @@ class MockAnimationController extends _i1.Mock
   _i3.TickerFuture animateBack(
     double? target, {
     Duration? duration,
-    _i3.Curve? curve = _i14.Curves.linear,
+    _i3.Curve? curve = _i15.Curves.linear,
   }) =>
       (super.noSuchMethod(
             Invocation.method(


### PR DESCRIPTION
## Problem / Issue

Every sheet transition in this package is driven by a `Curve` over a fixed
`Duration`. The consequence is not which easing looks nicer — it is that a curve
**cannot** be velocity aware. Its trajectory is a pure function of elapsed time,
so a flick and a slow release from the same position produce byte-for-byte
identical motion.

The velocity was already being measured and then thrown away. `_SheetDismissible`
computed the release velocity, used it as a boolean threshold to decide
pop-vs-stay, and then animated back with a duration derived purely from the
remaining distance. `velocity` appeared nowhere in that call.

Related symptom, same root cause: `effectiveCurve` had to swap in `Curves.linear`
mid-gesture, and `_isUserGestureInProgress` had to be reset late, specifically to
stop the sheet jerking on release (#250). A curve-driven controller has no notion
of current velocity, so continuity at the gesture-to-animation handoff had to be
faked. A spring gets it for free: you hand it the position and the velocity, and
it continues from there.

`SheetController.animateTo` had the same limitation, and no way to express a
spring at all.

### Prior art

The design here follows
[**stupid_simple_sheet**](https://pub.dev/packages/stupid_simple_sheet), which
solved this problem first and solved it well. It drives its route transition with
a `Simulation` via Flutter's `TransitionRoute.createSimulation` hook, feeds the
finger's release velocity into the spring, and uses an unbounded controller so
the overshoot is not clamped away. Those three decisions are exactly the ones
this PR makes, and the credit for demonstrating that they work belongs there. Its
motion vocabulary comes from [motor](https://pub.dev/packages/motor), whose
`CupertinoMotion` presets this PR mirrors.

## Solution

Introduce `SheetMotion`, a description of how a sheet travels from where it is to
where it is going. It comes in two kinds:

- **`CurvedSheetMotion`** interpolates along a `Curve` over a fixed `Duration`.
  This is the existing behaviour and remains the default.
- **`SpringSheetMotion`** hands the trajectory to a spring simulation. Because a
  spring is velocity aware, the speed at which the user releases a gesture is
  carried into the animation that follows it.

```dart
ModalSheetRoute<void>(
  swipeDismissible: true,
  transitionMotion: const SpringSheetMotion(),
  builder: (context) => Sheet(child: ...),
);

controller.animateTo(
  const SheetOffset(0.5),
  motion: SpringSheetMotion.snappy(),
);
```

The default spring is the one Flutter itself uses for `CupertinoModalPopupRoute`
and `CupertinoDialogRoute` — stiffness and damping read from the
`CASpringAnimation` that iOS uses, critically damped, settling in ~404 ms.
Presets mirroring the four `duration`/`bounce` pairs iOS uses are provided as
`smooth`, `snappy`, `bouncy` and `interactive`, along with `withBounce` for
SwiftUI's `spring(duration:bounce:)` parameterisation.

### A motion describes normalized progress, not pixels

This is the load-bearing decision. A `SheetMotion` always describes a progress
running from 0 to 1, whatever the consumer maps it onto, and consumers convert at
the boundary. It is what lets one type configure both a route transition and an
`animateTo` over an arbitrary distance.

A `SpringSimulation`'s *position* is scale invariant, but its `Tolerance` is not —
`isDone` compares the remaining distance in the caller's own units. Handing the
same spring a pixel-space simulation would make the settle time drift with the
distance travelled (633 ms at 100px, 717 ms at 600px, 733 ms at 900px, against a
flat 417 ms normalized), which destroys the one property a spring is supposed to
have. Two tests pin this so the normalization cannot be optimised away later.

## Also included: a curve was being applied twice

While reworking `AnimatedSheetActivity` I found a pre-existing bug in it, in the
method this PR rewrites.

`AnimationController.animateTo(duration:, curve:)` drives the controller with an
`_InterpolationSimulation` that has **already** applied the curve, so
`controller.value` is the curved progress. `onAnimationTick()` then applied the
curve to it a second time, so the sheet followed `curve ∘ curve` instead of
`curve`. With the default `Curves.easeInOut` that is up to **12.2% of the travel**
off at t ≈ 0.34 — 73px on a 600px `animateTo`. Both endpoints are still correct,
so the animation looks plausible; it is simply sharper than requested. Every
existing test for this activity used the idempotent `Curves.linear`, which is why
it went unnoticed.

It is the first commit in this PR (`fix(pkg): Apply the animation curve only once
in AnimatedSheetActivity`), reviewable on its own, with a regression test that
uses a non-linear curve and fails against the previous implementation.

> [!IMPORTANT]
> This changes the motion of existing `animateTo` calls that pass a non-linear
> curve, including everyone relying on the default `Curves.easeInOut`. The
> animation now follows the curve that was actually requested. It may deserve its
> own release note, since squashing this PR will fold it into the `feat` entry.

## Notes for review

- **Unbounded controller.** A spring with bounce leaves the `[0, 1]` range before
  settling, and a bounded controller would clamp it — pinning a `bouncy` sheet at
  the top for ~350 ms. Spring-driven routes therefore use
  `AnimationController.unbounded`. That has a consequence worth knowing: an
  unbounded controller derives `completed`/`dismissed` from its infinite bounds,
  so it can never report them, which breaks routes added without a transition
  (`didAdd`/`didReplace`) and the drag routing in `_SheetDismissible`. Both are
  handled and both have regression tests.
- **`SheetMotion` is open.** Implement it to supply your own `Simulation`; there
  is a test doing exactly that with a `GravitySimulation`.
- **Considered alternative for the clamping.** Out-of-range values are currently
  contained at the four places that consume the transition progress. A tidier
  option, which is what stupid_simple_sheet does, is to override `animation` and
  `secondaryAnimation` to return a clamped view, so every consumer is safe by
  construction and `buildTransitions` reads the controller directly for the
  visual. That was left out here because `animation` is public API in this
  package: clamping it means anyone observing a route's transition stops seeing
  the overshoot while the painted sheet still shows it. Happy to switch if you
  would rather have the single choke point.
- **Accessibility.** `AnimationController.animateWith` does not apply the scaling
  that `animateTo`/`forward`/`reverse` apply when the platform asks for
  animations to be disabled, so simulation-driven animations would have ignored
  the setting. They now honour it.
- `transitionDuration` / `transitionCurve` on the routes, pages and `show*`
  helpers, and `duration` / `curve` on `animateTo`, are deprecated in favour of
  the new arguments and continue to work unchanged.

> [!NOTE]
> Migrating `animateTo(duration:)` to `CurvedSheetMotion(duration:)` changes the
> easing, because `animateTo` has always defaulted to `Curves.easeInOut` while
> `CurvedSheetMotion` defaults to `Curves.fastEaseInToSlowEaseOut`. Pass
> `kDefaultSheetAnimationMotion` to keep the previous easing. The deprecation
> message says so, and a test fails if the two ever silently converge.

## Testing

`407` tests pass, up from `356` on `main`. `dart analyze` is clean on the package
and the example, and the generated mocks regenerate to a no-op.

Every non-obvious behaviour is pinned by a test that was confirmed to fail
without its fix — the velocity carry-over, the unbounded controller, the route
status after `didAdd`, the motion captured at install, the double-applied curve,
the normalized-units contract, reduced motion, and dragging a sheet mid-overshoot.

`example/lib/tutorial/sheet_motion.dart` compares the curve against each spring
preset on both a route transition and an `animateTo`.
