### PR TITLE
build(pkg): Bump navigator_resizable from 3.0.2 to 3.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,14 +10,14 @@ topics:
   - widget
   - bottom-sheet
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.1"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"
 dependencies:
   collection: ^1.17.1
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  navigator_resizable: ^3.0.2
+  navigator_resizable: ^3.1.0
 # Dependencies for testing
 dev_dependencies:
   auto_route: ^11.1.0


### PR DESCRIPTION
`navigator_resizable` 3.1.0 contains two fixes for route transition handling that affect `PagedSheet`:

- A crash that occurs in the middle of a route transition.
- An assertion error when multiple routes are popped while a push transition is still running.

`navigator_resizable` 3.1.0 raises its own minimum SDK requirements to Flutter 3.41.0. Therefore, the `environment` constraints in `pubspec.yaml` are raised to match.
