### PR TITLE
fix(pkg): Fix sheet stuck behind extra navigator layer

### DIFF
--- a/lib/src/activity.dart
+++ b/lib/src/activity.dart
@@ -62,6 +62,23 @@ abstract class SheetActivity<T extends SheetModel> {
 
   bool isCompatibleWith(SheetModel newOwner) => newOwner is T;
 
+  /// Whether this activity must receive a call to [applyNewLayout] as soon
+  /// as it starts, even if the incoming layout has the exact same values as
+  /// the last layout the model processed.
+  ///
+  /// [SheetModel.applyNewLayout] skips calling [applyNewLayout] on the
+  /// current activity when the incoming layout is identical (by value) to
+  /// the previous one, as an optimization to avoid redundant work. This is
+  /// safe for activities that only react to genuine layout changes (e.g.
+  /// ballistic or settling animations), but activities that use
+  /// [applyNewLayout] to perform one-time setup -- most commonly, giving
+  /// [owner] its very first offset -- must still run even when the layout
+  /// coincidentally matches the previous one (which can happen, for example,
+  /// while a nested [Navigator] is still resolving its first route, one
+  /// frame after this activity started). Such activities should override
+  /// this to return `true`.
+  bool get needsInitialLayout => false;
+
   /// Returns the offset that [owner] would have if
   /// [applyNewLayout] were called with the given [layout].
   ///
@@ -135,6 +152,9 @@ class InitialSheetActivity<T extends SheetModel> extends SheetActivity<T> {
   InitialSheetActivity({required this.preferredInitialOffset});
 
   final SheetOffset preferredInitialOffset;
+
+  @override
+  bool get needsInitialLayout => true;
 
   @override
   void init(T owner) {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -325,16 +325,36 @@ abstract class SheetModel<C extends SheetModelConfig> extends SheetModelView
 
   SheetLayout? _layout;
 
+  // The activity that last received a call to `activity.applyNewLayout`.
+  //
+  // beginActivity() does not itself call applyNewLayout on the new activity;
+  // the new activity instead waits for the next call to this method (see the
+  // "It's also fine to initiate another activity..." note on
+  // SheetActivity.applyNewLayout). An activity whose `needsInitialLayout` is
+  // true relies on that call to perform one-time setup (typically giving
+  // `owner` its very first offset), so it must not be skipped even if the
+  // incoming layout happens to have the same values as the last layout this
+  // model processed -- which can otherwise happen when an intermediate
+  // widget/route briefly rebuilds with a placeholder that coincidentally has
+  // the same size as the final content. See
+  // https://github.com/fujidaiti/smooth_sheets/issues/594 and #315.
+  SheetActivity? _lastLayoutAppliedActivity;
+
   void applyNewLayout(SheetLayout layout) {
+    final needsInitialCall =
+        activity.needsInitialLayout &&
+        !identical(activity, _lastLayoutAppliedActivity);
     // ignore: lines_longer_than_80_chars
     // TODO: Make the layout class immutable so that we can compare the old and new layouts by the equality operator.
-    if (layout.viewportSize == _layout?.viewportSize &&
+    if (!needsInitialCall &&
+        layout.viewportSize == _layout?.viewportSize &&
         layout.viewportPadding == _layout?.viewportPadding &&
         layout.contentSize == _layout?.contentSize &&
         layout.contentBaseline == _layout?.contentBaseline &&
         layout.contentMargin == _layout?.contentMargin) {
       return;
     }
+    _lastLayoutAppliedActivity = activity;
 
     final oldLayout = _layout;
     _layout = layout;

--- a/lib/src/paged_sheet.dart
+++ b/lib/src/paged_sheet.dart
@@ -292,45 +292,6 @@ class _PagedSheetModel extends SheetModel<_PagedSheetModelConfig>
     }
   }
 
-  @override
-  void applyNewLayout(SheetLayout layout) {
-    // Workaround for https://github.com/fujidaiti/smooth_sheets/issues/315:
-    //
-    // When using auto_route and the sheet is fullscreen, the initialOffset is
-    // ignored on the first build. The root cause is that AutoRouter,
-    // which internally builds a Navigator, does not construct the Navigator
-    // during the first frame in which the sheet is built.
-    //
-    // In that first frame, the initialOffset is ignored because _currentEntry
-    // is not yet set. However, AutoRouter sizes itself to match the viewport,
-    // so the 'layout' argument's contentSize equals the viewportSize.
-    // In the following frame, AutoRouter builds the internal Navigator.
-    // If the first route in the Navigator is fullscreen, the 'layout' will
-    // have the exact same values as in the previous frame.
-    // As a result, super.applyNewLayout() returns immediately,
-    // and the initialOffset is not applied.
-    //
-    // This workaround applies a zero-sized layout to the sheet when it is first
-    // built and _currentEntry is still null (implying that the Navigator has
-    // not yet been built). This ensures that super.applyNewLayout updates the
-    // offset to respect the initialOffset once the Navigator is built in the
-    // next frame.
-    if (!hasMetrics && _currentEntry == null) {
-      super.applyNewLayout(
-        ImmutableSheetLayout(
-          contentBaseline: 0,
-          size: Size.zero,
-          contentSize: Size.zero,
-          contentMargin: EdgeInsets.zero,
-          viewportPadding: layout.viewportPadding,
-          viewportSize: layout.viewportSize,
-        ),
-      );
-    } else {
-      super.applyNewLayout(layout);
-    }
-  }
-
   void didChangeInternalStateOfEntry(_PagedSheetEntry entry) {
     if (_currentEntry == entry) {
       config = config.copyWith(snapGrid: entry.snapGrid);
@@ -389,6 +350,9 @@ class _PagedSheetModel extends SheetModel<_PagedSheetModelConfig>
 class _InitialActivity extends SheetActivity<_PagedSheetModel> {
   @override
   bool get shouldIgnorePointer => true;
+
+  @override
+  bool get needsInitialLayout => true;
 
   @override
   double dryApplyNewLayout(ViewportLayout layout) =>
@@ -471,6 +435,9 @@ class _PostTransitionWithoutAnimationActivity
 
   @override
   bool get shouldIgnorePointer => true;
+
+  @override
+  bool get needsInitialLayout => true;
 
   @override
   void init(_PagedSheetModel owner) {

--- a/test/integration/issue_594_test.dart
+++ b/test/integration/issue_594_test.dart
@@ -1,0 +1,219 @@
+// Regression test for https://github.com/fujidaiti/smooth_sheets/issues/594
+//
+// An auto_route `EmptyShellRoute` inserts an extra "invisible" Navigator
+// layer between `PagedSheet.navigator` and the actual `PagedSheetRoute`.
+// This is a deeper variant of issue #315: `AutoRouter()` doesn't build its
+// internal `Navigator` on the same frame it's first built, so for one frame
+// it renders a fullscreen placeholder. With an `EmptyShellRoute`, there are
+// two such `AutoRouter`s to resolve, so there can be a frame where that
+// placeholder's size coincidentally matches the real, final content size
+// (which happens whenever the route's content is fullscreen). When that
+// happens, `SheetModel.applyNewLayout`'s "layout unchanged" fast path used
+// to skip notifying the newly-started activity, leaving the sheet
+// permanently stuck at offset 0 (fully below the viewport) instead of
+// settling at `initialOffset`.
+//
+// Fixed generally (not with an auto_route-specific workaround) by having
+// `SheetActivity` declare whether it needs a guaranteed initial call to
+// `applyNewLayout`, and having `SheetModel.applyNewLayout` honor that even
+// when the incoming layout is value-identical to the previous one.
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+const _sheetKey = Key('modal-sheet');
+const _firstSheetPageKey = Key('first-sheet-page');
+
+void main() {
+  Future<void> pumpTestApp(WidgetTester tester, RootStackRouter router) async {
+    await tester.pumpWidget(_TestApp(router: router));
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets(
+    'No EmptyShellRoute layer -> fullscreen sheet appears at the '
+    'expected initialOffset',
+    (tester) async {
+      await pumpTestApp(
+        tester,
+        _TestRouter(useShellLayer: false, contentHeight: 600),
+      );
+
+      await tester.tap(find.text('Open sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_firstSheetPageKey), findsOneWidget);
+      expect(
+        tester.getRect(find.byKey(_sheetKey)),
+        const Rect.fromLTRB(0, 300, 800, 900),
+        reason:
+            'Half of the 600-tall sheet should be visible '
+            '(initialOffset: 0.5)',
+      );
+    },
+  );
+
+  testWidgets(
+    'EmptyShellRoute + fullscreen content -> sheet still appears at the '
+    'expected initialOffset (issue #594)',
+    (tester) async {
+      await pumpTestApp(
+        tester,
+        _TestRouter(useShellLayer: true, contentHeight: 600),
+      );
+
+      await tester.tap(find.text('Open sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_firstSheetPageKey), findsOneWidget);
+      expect(
+        tester.getRect(find.byKey(_sheetKey)),
+        const Rect.fromLTRB(0, 300, 800, 900),
+        reason:
+            'Same as the baseline test above: the extra EmptyShellRoute '
+            'layer must not prevent the sheet from settling at the '
+            'expected initialOffset.',
+      );
+    },
+  );
+
+  testWidgets(
+    'EmptyShellRoute + non-fullscreen content -> settles correctly',
+    (tester) async {
+      await pumpTestApp(
+        tester,
+        _TestRouter(useShellLayer: true, contentHeight: 300),
+      );
+
+      await tester.tap(find.text('Open sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_firstSheetPageKey), findsOneWidget);
+      expect(
+        tester.getRect(find.byKey(_sheetKey)),
+        const Rect.fromLTRB(0, 450, 800, 750),
+        reason:
+            'Half of the 300-tall sheet should be visible '
+            '(initialOffset: 0.5)',
+      );
+    },
+  );
+}
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({required this.router});
+
+  final RootStackRouter router;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(routerConfig: router.config());
+  }
+}
+
+class _TestRouter extends RootStackRouter {
+  _TestRouter({required this.useShellLayer, required this.contentHeight});
+
+  final bool useShellLayer;
+  final double contentHeight;
+
+  @override
+  List<AutoRoute> get routes => [
+    AutoRoute(
+      path: '/',
+      page: PageInfo('_HomeRoute', builder: (data) => const _HomePage()),
+    ),
+    CustomRoute<dynamic>(
+      path: '/modal',
+      page: PageInfo(
+        '_ModalSheetRoute',
+        builder: (data) => _ModalSheetPage(),
+      ),
+      customRouteBuilder: <T>(context, child, page) {
+        return ModalSheetRoute(settings: page, builder: (_) => child);
+      },
+      children: [
+        if (useShellLayer)
+          AutoRoute(
+            initial: true,
+            path: 'shell',
+            page: const EmptyShellRoute('_ShellRoute'),
+            children: [_firstRoute()],
+          )
+        else
+          _firstRoute(),
+      ],
+    ),
+  ];
+
+  CustomRoute<dynamic> _firstRoute() {
+    return CustomRoute<dynamic>(
+      initial: true,
+      path: 'first',
+      page: PageInfo(
+        '_FirstSheetRoute',
+        builder: (data) => _FirstSheetPage(height: contentHeight),
+      ),
+      customRouteBuilder: <T>(context, child, page) {
+        return PagedSheetRoute(
+          settings: page,
+          initialOffset: const SheetOffset(0.5),
+          snapGrid: const SheetSnapGrid(
+            snaps: [SheetOffset(0.5), SheetOffset(1)],
+          ),
+          builder: (_) => child,
+        );
+      },
+    );
+  }
+}
+
+class _HomePage extends StatelessWidget {
+  const _HomePage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: () => AutoRouter.of(context).pushPath('/modal'),
+          child: const Text('Open sheet'),
+        ),
+      ),
+    );
+  }
+}
+
+class _ModalSheetPage extends StatelessWidget {
+  const _ModalSheetPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return PagedSheet(
+      key: _sheetKey,
+      decoration: MaterialSheetDecoration(
+        size: SheetSize.stretch,
+        color: Colors.white,
+      ),
+      navigator: AutoRouter(),
+    );
+  }
+}
+
+class _FirstSheetPage extends StatelessWidget {
+  const _FirstSheetPage({required this.height});
+
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.fromSize(
+      key: _firstSheetPageKey,
+      size: Size.fromHeight(height),
+      child: Container(color: Colors.blue.shade200),
+    );
+  }
+}


### PR DESCRIPTION
## Problem / Issue

Closes #594

When a `PagedSheetRoute` sits behind an extra "invisible" Navigator layer relative to its `PagedSheet` (e.g. an `auto_route` `EmptyShellRoute` between the `PagedSheet` and the actual route), the sheet could fail to appear at all, staying stuck fully below the viewport instead of settling at its `initialOffset`.

This turned out to be a deeper variant of the already-fixed #315: an intermediate Navigator can render a placeholder for one frame before it builds its real content, and that placeholder can coincidentally report the exact same layout size as the eventual real content. When that happens, `SheetModel.applyNewLayout`'s "layout unchanged" fast path skipped notifying the activity that had just started and was responsible for computing the sheet's initial offset, leaving it stuck.

The previous fix for #315 addressed one specific case of this with an `auto_route`-specific workaround inside `PagedSheet`'s model. That workaround doesn't generalize (as seen in #594), and we'd rather not keep adding router-specific patches for what is really a general framework bug.

## Solution

`SheetActivity` now declares whether it needs a guaranteed first call to `applyNewLayout` (`needsInitialLayout`). Activities that only react to genuine layout changes (ballistic, settling, idle, drag, ...) are unaffected. Activities that use `applyNewLayout` to perform one-time setup — most importantly, giving the sheet its very first offset — opt into this and are now guaranteed to run at least once, even if the incoming layout happens to be value-identical to the previous one.

This fixes both #594 and the original #315 scenario generally, so the `auto_route`-specific workaround in `PagedSheet`'s model has been removed.

Added `test/integration/issue_594_test.dart`, which reproduces the reported scenario (fullscreen `PagedSheetRoute` behind an `EmptyShellRoute`) and verifies the sheet settles at the expected offset, alongside a baseline (no shell layer) and a control (non-fullscreen content) case.
